### PR TITLE
fixed missing validation errors

### DIFF
--- a/crates/example/src/main.rs
+++ b/crates/example/src/main.rs
@@ -58,16 +58,16 @@ pub mod structs {
         #[interpolate(flat)]
         pub z: u32,
 
+        #[location(2)]
         pub other: f32,
     }
 
     #[output]
     pub struct MyOutputs {
-        #[builtin(position)]
-        #[invariant]
+        #[location(0)]
         pub x: f32,
 
-        #[location(0)]
+        #[location(1)]
         pub y: Vec4<f32>,
     }
 


### PR DESCRIPTION
## Summary
- Fix compile-time WGSL validation to catch semantic errors (like missing struct field bindings) by running naga::valid::Validator in addition to just parsing
- Improve error source mapping by using naga's offset and length fields to find exact or best-matching Rust spans for WGSL errors

## Changes
* crates/wgsl-rs-macros/src/lib.rs:
  - Extended validate_wgsl to run full naga semantic validation, not just parsing
  - Added offset_to_line_column helper to convert byte offsets to line/column positions
  - Refactored error conversion into convert_naga_error which now uses exact span matching when possible, falling back to contains-based matching
* crates/wgsl-rs-macros/src/code_gen/formatter.rs:
  - Updated RustAtom::Tokens to use struct variant with separate tokens and span fields
  - Added mapping_for_wgsl_span method for exact span matching with fallback to smallest containing span
* crates/example/src/main.rs:
  - Fixed invalid WGSL in example: added #[location(2)] to other field and changed MyOutputs to use locations instead of @builtin(position) (which isn't valid for fragment outputs)