### PR TITLE
feat: extend binary ops

### DIFF
--- a/crates/example/src/main.rs
+++ b/crates/example/src/main.rs
@@ -187,6 +187,98 @@ pub mod enum_example {
     }
 }
 
+#[wgsl]
+#[allow(dead_code)]
+pub mod binary_ops_example {
+    //! Demonstrates all supported binary operators including:
+    //! - Arithmetic: + - * / %
+    //! - Comparison: == != < <= > >=
+    //! - Logical: && ||
+    //! - Bitwise: & | ^ << >>
+
+    use wgsl_rs::std::*;
+
+    // Demonstrates arithmetic operators including remainder.
+    #[fragment]
+    pub fn test_arithmetic() -> Vec4f {
+        let a = vec3f(10.0, 11.0, 12.0);
+        let b = 3.0;
+        let add = a + b;
+        let sub = a - b;
+        let mul = a * b;
+        let div = a / b;
+        let rem = a % b;
+        vec4f(add.x(), sub.y(), (mul * div).z(), rem.z())
+    }
+
+    // Demonstrates comparison operators.
+    // All comparison operators return bool (or vecN<bool> for vectors).
+    #[fragment]
+    pub fn test_comparison() -> Vec4f {
+        let a = 5;
+        let b = 10;
+
+        // Comparison operators
+        let lt = a < b;
+        let le = a <= b;
+        let _gt = a > b;
+        let ge = a >= b;
+        let eq = a == b;
+        let ne = a != b;
+
+        // Use the booleans in a calculation
+        // In WGSL, we use select() to convert bool to numeric
+        let lt_val = select(0.0, 1.0, lt);
+        let eq_val = select(0.0, 1.0, eq);
+        let ne_val = select(0.0, 1.0, ne);
+        let combined = select(0.0, 1.0, le && ge);
+
+        vec4f(lt_val, eq_val, ne_val, combined)
+    }
+
+    // Demonstrates logical operators (short-circuit and/or).
+    #[fragment]
+    pub fn test_logical() -> Vec4f {
+        let a = true;
+        let b = false;
+
+        // Logical operators (short-circuit evaluation)
+        let and_result = a && b;
+        let or_result = a || b;
+        let complex = (a && b) || (!a && !b);
+
+        let and_val = select(0.0, 1.0, and_result);
+        let or_val = select(0.0, 1.0, or_result);
+        let complex_val = select(0.0, 1.0, complex);
+
+        vec4f(and_val, or_val, complex_val, 1.0)
+    }
+
+    // Demonstrates bitwise operators.
+    #[fragment]
+    pub fn test_bitwise() -> Vec4f {
+        let a: u32 = 0xFF00;
+        let b: u32 = 0x0F0F;
+
+        // Bitwise operators
+        let and_result = a & b;
+        let or_result = a | b;
+        let xor_result = a ^ b;
+
+        // Shift operators
+        let shl_result = a << 4u32;
+        let shr_result = a >> 4u32;
+
+        // Convert to floats for output (normalized)
+        let and_f = f32(and_result) / 65535.0;
+        let or_f = f32(or_result) / 65535.0;
+        let xor_f = f32(xor_result) / 65535.0;
+        let shift_f = f32(shl_result ^ shr_result) / 65535.0;
+
+        vec4f(and_f, or_f, xor_f, shift_f)
+    }
+}
+
 fn validate_and_print_source(source: &str) {
     println!("raw source:\n\n{source}\n\n");
 
@@ -541,6 +633,11 @@ pub fn main() {
     {
         // enum_example
         let source = enum_example::WGSL_MODULE.wgsl_source().join("\n");
+        validate_and_print_source(&source);
+    }
+    {
+        // binary_ops_example - demonstrates all binary operators
+        let source = binary_ops_example::WGSL_MODULE.wgsl_source().join("\n");
         validate_and_print_source(&source);
     }
 

--- a/crates/example/src/main.rs
+++ b/crates/example/src/main.rs
@@ -279,11 +279,12 @@ pub mod binary_ops_example {
     }
 }
 
-fn validate_and_print_source(source: &str) {
+fn validate_and_print_source(module: &wgsl_rs::Module) {
+    let source = module.wgsl_source().join("\n");
     println!("raw source:\n\n{source}\n\n");
 
     // Parse the source into a Module.
-    let module: naga::Module = naga::front::wgsl::parse_str(source).unwrap();
+    let module: naga::Module = naga::front::wgsl::parse_str(&source).unwrap();
 
     // Validate the module.
     // Validation can be made less restrictive by changing the ValidationFlags.
@@ -297,7 +298,7 @@ fn validate_and_print_source(source: &str) {
 
     let info = match result {
         Err(e) => {
-            panic!("{}", e.emit_to_string(source));
+            panic!("{}", e.emit_to_string(&source));
         }
         Ok(i) => i,
     };
@@ -605,41 +606,13 @@ fn build_linkage() {
 }
 
 pub fn main() {
-    {
-        // hello_triangle
-        let source = hello_triangle::WGSL_MODULE.wgsl_source().join("\n");
-        validate_and_print_source(&source);
-    }
-    {
-        // structs
-        let source = structs::WGSL_MODULE.wgsl_source().join("\n");
-        validate_and_print_source(&source);
-    }
-    {
-        // compute_shader
-        let source = compute_shader::WGSL_MODULE.wgsl_source().join("\n");
-        validate_and_print_source(&source);
-    }
-    {
-        // matrix_example
-        let source = matrix_example::WGSL_MODULE.wgsl_source().join("\n");
-        validate_and_print_source(&source);
-    }
-    {
-        // impl_example - demonstrates struct impl blocks with explicit receiver syntax
-        let source = impl_example::WGSL_MODULE.wgsl_source().join("\n");
-        validate_and_print_source(&source);
-    }
-    {
-        // enum_example
-        let source = enum_example::WGSL_MODULE.wgsl_source().join("\n");
-        validate_and_print_source(&source);
-    }
-    {
-        // binary_ops_example - demonstrates all binary operators
-        let source = binary_ops_example::WGSL_MODULE.wgsl_source().join("\n");
-        validate_and_print_source(&source);
-    }
+    validate_and_print_source(&hello_triangle::WGSL_MODULE);
+    validate_and_print_source(&structs::WGSL_MODULE);
+    validate_and_print_source(&compute_shader::WGSL_MODULE);
+    validate_and_print_source(&matrix_example::WGSL_MODULE);
+    validate_and_print_source(&impl_example::WGSL_MODULE);
+    validate_and_print_source(&enum_example::WGSL_MODULE);
+    validate_and_print_source(&binary_ops_example::WGSL_MODULE);
 
     print_linkage();
     build_linkage();

--- a/crates/wgsl-rs-macros/src/lib.rs
+++ b/crates/wgsl-rs-macros/src/lib.rs
@@ -179,7 +179,9 @@ fn validate_wgsl(code: &GeneratedWgslCode, source_lines: &[String]) -> Result<()
                     loc,
                 )
             });
-            let error = errors.next().expect("there is at least one");
+            let error = errors
+                .next()
+                .unwrap_or_else(|| syn::Error::new(proc_macro2::Span::call_site(), format!("{e}")));
             return Err(errors.fold(error, |mut error, e| {
                 error.combine(e);
                 error

--- a/crates/wgsl-rs-macros/src/parse.rs
+++ b/crates/wgsl-rs-macros/src/parse.rs
@@ -512,12 +512,31 @@ impl std::fmt::Display for Lit {
     }
 }
 
-/// A binary operator: `+` `-` `*`.
+/// A binary operator: `+` `-` `*` `/` `%` `==` `!=` `<` `<=` `>` `>=` `&&` `||`
+/// `&` `|` `^` `<<` `>>`.
 pub enum BinOp {
+    // Arithmetic
     Add(Token![+]),
     Sub(Token![-]),
     Mul(Token![*]),
     Div(Token![/]),
+    Rem(Token![%]),
+    // Comparison
+    Eq(Token![==]),
+    Ne(Token![!=]),
+    Lt(Token![<]),
+    Le(Token![<=]),
+    Gt(Token![>]),
+    Ge(Token![>=]),
+    // Logical
+    And(Token![&&]),
+    Or(Token![||]),
+    // Bitwise
+    BitAnd(Token![&]),
+    BitOr(Token![|]),
+    BitXor(Token![^]),
+    Shl(Token![<<]),
+    Shr(Token![>>]),
 }
 
 impl TryFrom<&syn::BinOp> for BinOp {
@@ -525,10 +544,29 @@ impl TryFrom<&syn::BinOp> for BinOp {
 
     fn try_from(value: &syn::BinOp) -> Result<Self, Self::Error> {
         Ok(match value {
+            // Arithmetic
             syn::BinOp::Add(t) => Self::Add(*t),
             syn::BinOp::Sub(t) => Self::Sub(*t),
             syn::BinOp::Mul(t) => Self::Mul(*t),
             syn::BinOp::Div(t) => Self::Div(*t),
+            syn::BinOp::Rem(t) => Self::Rem(*t),
+            // Comparison
+            syn::BinOp::Eq(t) => Self::Eq(*t),
+            syn::BinOp::Ne(t) => Self::Ne(*t),
+            syn::BinOp::Lt(t) => Self::Lt(*t),
+            syn::BinOp::Le(t) => Self::Le(*t),
+            syn::BinOp::Gt(t) => Self::Gt(*t),
+            syn::BinOp::Ge(t) => Self::Ge(*t),
+            // Logical
+            syn::BinOp::And(t) => Self::And(*t),
+            syn::BinOp::Or(t) => Self::Or(*t),
+            // Bitwise
+            syn::BinOp::BitAnd(t) => Self::BitAnd(*t),
+            syn::BinOp::BitOr(t) => Self::BitOr(*t),
+            syn::BinOp::BitXor(t) => Self::BitXor(*t),
+            syn::BinOp::Shl(t) => Self::Shl(*t),
+            syn::BinOp::Shr(t) => Self::Shr(*t),
+            // Compound assignments are not supported (yet)
             other => UnsupportedSnafu {
                 span: other.span(),
                 note: format!(
@@ -544,10 +582,28 @@ impl TryFrom<&syn::BinOp> for BinOp {
 impl std::fmt::Display for BinOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
+            // Arithmetic
             BinOp::Add(_) => "+",
             BinOp::Sub(_) => "-",
             BinOp::Mul(_) => "*",
             BinOp::Div(_) => "/",
+            BinOp::Rem(_) => "%",
+            // Comparison
+            BinOp::Eq(_) => "==",
+            BinOp::Ne(_) => "!=",
+            BinOp::Lt(_) => "<",
+            BinOp::Le(_) => "<=",
+            BinOp::Gt(_) => ">",
+            BinOp::Ge(_) => ">=",
+            // Logical
+            BinOp::And(_) => "&&",
+            BinOp::Or(_) => "||",
+            // Bitwise
+            BinOp::BitAnd(_) => "&",
+            BinOp::BitOr(_) => "|",
+            BinOp::BitXor(_) => "^",
+            BinOp::Shl(_) => "<<",
+            BinOp::Shr(_) => ">>",
         };
         f.write_str(s)
     }
@@ -2757,6 +2813,108 @@ mod test {
         let expr: syn::Expr = syn::parse_str("333 + TIMES").unwrap();
         let expr = Expr::try_from(&expr).unwrap();
         assert_eq!("333+TIMES", &expr.to_wgsl());
+    }
+
+    // Remainder operator
+    #[test]
+    fn parse_expr_binary_rem() {
+        let expr: syn::Expr = syn::parse_str("10 % 3").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("10%3", &expr.to_wgsl());
+    }
+
+    // Comparison operators
+    #[test]
+    fn parse_expr_binary_eq() {
+        let expr: syn::Expr = syn::parse_str("a == b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a==b", &expr.to_wgsl());
+    }
+
+    #[test]
+    fn parse_expr_binary_ne() {
+        let expr: syn::Expr = syn::parse_str("a != b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a!=b", &expr.to_wgsl());
+    }
+
+    #[test]
+    fn parse_expr_binary_lt() {
+        let expr: syn::Expr = syn::parse_str("a < b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a<b", &expr.to_wgsl());
+    }
+
+    #[test]
+    fn parse_expr_binary_le() {
+        let expr: syn::Expr = syn::parse_str("a <= b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a<=b", &expr.to_wgsl());
+    }
+
+    #[test]
+    fn parse_expr_binary_gt() {
+        let expr: syn::Expr = syn::parse_str("a > b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a>b", &expr.to_wgsl());
+    }
+
+    #[test]
+    fn parse_expr_binary_ge() {
+        let expr: syn::Expr = syn::parse_str("a >= b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a>=b", &expr.to_wgsl());
+    }
+
+    // Logical operators
+    #[test]
+    fn parse_expr_binary_and() {
+        let expr: syn::Expr = syn::parse_str("a && b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a&&b", &expr.to_wgsl());
+    }
+
+    #[test]
+    fn parse_expr_binary_or() {
+        let expr: syn::Expr = syn::parse_str("a || b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a||b", &expr.to_wgsl());
+    }
+
+    // Bitwise operators
+    #[test]
+    fn parse_expr_binary_bitand() {
+        let expr: syn::Expr = syn::parse_str("a & b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a&b", &expr.to_wgsl());
+    }
+
+    #[test]
+    fn parse_expr_binary_bitor() {
+        let expr: syn::Expr = syn::parse_str("a | b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a|b", &expr.to_wgsl());
+    }
+
+    #[test]
+    fn parse_expr_binary_bitxor() {
+        let expr: syn::Expr = syn::parse_str("a ^ b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a^b", &expr.to_wgsl());
+    }
+
+    #[test]
+    fn parse_expr_binary_shl() {
+        let expr: syn::Expr = syn::parse_str("a << b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a<<b", &expr.to_wgsl());
+    }
+
+    #[test]
+    fn parse_expr_binary_shr() {
+        let expr: syn::Expr = syn::parse_str("a >> b").unwrap();
+        let expr = Expr::try_from(&expr).unwrap();
+        assert_eq!("a>>b", &expr.to_wgsl());
     }
 
     #[test]

--- a/crates/wgsl-rs/src/std/vectors.rs
+++ b/crates/wgsl-rs/src/std/vectors.rs
@@ -246,3 +246,182 @@ impl_from_vec!(glam::UVec4, Vec4u, u32, 4);
 impl_from_vec!(glam::BVec2, Vec2b, bool, 2);
 impl_from_vec!(glam::BVec3, Vec3b, bool, 3);
 impl_from_vec!(glam::BVec4, Vec4b, bool, 4);
+
+/// Implements vector-vector binary operations (Add, Sub, Mul, Div).
+macro_rules! impl_vec_ops {
+    ($vec:ty) => {
+        impl std::ops::Add for $vec {
+            type Output = $vec;
+            fn add(self, rhs: $vec) -> Self::Output {
+                Self {
+                    inner: self.inner + rhs.inner,
+                }
+            }
+        }
+
+        impl std::ops::Sub for $vec {
+            type Output = $vec;
+            fn sub(self, rhs: $vec) -> Self::Output {
+                Self {
+                    inner: self.inner - rhs.inner,
+                }
+            }
+        }
+
+        impl std::ops::Mul for $vec {
+            type Output = $vec;
+            fn mul(self, rhs: $vec) -> Self::Output {
+                Self {
+                    inner: self.inner * rhs.inner,
+                }
+            }
+        }
+
+        impl std::ops::Div for $vec {
+            type Output = $vec;
+            fn div(self, rhs: $vec) -> Self::Output {
+                Self {
+                    inner: self.inner / rhs.inner,
+                }
+            }
+        }
+    };
+}
+
+/// Implements vector-vector Rem operation (only for f32 vectors).
+macro_rules! impl_vec_rem {
+    ($vec:ty) => {
+        impl std::ops::Rem for $vec {
+            type Output = $vec;
+            fn rem(self, rhs: $vec) -> Self::Output {
+                Self {
+                    inner: self.inner % rhs.inner,
+                }
+            }
+        }
+    };
+}
+
+/// Implements vector-scalar and scalar-vector binary operations (Add, Sub, Mul,
+/// Div).
+macro_rules! impl_vec_scalar_ops {
+    ($vec:ty, $scalar:ty) => {
+        // Vec op Scalar
+        impl std::ops::Add<$scalar> for $vec {
+            type Output = $vec;
+            fn add(self, rhs: $scalar) -> Self::Output {
+                Self {
+                    inner: self.inner + rhs,
+                }
+            }
+        }
+
+        impl std::ops::Sub<$scalar> for $vec {
+            type Output = $vec;
+            fn sub(self, rhs: $scalar) -> Self::Output {
+                Self {
+                    inner: self.inner - rhs,
+                }
+            }
+        }
+
+        impl std::ops::Mul<$scalar> for $vec {
+            type Output = $vec;
+            fn mul(self, rhs: $scalar) -> Self::Output {
+                Self {
+                    inner: self.inner * rhs,
+                }
+            }
+        }
+
+        impl std::ops::Div<$scalar> for $vec {
+            type Output = $vec;
+            fn div(self, rhs: $scalar) -> Self::Output {
+                Self {
+                    inner: self.inner / rhs,
+                }
+            }
+        }
+
+        // Scalar op Vec
+        impl std::ops::Add<$vec> for $scalar {
+            type Output = $vec;
+            fn add(self, rhs: $vec) -> Self::Output {
+                <$vec>::from(self + rhs.inner)
+            }
+        }
+
+        impl std::ops::Sub<$vec> for $scalar {
+            type Output = $vec;
+            fn sub(self, rhs: $vec) -> Self::Output {
+                <$vec>::from(self - rhs.inner)
+            }
+        }
+
+        impl std::ops::Mul<$vec> for $scalar {
+            type Output = $vec;
+            fn mul(self, rhs: $vec) -> Self::Output {
+                <$vec>::from(self * rhs.inner)
+            }
+        }
+
+        impl std::ops::Div<$vec> for $scalar {
+            type Output = $vec;
+            fn div(self, rhs: $vec) -> Self::Output {
+                <$vec>::from(self / rhs.inner)
+            }
+        }
+    };
+}
+
+/// Implements vector-scalar and scalar-vector Rem operation (only for f32
+/// vectors).
+macro_rules! impl_vec_scalar_rem {
+    ($vec:ty, $scalar:ty) => {
+        impl std::ops::Rem<$scalar> for $vec {
+            type Output = $vec;
+            fn rem(self, rhs: $scalar) -> Self::Output {
+                Self {
+                    inner: self.inner % rhs,
+                }
+            }
+        }
+
+        impl std::ops::Rem<$vec> for $scalar {
+            type Output = $vec;
+            fn rem(self, rhs: $vec) -> Self::Output {
+                <$vec>::from(self % rhs.inner)
+            }
+        }
+    };
+}
+
+// Float vectors: Add, Sub, Mul, Div, Rem
+impl_vec_ops!(Vec2f);
+impl_vec_ops!(Vec3f);
+impl_vec_ops!(Vec4f);
+impl_vec_rem!(Vec2f);
+impl_vec_rem!(Vec3f);
+impl_vec_rem!(Vec4f);
+impl_vec_scalar_ops!(Vec2f, f32);
+impl_vec_scalar_ops!(Vec3f, f32);
+impl_vec_scalar_ops!(Vec4f, f32);
+impl_vec_scalar_rem!(Vec2f, f32);
+impl_vec_scalar_rem!(Vec3f, f32);
+impl_vec_scalar_rem!(Vec4f, f32);
+
+// Signed integer vectors: Add, Sub, Mul, Div (no Rem)
+impl_vec_ops!(Vec2i);
+impl_vec_ops!(Vec3i);
+impl_vec_ops!(Vec4i);
+impl_vec_scalar_ops!(Vec2i, i32);
+impl_vec_scalar_ops!(Vec3i, i32);
+impl_vec_scalar_ops!(Vec4i, i32);
+
+// Unsigned integer vectors: Add, Sub, Mul, Div (no Rem)
+impl_vec_ops!(Vec2u);
+impl_vec_ops!(Vec3u);
+impl_vec_ops!(Vec4u);
+impl_vec_scalar_ops!(Vec2u, u32);
+impl_vec_scalar_ops!(Vec3u, u32);
+impl_vec_scalar_ops!(Vec4u, u32);


### PR DESCRIPTION
Implements std::ops traits for vector types to enable arithmetic operations between vectors and scalars.