### PR TITLE
feat: assignment statements

### DIFF
--- a/crates/example/src/main.rs
+++ b/crates/example/src/main.rs
@@ -279,6 +279,71 @@ pub mod binary_ops_example {
     }
 }
 
+/// Demonstrates assignment statements including:
+/// - Simple assignment: x = expr;
+/// - Compound assignment: x += expr;, x -= expr;, etc.
+/// - Field assignment: obj.field = expr;
+/// - Array element assignment: arr[i] = expr;
+#[wgsl]
+#[allow(dead_code, unused_assignments)]
+pub mod assignment_example {
+    use wgsl_rs::std::*;
+
+    pub struct Point {
+        pub x: f32,
+        pub y: f32,
+    }
+
+    #[fragment]
+    #[allow(clippy::assign_op_pattern)]
+    pub fn test_simple_assignment() -> Vec4f {
+        let mut value = 0.0;
+        value = 1.0;
+        value = value + 1.0; // intentionally not using += to test simple assignment
+        value = value + 1.0; // value is now 3.0 and is read below
+        vec4f(value, value, value, 1.0)
+    }
+
+    #[fragment]
+    pub fn test_compound_assignment() -> Vec4f {
+        let mut x = 10.0;
+        x += 5.0; // 15.0
+        x -= 3.0; // 12.0
+        x *= 2.0; // 24.0
+        x /= 4.0; // 6.0
+        vec4f(x, x, x, 1.0)
+    }
+
+    #[fragment]
+    pub fn test_bitwise_compound_assignment() -> Vec4f {
+        let mut bits: u32 = 0xFF00;
+        bits &= 0x0F0F;
+        bits |= 0x00F0;
+        bits ^= 0x000F;
+        bits <<= 2u32;
+        bits >>= 1u32;
+        vec4f(f32(bits) / 65535.0, 0.0, 0.0, 1.0)
+    }
+
+    #[fragment]
+    pub fn test_field_assignment() -> Vec4f {
+        let mut p = Point { x: 0.0, y: 0.0 };
+        p.x = 1.0;
+        p.y = 2.0;
+        vec4f(p.x, p.y, 0.0, 1.0)
+    }
+
+    #[fragment]
+    pub fn test_array_assignment() -> Vec4f {
+        let mut arr: [f32; 4] = [0.0, 0.0, 0.0, 0.0];
+        arr[0] = 1.0;
+        arr[1] = 2.0;
+        arr[2] = 3.0;
+        arr[3] = 4.0;
+        vec4f(arr[0], arr[1], arr[2], arr[3])
+    }
+}
+
 fn validate_and_print_source(module: &wgsl_rs::Module) {
     let source = module.wgsl_source().join("\n");
     println!("raw source:\n\n{source}\n\n");
@@ -613,6 +678,7 @@ pub fn main() {
     validate_and_print_source(&impl_example::WGSL_MODULE);
     validate_and_print_source(&enum_example::WGSL_MODULE);
     validate_and_print_source(&binary_ops_example::WGSL_MODULE);
+    validate_and_print_source(&assignment_example::WGSL_MODULE);
 
     print_linkage();
     build_linkage();

--- a/crates/wgsl-rs-macros/src/code_gen/formatter.rs
+++ b/crates/wgsl-rs-macros/src/code_gen/formatter.rs
@@ -632,6 +632,23 @@ impl GenerateCode for UnOp {
     }
 }
 
+impl GenerateCode for CompoundOp {
+    fn write_code(&self, code: &mut GeneratedWgslCode) {
+        match self {
+            CompoundOp::AddAssign(t) => code.write_atom(t),
+            CompoundOp::SubAssign(t) => code.write_atom(t),
+            CompoundOp::MulAssign(t) => code.write_atom(t),
+            CompoundOp::DivAssign(t) => code.write_atom(t),
+            CompoundOp::RemAssign(t) => code.write_atom(t),
+            CompoundOp::BitAndAssign(t) => code.write_atom(t),
+            CompoundOp::BitOrAssign(t) => code.write_atom(t),
+            CompoundOp::BitXorAssign(t) => code.write_atom(t),
+            CompoundOp::ShlAssign(t) => code.write_atom(t),
+            CompoundOp::ShrAssign(t) => code.write_atom(t),
+        }
+    }
+}
+
 impl GenerateCode for FieldValue {
     fn write_code(&self, code: &mut GeneratedWgslCode) {
         self.member.write_code(code);
@@ -900,6 +917,32 @@ impl GenerateCode for Stmt {
         match self {
             Stmt::Local(local) => local.write_code(code),
             Stmt::Const(item_const) => item_const.as_ref().write_code(code),
+            Stmt::Assignment {
+                lhs,
+                eq_token,
+                rhs,
+                semi_token,
+            } => {
+                lhs.write_code(code);
+                code.space();
+                code.write_atom(eq_token);
+                code.space();
+                rhs.write_code(code);
+                code.write_atom(semi_token);
+            }
+            Stmt::CompoundAssignment {
+                lhs,
+                op,
+                rhs,
+                semi_token,
+            } => {
+                lhs.write_code(code);
+                code.space();
+                op.write_code(code);
+                code.space();
+                rhs.write_code(code);
+                code.write_atom(semi_token);
+            }
             Stmt::Expr { expr, semi_token } => {
                 if let Some(semi) = semi_token {
                     expr.write_code(code);


### PR DESCRIPTION
Added support for simple and compound assignment statements (`x = expr;`, `x += expr;`, etc.) including field and array element assignment.