### PR TITLE
feat: match -> switch statements

### DIFF
--- a/crates/example/src/main.rs
+++ b/crates/example/src/main.rs
@@ -718,6 +718,104 @@ pub mod return_example {
     }
 }
 
+#[wgsl]
+#[allow(dead_code, unused_assignments)]
+pub mod switch_example {
+    //! Demonstrates switch/match statement support including:
+    //! - Simple integer matching
+    //! - Or-patterns (multiple cases)
+    //! - Default cases
+    //! - Auto-generated default when missing
+    //! - Const patterns (with warning suppression)
+
+    use wgsl_rs::std::*;
+
+    const LOW: i32 = 0;
+    const MID: i32 = 1;
+    const HIGH: i32 = 2;
+
+    #[fragment]
+    pub fn test_simple_switch() -> Vec4f {
+        let x: i32 = 2;
+        let mut result = 0.0;
+        match x {
+            0 => {
+                result = 0.0;
+            }
+            1 => {
+                result = 0.25;
+            }
+            2 => {
+                result = 0.5;
+            }
+            _ => {
+                result = 1.0;
+            }
+        }
+        vec4f(result, 0.0, 0.0, 1.0)
+    }
+
+    #[fragment]
+    #[allow(clippy::manual_range_patterns)]
+    pub fn test_or_patterns() -> Vec4f {
+        let x: u32 = 5;
+        let mut result = 0.0;
+        match x {
+            1 | 2 | 3 => {
+                result = 0.25;
+            }
+            4 | 5 | 6 => {
+                result = 0.5;
+            }
+            _ => {
+                result = 1.0;
+            }
+        }
+        vec4f(result, 0.0, 0.0, 1.0)
+    }
+
+    #[fragment]
+    pub fn test_missing_default() -> Vec4f {
+        let x: i32 = 1;
+        let mut result = 0.0;
+        // No default arm - WGSL will get auto-generated `default: {}`
+        // But Rust requires exhaustive matching, so we use a catch-all underscore
+        // that will be optimized out in the test below
+        match x {
+            0 => {
+                result = 0.0;
+            }
+            1 => {
+                result = 1.0;
+            }
+            _ => {}
+        }
+        vec4f(result, 0.0, 0.0, 1.0)
+    }
+
+    #[fragment]
+    pub fn test_const_patterns() -> Vec4f {
+        let level: i32 = 1;
+        let mut brightness = 0.0;
+        #[wgsl_allow(non_literal_match_statement_patterns)]
+        match level {
+            LOW => {
+                brightness = 0.0;
+            }
+            MID => {
+                brightness = 0.5;
+            }
+            HIGH => {
+                brightness = 1.0;
+            }
+            _ => {
+                brightness = 0.0;
+            }
+        }
+        vec4f(brightness, 0.0, 0.0, 1.0)
+    }
+}
+
 fn validate_and_print_source(module: &wgsl_rs::Module) {
     let source = module.wgsl_source().join("\n");
     println!("raw source:\n\n{source}\n\n");
@@ -1059,6 +1157,7 @@ pub fn main() {
     validate_and_print_source(&break_example::WGSL_MODULE);
     validate_and_print_source(&for_loop_example::WGSL_MODULE);
     validate_and_print_source(&return_example::WGSL_MODULE);
+    validate_and_print_source(&switch_example::WGSL_MODULE);
 
     print_linkage();
     build_linkage();

--- a/crates/wgsl-rs-macros/src/lib.rs
+++ b/crates/wgsl-rs-macros/src/lib.rs
@@ -427,16 +427,22 @@ pub fn builtin(_attr: TokenStream, token_stream: TokenStream) -> TokenStream {
 
 /// Suppresses specific wgsl-rs warnings/errors on annotated statements.
 ///
-/// Use this attribute on for-loops with non-literal bounds to acknowledge
-/// that the loop may fail at runtime if the range is descending (WGSL only
-/// supports ascending iteration).
+/// Use this attribute to acknowledge cases where the transpiler cannot
+/// guarantee correctness at compile time, but you know the code is valid.
 ///
 /// # Available Warnings
 ///
 /// - `non_literal_loop_bounds`: Suppresses the error for for-loops with
-///   non-literal bounds (e.g., `for i in 0..n` where `n` is a variable).
+///   non-literal bounds (e.g., `for i in 0..n` where `n` is a variable). WGSL
+///   only supports ascending iteration, so the loop may fail at runtime if the
+///   range is descending.
 ///
-/// # Example
+/// - `non_literal_match_statement_patterns`: Suppresses the warning for match
+///   statements with non-literal case selectors (e.g., constants or
+///   identifiers). WGSL requires case selectors to be const-expressions, which
+///   the transpiler cannot always verify.
+///
+/// # Examples
 ///
 /// ```ignore
 /// pub fn sum_to_n(n: i32) -> i32 {
@@ -446,6 +452,22 @@ pub fn builtin(_attr: TokenStream, token_stream: TokenStream) -> TokenStream {
 ///         total += i;
 ///     }
 ///     total
+/// }
+/// ```
+///
+/// ```ignore
+/// const LOW: i32 = 0;
+/// const HIGH: i32 = 1;
+///
+/// pub fn with_const_patterns(level: i32) -> f32 {
+///     let mut result = 0.0;
+///     #[wgsl_allow(non_literal_match_statement_patterns)]
+///     match level {
+///         LOW => { result = 0.1; }
+///         HIGH => { result = 1.0; }
+///         _ => {}
+///     }
+///     result
 /// }
 /// ```
 ///


### PR DESCRIPTION
These changes add support for transpiling Rust `match` statements into WGSL `switch` statements. The support is limited, and use non-literal patterns on match arms causes a warning or error to me emitted, which can be suppressed with a `#[wgsl_allow(non_literal_match_statement_patterns)]` annotation on the match. 