### PR TITLE
fix: enums are alias for u32

### DIFF
--- a/crates/example/src/main.rs
+++ b/crates/example/src/main.rs
@@ -200,12 +200,26 @@ pub mod enum_example {
         WaitangiDay,
     }
 
-    storage!(group(0), binding(0), INPUT: [Holidays; 256]);
+    storage!(group(0), binding(0), read_write, INPUT: [Holidays; 256]);
 
 
     #[compute]
     #[workgroup_size(16)]
-    pub fn compute_holidays(#[builtin(global_invocation_id)] global_id: Vec3u) {}
+    pub fn compute_holidays(#[builtin(global_invocation_id)] global_id: Vec3u) {
+        let index = global_id.x();
+
+        let holiday = &mut get_mut!(INPUT)[index as usize];
+
+        #[wgsl_allow(non_literal_match_statement_patterns)]
+        match *holiday {
+            Holidays::AprilFoolsDay => {
+                *holiday = Holidays::WaitangiDay;
+            }
+            Holidays::WaitangiDay => {
+                *holiday = Holidays::AprilFoolsDay;
+            }
+        }
+    }
 }
 
 #[wgsl]

--- a/crates/wgsl-rs-macros/src/code_gen/formatter.rs
+++ b/crates/wgsl-rs-macros/src/code_gen/formatter.rs
@@ -1726,6 +1726,15 @@ impl GenerateCode for ItemEnum {
             variants,
         } = self;
 
+        // Generate type alias first: alias EnumName = u32;
+        // This allows the enum name to be used as a type (e.g., in arrays)
+        code.write_str(enum_token.span(), "alias");
+        code.space();
+        enum_ident.write_code(code);
+        code.write_str(enum_token.span(), " = u32;");
+        code.newline();
+
+        // Generate constants for each variant
         let mut current_discriminant: u32 = 0;
 
         for variant in variants {


### PR DESCRIPTION
These changes fix an issue where enums used in structs and arrays caused a type error, since they were silently transpiled to `u32`. Now an alias for the type name is generated along with each const variant.