### PR TITLE
feat: initial synchronization primitives

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -236,6 +236,14 @@ Added `workgroup!` macro for declaring workgroup-scoped variables shared across 
 - Added `AddressSpace::Workgroup` variant for future pointer support
 - Atomic builtin functions (atomicLoad, atomicStore, etc.) will be added in a future update
 
+### 2026-02-13: Synchronization builtin functions
+
+Added `storageBarrier()`, `workgroupBarrier()`, `textureBarrier()`, and `workgroupUniformLoad()` synchronization builtins for compute shader workgroup coordination.
+- Barrier functions are no-ops on the CPU side (no parallel dispatch runtime yet)
+- `workgroup_uniform_load` uses a `WorkgroupUniformLoad` trait with impls for `Workgroup<T: Clone>` and `Workgroup<Atomic<{u32,i32}>>`
+- Extended `ptr!` macro and parser to support `workgroup` address space
+- Added name mappings in `BUILTIN_CASE_NAME_MAP` for all four sync builtins
+
 ### 2026-01-24: RuntimeArray<T> support
 
 Added `RuntimeArray<T>` type for runtime-sized arrays (WGSL `array<T>` without size parameter).

--- a/crates/wgsl-rs-macros/src/builtins.rs
+++ b/crates/wgsl-rs-macros/src/builtins.rs
@@ -37,6 +37,11 @@ pub const BUILTIN_CASE_NAME_MAP: &[(&str, &str)] = &[
     ("atomic_store", "atomicStore"),
     ("atomic_sub", "atomicSub"),
     ("atomic_xor", "atomicXor"),
+    // Synchronization
+    ("storage_barrier", "storageBarrier"),
+    ("texture_barrier", "textureBarrier"),
+    ("workgroup_barrier", "workgroupBarrier"),
+    ("workgroup_uniform_load", "workgroupUniformLoad"),
     // Bit manipulation
     ("count_leading_zeros", "countLeadingZeros"),
     ("count_one_bits", "countOneBits"),

--- a/crates/wgsl-rs-macros/src/parse.rs
+++ b/crates/wgsl-rs-macros/src/parse.rs
@@ -869,12 +869,13 @@ impl TryFrom<&syn::Type> for Type {
                 let address_space = match parsed.address_space.to_string().as_str() {
                     "function" => AddressSpace::Function,
                     "private" => AddressSpace::Private,
+                    "workgroup" => AddressSpace::Workgroup,
                     other => {
                         return UnsupportedSnafu {
                             span: parsed.address_space.span(),
                             note: format!(
-                                "unsupported address space '{}', only 'function' and 'private' \
-                                 are supported",
+                                "unsupported address space '{}', only 'function', 'private', and \
+                                 'workgroup' are supported",
                                 other
                             ),
                         }

--- a/crates/wgsl-rs-macros/src/ptr.rs
+++ b/crates/wgsl-rs-macros/src/ptr.rs
@@ -63,10 +63,16 @@ pub fn ptr(input: TokenStream) -> TokenStream {
             // In Rust, this maps to &mut T for mutable access.
             quote! { &mut #store_type }.into()
         }
+        "workgroup" => {
+            // Workgroup address space has read_write access mode by default.
+            // In Rust, this maps to &mut T for mutable access.
+            quote! { &mut #store_type }.into()
+        }
         other => syn::Error::new(
             address_space.span(),
             format!(
-                "unsupported address space '{}', only 'function' and 'private' are supported",
+                "unsupported address space '{}', only 'function', 'private', and 'workgroup' are \
+                 supported",
                 other
             ),
         )

--- a/crates/wgsl-rs/src/std.rs
+++ b/crates/wgsl-rs/src/std.rs
@@ -29,6 +29,7 @@ mod bitcast;
 mod matrix;
 mod numeric;
 mod packing;
+mod synchronization;
 mod texture;
 mod vector;
 
@@ -37,6 +38,7 @@ pub use bitcast::*;
 pub use matrix::*;
 pub use numeric::*;
 pub use packing::*;
+pub use synchronization::*;
 pub use texture::*;
 pub use vector::*;
 

--- a/crates/wgsl-rs/src/std/synchronization.rs
+++ b/crates/wgsl-rs/src/std/synchronization.rs
@@ -1,0 +1,219 @@
+//! Synchronization Built-in Functions
+//!
+//! WGSL synchronization functions for compute shader workgroup coordination.
+//! See: <https://gpuweb.github.io/gpuweb/wgsl/#sync-builtin-functions>
+//!
+//! All synchronization functions execute a control barrier with Acquire/Release
+//! memory ordering. They use the `Workgroup` memory scope and execution scope.
+//!
+//! All synchronization functions must only be used in the compute shader stage
+//! and must only be invoked in uniform control flow.
+//!
+//! ## CPU-Side Behavior
+//!
+//! On the CPU side, the barrier functions are currently no-ops because there
+//! is no parallel dispatch runtime. When a multi-threaded compute dispatch
+//! is implemented, these should be revisited to use proper thread barriers.
+
+use super::{
+    Workgroup,
+    atomic::{Atomic, atomic_load, atomic_load_i32},
+};
+
+/// Executes a control barrier synchronization function that affects memory
+/// and atomic operations in the storage address space.
+///
+/// Ensures all storage buffer writes by invocations in the workgroup are
+/// visible to all other invocations before any subsequent storage memory
+/// or atomic operations execute.
+///
+/// # Compute Shader Only
+/// This function must only be called from compute shader entry points
+/// in uniform control flow.
+///
+/// # CPU-Side Behavior
+/// Currently a no-op. The CPU has no parallel workgroup dispatch runtime.
+// TODO: revisit after implementing a parallel dispatch runtime
+pub fn storage_barrier() {}
+
+/// Executes a control barrier synchronization function that affects memory
+/// operations in the handle address space.
+///
+/// Ensures all texture memory operations by invocations in the workgroup
+/// are visible to all other invocations before any subsequent handle memory
+/// operations execute.
+///
+/// # Compute Shader Only
+/// This function must only be called from compute shader entry points
+/// in uniform control flow.
+///
+/// # CPU-Side Behavior
+/// Currently a no-op. The CPU has no parallel workgroup dispatch runtime.
+// TODO: revisit after implementing a parallel dispatch runtime
+pub fn texture_barrier() {}
+
+/// Executes a control barrier synchronization function that affects memory
+/// and atomic operations in the workgroup address space.
+///
+/// Ensures all workgroup memory writes by invocations are visible to all
+/// other invocations, and synchronizes execution across the workgroup.
+///
+/// # Compute Shader Only
+/// This function must only be called from compute shader entry points
+/// in uniform control flow.
+///
+/// # CPU-Side Behavior
+/// Currently a no-op. The CPU has no parallel workgroup dispatch runtime.
+// TODO: revisit after implementing a parallel dispatch runtime
+pub fn workgroup_barrier() {}
+
+/// Trait for types that support `workgroupUniformLoad`.
+///
+/// Returns the value from a workgroup variable, ensuring the value is
+/// uniform across the workgroup. Also executes a workgroup barrier.
+///
+/// This trait has two families of implementations:
+/// - `Workgroup<T>` where `T: Clone` — returns a clone of the stored value
+/// - `Workgroup<Atomic<T>>` — atomically loads and returns the inner scalar
+pub trait WorkgroupUniformLoad {
+    /// The type returned by the uniform load.
+    type Output;
+
+    /// Performs the uniform load, returning the value.
+    fn uniform_load(&self) -> Self::Output;
+}
+
+impl<T: Clone> WorkgroupUniformLoad for Workgroup<T> {
+    type Output = T;
+
+    fn uniform_load(&self) -> T {
+        self.get().clone()
+    }
+}
+
+/// Returns the value pointed to by a workgroup variable, ensuring the
+/// value is uniform across the workgroup.
+///
+/// This is the Rust equivalent of WGSL's
+/// `workgroupUniformLoad(p: ptr<workgroup, T>) -> T`.
+///
+/// The return value is uniform — all invocations in the workgroup observe
+/// the same value. Also executes a workgroup barrier.
+///
+/// # Overloads
+///
+/// In WGSL, `workgroupUniformLoad` has two overloads:
+/// - `fn workgroupUniformLoad(p: ptr<workgroup, T>) -> T` for constructible
+///   types
+/// - `fn workgroupUniformLoad(p: ptr<workgroup, atomic<T>, read_write>) -> T`
+///   for atomic types (returns the inner scalar, not the atomic wrapper)
+///
+/// Both overloads are handled by the [`WorkgroupUniformLoad`] trait.
+///
+/// # Compute Shader Only
+/// This function must only be called from compute shader entry points
+/// in uniform control flow.
+///
+/// # Example
+///
+/// ```ignore
+/// use wgsl_rs::std::*;
+///
+/// workgroup!(SHARED_VALUE: u32);
+///
+/// #[compute]
+/// #[workgroup_size(64)]
+/// fn main(#[builtin(local_invocation_index)] local_idx: u32) {
+///     let value: u32 = workgroup_uniform_load(&SHARED_VALUE);
+/// }
+/// ```
+pub fn workgroup_uniform_load<W: WorkgroupUniformLoad>(p: &W) -> W::Output {
+    p.uniform_load()
+}
+
+/// Specialized implementation for `Workgroup<Atomic<u32>>`.
+///
+/// Returns the `u32` scalar value via an atomic load, matching the WGSL
+/// overload `workgroupUniformLoad(p: ptr<workgroup, atomic<u32>, read_write>)
+/// -> u32`.
+impl WorkgroupUniformLoad for Workgroup<Atomic<u32>> {
+    type Output = u32;
+
+    fn uniform_load(&self) -> u32 {
+        atomic_load(&self.get())
+    }
+}
+
+/// Specialized implementation for `Workgroup<Atomic<i32>>`.
+///
+/// Returns the `i32` scalar value via an atomic load, matching the WGSL
+/// overload `workgroupUniformLoad(p: ptr<workgroup, atomic<i32>, read_write>)
+/// -> i32`.
+impl WorkgroupUniformLoad for Workgroup<Atomic<i32>> {
+    type Output = i32;
+
+    fn uniform_load(&self) -> i32 {
+        atomic_load_i32(&self.get())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_storage_barrier_is_callable() {
+        // Barrier functions should be callable without panicking.
+        // They are no-ops on the CPU side.
+        storage_barrier();
+    }
+
+    #[test]
+    fn test_texture_barrier_is_callable() {
+        texture_barrier();
+    }
+
+    #[test]
+    fn test_workgroup_barrier_is_callable() {
+        workgroup_barrier();
+    }
+
+    #[test]
+    fn test_workgroup_uniform_load_u32() {
+        let wg: Workgroup<u32> = Workgroup::new();
+        wg.set(42);
+        let value = workgroup_uniform_load(&wg);
+        assert_eq!(value, 42u32);
+    }
+
+    #[test]
+    #[allow(clippy::approx_constant)]
+    fn test_workgroup_uniform_load_f32() {
+        let wg: Workgroup<f32> = Workgroup::new();
+        wg.set(3.14);
+        let value = workgroup_uniform_load(&wg);
+        assert!((value - 3.14).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_workgroup_uniform_load_atomic_u32() {
+        use crate::std::atomic::atomic_store;
+
+        let wg: Workgroup<Atomic<u32>> = Workgroup::new();
+        wg.set(Atomic::default());
+        atomic_store(&wg.get(), 99);
+        let value = workgroup_uniform_load(&wg);
+        assert_eq!(value, 99u32);
+    }
+
+    #[test]
+    fn test_workgroup_uniform_load_atomic_i32() {
+        use crate::std::atomic::atomic_store_i32;
+
+        let wg: Workgroup<Atomic<i32>> = Workgroup::new();
+        wg.set(Atomic::default());
+        atomic_store_i32(&wg.get(), -42);
+        let value = workgroup_uniform_load(&wg);
+        assert_eq!(value, -42i32);
+    }
+}


### PR DESCRIPTION
These changes add support for the synchronization primitives `storage_barrier`, `workgroup_barrier`, `workgroup_uniform_load` and `texture_barrier`. On Rust CPU these are noops, and we'll have to think hard about a parallel execution model.

Fixes #19 