### PR TITLE
fix: use plain structs for vectors and matrices

### DIFF
--- a/crates/example/src/examples.rs
+++ b/crates/example/src/examples.rs
@@ -55,7 +55,7 @@ pub mod hello_triangle {
         const POS: [Vec2f; 3] = [vec2f(0.0, 0.5), vec2f(-0.5, -0.5), vec2f(0.5, -0.5)];
 
         let position = POS[vertex_index as usize];
-        vec4f(position.x(), position.y(), 0.0, 1.0)
+        vec4f(position.x, position.y, 0.0, 1.0)
     }
 
     #[fragment]
@@ -1326,7 +1326,7 @@ pub mod slab_read_write {
         }
 
         // Modify it
-        data.three_four.set_x(123.0);
+        data.three_four.x = 123.0;
 
         // Write the modified `Data` struct back to the slab
         let out_array = Data::to_array(data);

--- a/crates/wgsl-rs-macros/src/swizzle.rs
+++ b/crates/wgsl-rs-macros/src/swizzle.rs
@@ -2,7 +2,7 @@
 
 use itertools::Itertools;
 use proc_macro::TokenStream;
-use quote::{ToTokens, format_ident, quote};
+use quote::{format_ident, quote, ToTokens};
 use syn::parse::Parse;
 
 /// Parses macro input like `Vec2, [x, y], [r, g]` and
@@ -118,11 +118,11 @@ impl ToTokens for Swizzling {
                     .map(|p| p.field.clone())
                     .collect::<Vec<_>>();
                 if let Some(constructor) = &self.constructor {
-                    quote! { #constructor(#(self.inner.#components),*) }
+                    quote! { #constructor(#(self.#components),*) }
                 } else {
                     // There's only one component
                     let component = components.pop().unwrap();
-                    quote! { self.inner.#component }
+                    quote! { self.#component }
                 }
             }
 
@@ -142,26 +142,10 @@ impl ToTokens for Swizzling {
                 let get_constructor = self.get_constructor();
                 let return_ty = self.return_ty();
 
-                // Only single-component swizzles get setters, matching WGSL
-                // spec §8.5.1: multi-letter swizzles cannot appear on the
-                // left-hand side of an assignment.
-                let setter = if self.constructor.is_none() {
-                    let set_fn_ident = format_ident!("set_{get_fn_ident}");
-                    let field = &self.components[0].field;
-                    quote! {
-                        pub fn #set_fn_ident(&mut self, value: #return_ty) {
-                            self.inner.#field = value;
-                        }
-                    }
-                } else {
-                    quote! {}
-                };
-
                 quote! {
                     pub fn #get_fn_ident(&self) -> #return_ty {
                         #get_constructor
                     }
-                    #setter
                 }
                 .to_tokens(tokens)
             }

--- a/crates/wgsl-rs-macros/src/swizzle.rs
+++ b/crates/wgsl-rs-macros/src/swizzle.rs
@@ -2,7 +2,7 @@
 
 use itertools::Itertools;
 use proc_macro::TokenStream;
-use quote::{format_ident, quote, ToTokens};
+use quote::{ToTokens, format_ident, quote};
 use syn::parse::Parse;
 
 /// Parses macro input like `Vec2, [x, y], [r, g]` and

--- a/crates/wgsl-rs/src/std/bitcast.rs
+++ b/crates/wgsl-rs/src/std/bitcast.rs
@@ -161,9 +161,9 @@ mod bitcast_impls {
         ($n:literal, $src_vec:ty, $dst_vec:ty, $src_scalar:ty, $dst_scalar:ty) => {
             impl Bitcast<$dst_vec> for $src_vec {
                 fn bitcast(self) -> $dst_vec {
-                    let src: [$src_scalar; $n] = <$src_scalar>::vec_to_array(self);
+                    let src: [$src_scalar; $n] = self.to_array();
                     let dst: [$dst_scalar; $n] = src.map(|s| Bitcast::<$dst_scalar>::bitcast(s));
-                    <$dst_scalar>::vec_from_array(dst)
+                    <$dst_vec>::from_array(dst)
                 }
             }
         };

--- a/crates/wgsl-rs/src/std/matrix.rs
+++ b/crates/wgsl-rs/src/std/matrix.rs
@@ -1,247 +1,351 @@
+//! Matrix implementations.
+//!
+//! Column-major matrices with public `columns` arrays, matching WGSL's
+//! matrix types. Columns are accessed by index: `m[0]`, `m[1]`, etc.
+
 use super::*;
 
-/// Trait identifying the standard library's inner matrix types.
-///
-/// WGSL supports matrices consisting of `f32` and `f16` elements.
-pub trait ScalarCompOfMatrix<const N: usize, const M: usize>:
-    ScalarCompOfVec<N> + ScalarCompOfVec<M>
-{
-    type Output: Clone + Copy;
-}
-
-/// An `NxM` dimensional column-major matrix.
-#[repr(transparent)]
+/// A 2x2 column-major matrix of `f32` components (2 columns of `Vec2f`).
+#[repr(C)]
 #[derive(Copy, Clone)]
-pub struct Mat<const N: usize, const M: usize, T: ScalarCompOfMatrix<N, M>> {
-    pub(crate) inner: <T as ScalarCompOfMatrix<N, M>>::Output,
+pub struct Mat2x2f {
+    columns: [Vec2f; 2],
 }
 
-/// matrix! generates the N×N matrix:
-/// * ScalarCompOfMatrix impl
-/// * concretized type alias
-/// * const constructor
-macro_rules! matrix {
-    ($n:literal, $m: literal, $ty:ty, $inner:ty, $construct_inner:path, $col_ty:ty, [$($cols:ident),+]) => {
-        paste::paste! {
-            impl ScalarCompOfMatrix<$n, $m> for $ty {
-                type Output = $inner;
-            }
-
-            #[doc = concat!("A ", $n, "x", $m, " column-major matrix of ", stringify!($ty), " components.")]
-            pub type [<Mat $n x $m f>] = Mat<$n, $m, $ty>;
-
-            #[doc = concat!("Constructs a ", $n, "x", $m, " column-major matrix of ", stringify!($ty), " components.")]
-            pub const fn [<mat $n x $m f>]($($cols: $col_ty<$ty>),+) -> Mat<$n, $m, $ty> {
-                let inner = $construct_inner($($cols.inner),+);
-                Mat { inner }
-            }
-        }
-    };
+/// A 2x3 column-major matrix of `f32` components (2 columns of `Vec3f`).
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Mat2x3f {
+    columns: [Vec3f; 2],
 }
 
-// Mat<2, 2, f32>
-matrix!(
-    2,
-    2,
-    f32,
-    glam::Mat2,
-    glam::Mat2::from_cols,
-    Vec2,
-    [x_axis, y_axis]
-);
-
-const fn mat32_inner(x_axis: glam::Vec3, y_axis: glam::Vec3) -> [glam::Vec3; 2] {
-    [x_axis, y_axis]
+/// A 2x4 column-major matrix of `f32` components (2 columns of `Vec4f`).
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Mat2x4f {
+    columns: [Vec4f; 2],
 }
-matrix!(
-    2,
-    3,
-    f32,
-    [glam::Vec3; 2],
-    mat32_inner,
-    Vec3,
-    [x_axis, y_axis]
-);
 
-// Mat<3, 3, f32>
-matrix!(
-    3,
-    3,
-    f32,
-    glam::Mat3,
-    glam::Mat3::from_cols,
-    Vec3,
-    [x_axis, y_axis, z_axis]
-);
-
-// Mat<3, 2, f32>
-matrix!(
-    3,
-    2,
-    f32,
-    glam::Affine2,
-    glam::Affine2::from_cols,
-    Vec2,
-    [x_axis, y_axis, z_axis]
-);
-
-// Mat<4, 4, f32>
-matrix!(
-    4,
-    4,
-    f32,
-    glam::Mat4,
-    glam::Mat4::from_cols,
-    Vec4,
-    [x_axis, y_axis, z_axis, w_axis]
-);
-
-// Mat<4, 3, f32>
-const fn mat43_inner(
-    x_axis: glam::Vec3,
-    y_axis: glam::Vec3,
-    z_axis: glam::Vec3,
-    w_axis: glam::Vec3,
-) -> [glam::Vec3; 4] {
-    [x_axis, y_axis, z_axis, w_axis]
+/// A 3x2 column-major matrix of `f32` components (3 columns of `Vec2f`).
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Mat3x2f {
+    columns: [Vec2f; 3],
 }
-matrix!(
-    4,
-    3,
-    f32,
-    [glam::Vec3; 4],
-    mat43_inner,
-    Vec3,
-    [x_axis, y_axis, z_axis, w_axis]
-);
 
-// Mat<4, 2, f32>
-const fn mat42_inner(
-    x_axis: glam::Vec2,
-    y_axis: glam::Vec2,
-    z_axis: glam::Vec2,
-    w_axis: glam::Vec2,
-) -> [glam::Vec2; 4] {
-    [x_axis, y_axis, z_axis, w_axis]
+/// A 3x3 column-major matrix of `f32` components (3 columns of `Vec3f`).
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Mat3x3f {
+    columns: [Vec3f; 3],
 }
-matrix!(
-    4,
-    2,
-    f32,
-    [glam::Vec2; 4],
-    mat42_inner,
-    Vec2,
-    [x_axis, y_axis, z_axis, w_axis]
-);
 
-// Mat<2, 4, f32>
-const fn mat24_inner(x_axis: glam::Vec4, y_axis: glam::Vec4) -> [glam::Vec4; 2] {
-    [x_axis, y_axis]
+/// A 3x4 column-major matrix of `f32` components (3 columns of `Vec4f`).
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Mat3x4f {
+    columns: [Vec4f; 3],
 }
-matrix!(
-    2,
-    4,
-    f32,
-    [glam::Vec4; 2],
-    mat24_inner,
-    Vec4,
-    [x_axis, y_axis]
-);
 
-// Mat<3, 4, f32>
-const fn mat34_inner(
-    x_axis: glam::Vec4,
-    y_axis: glam::Vec4,
-    z_axis: glam::Vec4,
-) -> [glam::Vec4; 3] {
-    [x_axis, y_axis, z_axis]
+/// A 4x2 column-major matrix of `f32` components (4 columns of `Vec2f`).
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Mat4x2f {
+    columns: [Vec2f; 4],
 }
-matrix!(
-    3,
-    4,
-    f32,
-    [glam::Vec4; 3],
-    mat34_inner,
-    Vec4,
-    [x_axis, y_axis, z_axis]
-);
 
-/// Alias for Mat2x2f.
+/// A 4x3 column-major matrix of `f32` components (4 columns of `Vec3f`).
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Mat4x3f {
+    columns: [Vec3f; 4],
+}
+
+/// A 4x4 column-major matrix of `f32` components (4 columns of `Vec4f`).
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Mat4x4f {
+    columns: [Vec4f; 4],
+}
+
+/// Alias for `Mat2x2f`.
 pub type Mat2f = Mat2x2f;
-/// Alias for Mat3x3f.
+/// Alias for `Mat3x3f`.
 pub type Mat3f = Mat3x3f;
-/// Alias for Mat4x4f.
+/// Alias for `Mat4x4f`.
 pub type Mat4f = Mat4x4f;
 
-/// From<glam::MatN> for MatNf...
-macro_rules! impl_from_mat {
-    ($from:ty, $to:ident) => {
-        impl From<$from> for $to {
-            fn from(value: $from) -> Self {
-                $to { inner: value }
+// Const constructor functions matching WGSL naming conventions.
+
+/// Constructs a 2x2 column-major matrix of `f32` components.
+pub const fn mat2x2f(x_axis: Vec2f, y_axis: Vec2f) -> Mat2x2f {
+    Mat2x2f {
+        columns: [x_axis, y_axis],
+    }
+}
+
+/// Constructs a 2x3 column-major matrix of `f32` components.
+pub const fn mat2x3f(x_axis: Vec3f, y_axis: Vec3f) -> Mat2x3f {
+    Mat2x3f {
+        columns: [x_axis, y_axis],
+    }
+}
+
+/// Constructs a 2x4 column-major matrix of `f32` components.
+pub const fn mat2x4f(x_axis: Vec4f, y_axis: Vec4f) -> Mat2x4f {
+    Mat2x4f {
+        columns: [x_axis, y_axis],
+    }
+}
+
+/// Constructs a 3x2 column-major matrix of `f32` components.
+pub const fn mat3x2f(x_axis: Vec2f, y_axis: Vec2f, z_axis: Vec2f) -> Mat3x2f {
+    Mat3x2f {
+        columns: [x_axis, y_axis, z_axis],
+    }
+}
+
+/// Constructs a 3x3 column-major matrix of `f32` components.
+pub const fn mat3x3f(x_axis: Vec3f, y_axis: Vec3f, z_axis: Vec3f) -> Mat3x3f {
+    Mat3x3f {
+        columns: [x_axis, y_axis, z_axis],
+    }
+}
+
+/// Constructs a 3x4 column-major matrix of `f32` components.
+pub const fn mat3x4f(x_axis: Vec4f, y_axis: Vec4f, z_axis: Vec4f) -> Mat3x4f {
+    Mat3x4f {
+        columns: [x_axis, y_axis, z_axis],
+    }
+}
+
+/// Constructs a 4x2 column-major matrix of `f32` components.
+pub const fn mat4x2f(x_axis: Vec2f, y_axis: Vec2f, z_axis: Vec2f, w_axis: Vec2f) -> Mat4x2f {
+    Mat4x2f {
+        columns: [x_axis, y_axis, z_axis, w_axis],
+    }
+}
+
+/// Constructs a 4x3 column-major matrix of `f32` components.
+pub const fn mat4x3f(x_axis: Vec3f, y_axis: Vec3f, z_axis: Vec3f, w_axis: Vec3f) -> Mat4x3f {
+    Mat4x3f {
+        columns: [x_axis, y_axis, z_axis, w_axis],
+    }
+}
+
+/// Constructs a 4x4 column-major matrix of `f32` components.
+pub const fn mat4x4f(x_axis: Vec4f, y_axis: Vec4f, z_axis: Vec4f, w_axis: Vec4f) -> Mat4x4f {
+    Mat4x4f {
+        columns: [x_axis, y_axis, z_axis, w_axis],
+    }
+}
+
+// Index impls for all matrix types, for both `usize` and `u32`.
+
+macro_rules! impl_mat_index {
+    ($mat:ty, $col_ty:ty) => {
+        impl std::ops::Index<usize> for $mat {
+            type Output = $col_ty;
+            fn index(&self, index: usize) -> &$col_ty {
+                &self.columns[index]
+            }
+        }
+
+        impl std::ops::IndexMut<usize> for $mat {
+            fn index_mut(&mut self, index: usize) -> &mut $col_ty {
+                &mut self.columns[index]
+            }
+        }
+
+        impl std::ops::Index<u32> for $mat {
+            type Output = $col_ty;
+            fn index(&self, index: u32) -> &$col_ty {
+                &self.columns[index as usize]
+            }
+        }
+
+        impl std::ops::IndexMut<u32> for $mat {
+            fn index_mut(&mut self, index: u32) -> &mut $col_ty {
+                &mut self.columns[index as usize]
             }
         }
     };
 }
-impl_from_mat!(glam::Mat2, Mat2f);
-impl_from_mat!(glam::Mat3, Mat3f);
-impl_from_mat!(glam::Mat4, Mat4f);
 
-/// Implements matrix * matrix multiplication for square matrices.
-macro_rules! impl_mat_mul_mat {
-    ($mat:ty) => {
-        impl std::ops::Mul<$mat> for $mat {
-            type Output = $mat;
-            fn mul(self, rhs: $mat) -> Self::Output {
-                Self {
-                    inner: self.inner * rhs.inner,
-                }
-            }
+impl_mat_index!(Mat2x2f, Vec2f);
+impl_mat_index!(Mat2x3f, Vec3f);
+impl_mat_index!(Mat2x4f, Vec4f);
+impl_mat_index!(Mat3x2f, Vec2f);
+impl_mat_index!(Mat3x3f, Vec3f);
+impl_mat_index!(Mat3x4f, Vec4f);
+impl_mat_index!(Mat4x2f, Vec2f);
+impl_mat_index!(Mat4x3f, Vec3f);
+impl_mat_index!(Mat4x4f, Vec4f);
+
+// From/Into conversions for glam types.
+
+impl From<glam::Mat2> for Mat2x2f {
+    fn from(m: glam::Mat2) -> Self {
+        Mat2x2f {
+            columns: [m.x_axis.into(), m.y_axis.into()],
         }
-    };
+    }
 }
-impl_mat_mul_mat!(Mat2f);
-impl_mat_mul_mat!(Mat3f);
-impl_mat_mul_mat!(Mat4f);
 
-/// Implements matrix * vector multiplication.
-macro_rules! impl_mat_mul_vec {
-    ($mat:ty, $vec:ty) => {
-        impl std::ops::Mul<$vec> for $mat {
-            type Output = $vec;
-            fn mul(self, rhs: $vec) -> Self::Output {
-                <$vec>::from(self.inner * rhs.inner)
-            }
-        }
-    };
+impl From<Mat2x2f> for glam::Mat2 {
+    fn from(m: Mat2x2f) -> Self {
+        glam::Mat2::from_cols(m.columns[0].into(), m.columns[1].into())
+    }
 }
-impl_mat_mul_vec!(Mat2f, Vec2f);
-impl_mat_mul_vec!(Mat3f, Vec3f);
-impl_mat_mul_vec!(Mat4f, Vec4f);
 
-/// Implements matrix * scalar and scalar * matrix multiplication.
-macro_rules! impl_mat_mul_scalar {
-    ($mat:ty) => {
-        impl std::ops::Mul<f32> for $mat {
-            type Output = $mat;
-            fn mul(self, rhs: f32) -> Self::Output {
-                Self {
-                    inner: self.inner * rhs,
-                }
-            }
+impl From<glam::Mat3> for Mat3x3f {
+    fn from(m: glam::Mat3) -> Self {
+        Mat3x3f {
+            columns: [m.x_axis.into(), m.y_axis.into(), m.z_axis.into()],
         }
-
-        impl std::ops::Mul<$mat> for f32 {
-            type Output = $mat;
-            fn mul(self, rhs: $mat) -> Self::Output {
-                <$mat>::from(self * rhs.inner)
-            }
-        }
-    };
+    }
 }
-impl_mat_mul_scalar!(Mat2f);
-impl_mat_mul_scalar!(Mat3f);
-impl_mat_mul_scalar!(Mat4f);
+
+impl From<Mat3x3f> for glam::Mat3 {
+    fn from(m: Mat3x3f) -> Self {
+        glam::Mat3::from_cols(
+            m.columns[0].into(),
+            m.columns[1].into(),
+            m.columns[2].into(),
+        )
+    }
+}
+
+impl From<glam::Mat4> for Mat4x4f {
+    fn from(m: glam::Mat4) -> Self {
+        Mat4x4f {
+            columns: [
+                m.x_axis.into(),
+                m.y_axis.into(),
+                m.z_axis.into(),
+                m.w_axis.into(),
+            ],
+        }
+    }
+}
+
+impl From<Mat4x4f> for glam::Mat4 {
+    fn from(m: Mat4x4f) -> Self {
+        glam::Mat4::from_cols(
+            m.columns[0].into(),
+            m.columns[1].into(),
+            m.columns[2].into(),
+            m.columns[3].into(),
+        )
+    }
+}
+
+// Arithmetic: matrix * matrix, matrix * vector, matrix * scalar, scalar *
+// matrix. Delegated to glam for the square matrix types.
+
+impl std::ops::Mul<Mat2x2f> for Mat2x2f {
+    type Output = Mat2x2f;
+    fn mul(self, rhs: Mat2x2f) -> Mat2x2f {
+        let g: glam::Mat2 = self.into();
+        let rg: glam::Mat2 = rhs.into();
+        (g * rg).into()
+    }
+}
+
+impl std::ops::Mul<Vec2f> for Mat2x2f {
+    type Output = Vec2f;
+    fn mul(self, rhs: Vec2f) -> Vec2f {
+        let g: glam::Mat2 = self.into();
+        let gv: glam::Vec2 = rhs.into();
+        (g * gv).into()
+    }
+}
+
+impl std::ops::Mul<f32> for Mat2x2f {
+    type Output = Mat2x2f;
+    fn mul(self, rhs: f32) -> Mat2x2f {
+        let g: glam::Mat2 = self.into();
+        (g * rhs).into()
+    }
+}
+
+impl std::ops::Mul<Mat2x2f> for f32 {
+    type Output = Mat2x2f;
+    fn mul(self, rhs: Mat2x2f) -> Mat2x2f {
+        let g: glam::Mat2 = rhs.into();
+        (self * g).into()
+    }
+}
+
+impl std::ops::Mul<Mat3x3f> for Mat3x3f {
+    type Output = Mat3x3f;
+    fn mul(self, rhs: Mat3x3f) -> Mat3x3f {
+        let g: glam::Mat3 = self.into();
+        let rg: glam::Mat3 = rhs.into();
+        (g * rg).into()
+    }
+}
+
+impl std::ops::Mul<Vec3f> for Mat3x3f {
+    type Output = Vec3f;
+    fn mul(self, rhs: Vec3f) -> Vec3f {
+        let g: glam::Mat3 = self.into();
+        let gv: glam::Vec3 = rhs.into();
+        (g * gv).into()
+    }
+}
+
+impl std::ops::Mul<f32> for Mat3x3f {
+    type Output = Mat3x3f;
+    fn mul(self, rhs: f32) -> Mat3x3f {
+        let g: glam::Mat3 = self.into();
+        (g * rhs).into()
+    }
+}
+
+impl std::ops::Mul<Mat3x3f> for f32 {
+    type Output = Mat3x3f;
+    fn mul(self, rhs: Mat3x3f) -> Mat3x3f {
+        let g: glam::Mat3 = rhs.into();
+        (self * g).into()
+    }
+}
+
+impl std::ops::Mul<Mat4x4f> for Mat4x4f {
+    type Output = Mat4x4f;
+    fn mul(self, rhs: Mat4x4f) -> Mat4x4f {
+        let g: glam::Mat4 = self.into();
+        let rg: glam::Mat4 = rhs.into();
+        (g * rg).into()
+    }
+}
+
+impl std::ops::Mul<Vec4f> for Mat4x4f {
+    type Output = Vec4f;
+    fn mul(self, rhs: Vec4f) -> Vec4f {
+        let g: glam::Mat4 = self.into();
+        let gv: glam::Vec4 = rhs.into();
+        (g * gv).into()
+    }
+}
+
+impl std::ops::Mul<f32> for Mat4x4f {
+    type Output = Mat4x4f;
+    fn mul(self, rhs: f32) -> Mat4x4f {
+        let g: glam::Mat4 = self.into();
+        (g * rhs).into()
+    }
+}
+
+impl std::ops::Mul<Mat4x4f> for f32 {
+    type Output = Mat4x4f;
+    fn mul(self, rhs: Mat4x4f) -> Mat4x4f {
+        let g: glam::Mat4 = rhs.into();
+        (self * g).into()
+    }
+}
+
+// Determinant.
 
 /// Provides the numeric built-in function `determinant`.
 pub trait NumericBuiltinDeterminant {
@@ -259,29 +363,34 @@ pub fn determinant<T: NumericBuiltinDeterminant>(e: T) -> T::Scalar {
     <T as NumericBuiltinDeterminant>::determinant(e)
 }
 
-impl NumericBuiltinDeterminant for Mat2f {
+impl NumericBuiltinDeterminant for Mat2x2f {
     type Scalar = f32;
 
     fn determinant(self) -> f32 {
-        self.inner.determinant()
+        let g: glam::Mat2 = self.into();
+        g.determinant()
     }
 }
 
-impl NumericBuiltinDeterminant for Mat3f {
+impl NumericBuiltinDeterminant for Mat3x3f {
     type Scalar = f32;
 
     fn determinant(self) -> f32 {
-        self.inner.determinant()
+        let g: glam::Mat3 = self.into();
+        g.determinant()
     }
 }
 
-impl NumericBuiltinDeterminant for Mat4f {
+impl NumericBuiltinDeterminant for Mat4x4f {
     type Scalar = f32;
 
     fn determinant(self) -> f32 {
-        self.inner.determinant()
+        let g: glam::Mat4 = self.into();
+        g.determinant()
     }
 }
+
+// Transpose.
 
 /// Provides the numeric built-in function `transpose`.
 pub trait NumericBuiltinTranspose {
@@ -299,57 +408,42 @@ pub fn transpose<T: NumericBuiltinTranspose>(e: T) -> T::Output {
     <T as NumericBuiltinTranspose>::transpose(e)
 }
 
-impl NumericBuiltinTranspose for Mat2f {
-    type Output = Mat2f;
+impl NumericBuiltinTranspose for Mat2x2f {
+    type Output = Mat2x2f;
 
-    fn transpose(self) -> Mat2f {
-        Mat2f {
-            inner: self.inner.transpose(),
-        }
+    fn transpose(self) -> Mat2x2f {
+        let g: glam::Mat2 = self.into();
+        g.transpose().into()
     }
 }
 
-impl NumericBuiltinTranspose for Mat3f {
-    type Output = Mat3f;
+impl NumericBuiltinTranspose for Mat3x3f {
+    type Output = Mat3x3f;
 
-    fn transpose(self) -> Mat3f {
-        Mat3f {
-            inner: self.inner.transpose(),
-        }
+    fn transpose(self) -> Mat3x3f {
+        let g: glam::Mat3 = self.into();
+        g.transpose().into()
     }
 }
 
-impl NumericBuiltinTranspose for Mat4f {
-    type Output = Mat4f;
+impl NumericBuiltinTranspose for Mat4x4f {
+    type Output = Mat4x4f;
 
-    fn transpose(self) -> Mat4f {
-        Mat4f {
-            inner: self.inner.transpose(),
-        }
+    fn transpose(self) -> Mat4x4f {
+        let g: glam::Mat4 = self.into();
+        g.transpose().into()
     }
 }
 
 // Non-square matrix transpose implementations.
-//
-// For non-square matrices backed by `[glam::VecM; N]`, we need manual
-// transpose logic. A matrix with N columns of M-component vectors transposes
-// to M columns of N-component vectors.
 
 impl NumericBuiltinTranspose for Mat2x3f {
     type Output = Mat3x2f;
 
     fn transpose(self) -> Mat3x2f {
-        // self is 2 columns of Vec3: [[x0,y0,z0], [x1,y1,z1]]
-        // transpose is 3 columns of Vec2: [[x0,x1], [y0,y1], [z0,z1]]
-        let [c0, c1] = self.inner;
-        let c0a = c0.to_array();
-        let c1a = c1.to_array();
+        let [c0, c1] = self.columns;
         Mat3x2f {
-            inner: glam::Affine2::from_cols(
-                glam::Vec2::new(c0a[0], c1a[0]),
-                glam::Vec2::new(c0a[1], c1a[1]),
-                glam::Vec2::new(c0a[2], c1a[2]),
-            ),
+            columns: [vec2f(c0.x, c1.x), vec2f(c0.y, c1.y), vec2f(c0.z, c1.z)],
         }
     }
 }
@@ -358,16 +452,9 @@ impl NumericBuiltinTranspose for Mat3x2f {
     type Output = Mat2x3f;
 
     fn transpose(self) -> Mat2x3f {
-        // self is 3 columns of Vec2: Affine2 { matrix2: Mat2(x_axis, y_axis),
-        // translation } transpose is 2 columns of Vec3
-        let c0 = self.inner.matrix2.x_axis.to_array();
-        let c1 = self.inner.matrix2.y_axis.to_array();
-        let c2 = self.inner.translation.to_array();
+        let [c0, c1, c2] = self.columns;
         Mat2x3f {
-            inner: [
-                glam::Vec3::new(c0[0], c1[0], c2[0]),
-                glam::Vec3::new(c0[1], c1[1], c2[1]),
-            ],
+            columns: [vec3f(c0.x, c1.x, c2.x), vec3f(c0.y, c1.y, c2.y)],
         }
     }
 }
@@ -376,18 +463,12 @@ impl NumericBuiltinTranspose for Mat4x3f {
     type Output = Mat3x4f;
 
     fn transpose(self) -> Mat3x4f {
-        // self is 4 columns of Vec3
-        // transpose is 3 columns of Vec4
-        let [c0, c1, c2, c3] = self.inner;
-        let c0a = c0.to_array();
-        let c1a = c1.to_array();
-        let c2a = c2.to_array();
-        let c3a = c3.to_array();
+        let [c0, c1, c2, c3] = self.columns;
         Mat3x4f {
-            inner: [
-                glam::Vec4::new(c0a[0], c1a[0], c2a[0], c3a[0]),
-                glam::Vec4::new(c0a[1], c1a[1], c2a[1], c3a[1]),
-                glam::Vec4::new(c0a[2], c1a[2], c2a[2], c3a[2]),
+            columns: [
+                vec4f(c0.x, c1.x, c2.x, c3.x),
+                vec4f(c0.y, c1.y, c2.y, c3.y),
+                vec4f(c0.z, c1.z, c2.z, c3.z),
             ],
         }
     }
@@ -397,18 +478,13 @@ impl NumericBuiltinTranspose for Mat3x4f {
     type Output = Mat4x3f;
 
     fn transpose(self) -> Mat4x3f {
-        // self is 3 columns of Vec4
-        // transpose is 4 columns of Vec3
-        let [c0, c1, c2] = self.inner;
-        let c0a = c0.to_array();
-        let c1a = c1.to_array();
-        let c2a = c2.to_array();
+        let [c0, c1, c2] = self.columns;
         Mat4x3f {
-            inner: [
-                glam::Vec3::new(c0a[0], c1a[0], c2a[0]),
-                glam::Vec3::new(c0a[1], c1a[1], c2a[1]),
-                glam::Vec3::new(c0a[2], c1a[2], c2a[2]),
-                glam::Vec3::new(c0a[3], c1a[3], c2a[3]),
+            columns: [
+                vec3f(c0.x, c1.x, c2.x),
+                vec3f(c0.y, c1.y, c2.y),
+                vec3f(c0.z, c1.z, c2.z),
+                vec3f(c0.w, c1.w, c2.w),
             ],
         }
     }
@@ -418,18 +494,9 @@ impl NumericBuiltinTranspose for Mat4x2f {
     type Output = Mat2x4f;
 
     fn transpose(self) -> Mat2x4f {
-        // self is 4 columns of Vec2
-        // transpose is 2 columns of Vec4
-        let [c0, c1, c2, c3] = self.inner;
-        let c0a = c0.to_array();
-        let c1a = c1.to_array();
-        let c2a = c2.to_array();
-        let c3a = c3.to_array();
+        let [c0, c1, c2, c3] = self.columns;
         Mat2x4f {
-            inner: [
-                glam::Vec4::new(c0a[0], c1a[0], c2a[0], c3a[0]),
-                glam::Vec4::new(c0a[1], c1a[1], c2a[1], c3a[1]),
-            ],
+            columns: [vec4f(c0.x, c1.x, c2.x, c3.x), vec4f(c0.y, c1.y, c2.y, c3.y)],
         }
     }
 }
@@ -438,17 +505,13 @@ impl NumericBuiltinTranspose for Mat2x4f {
     type Output = Mat4x2f;
 
     fn transpose(self) -> Mat4x2f {
-        // self is 2 columns of Vec4
-        // transpose is 4 columns of Vec2
-        let [c0, c1] = self.inner;
-        let c0a = c0.to_array();
-        let c1a = c1.to_array();
+        let [c0, c1] = self.columns;
         Mat4x2f {
-            inner: [
-                glam::Vec2::new(c0a[0], c1a[0]),
-                glam::Vec2::new(c0a[1], c1a[1]),
-                glam::Vec2::new(c0a[2], c1a[2]),
-                glam::Vec2::new(c0a[3], c1a[3]),
+            columns: [
+                vec2f(c0.x, c1.x),
+                vec2f(c0.y, c1.y),
+                vec2f(c0.z, c1.z),
+                vec2f(c0.w, c1.w),
             ],
         }
     }
@@ -492,15 +555,8 @@ mod test {
     fn sanity_transpose_mat2() {
         let m = mat2x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0));
         let t = transpose(m);
-        // Column 0 of transpose = row 0 of original
-        let t_c0 = f32::vec_to_array(Vec2f {
-            inner: t.inner.x_axis,
-        });
-        let t_c1 = f32::vec_to_array(Vec2f {
-            inner: t.inner.y_axis,
-        });
-        assert_eq!(t_c0, [1.0, 3.0]);
-        assert_eq!(t_c1, [2.0, 4.0]);
+        assert_eq!(t.columns[0].to_array(), [1.0, 3.0]);
+        assert_eq!(t.columns[1].to_array(), [2.0, 4.0]);
     }
 
     #[test]
@@ -511,18 +567,9 @@ mod test {
             vec3f(7.0, 8.0, 9.0),
         );
         let t = transpose(m);
-        let t_c0 = f32::vec_to_array(Vec3f {
-            inner: t.inner.x_axis,
-        });
-        let t_c1 = f32::vec_to_array(Vec3f {
-            inner: t.inner.y_axis,
-        });
-        let t_c2 = f32::vec_to_array(Vec3f {
-            inner: t.inner.z_axis,
-        });
-        assert_eq!(t_c0, [1.0, 4.0, 7.0]);
-        assert_eq!(t_c1, [2.0, 5.0, 8.0]);
-        assert_eq!(t_c2, [3.0, 6.0, 9.0]);
+        assert_eq!(t.columns[0].to_array(), [1.0, 4.0, 7.0]);
+        assert_eq!(t.columns[1].to_array(), [2.0, 5.0, 8.0]);
+        assert_eq!(t.columns[2].to_array(), [3.0, 6.0, 9.0]);
     }
 
     #[test]
@@ -534,42 +581,32 @@ mod test {
             vec4f(13.0, 14.0, 15.0, 16.0),
         );
         let t = transpose(m);
-        let t_c0 = f32::vec_to_array(Vec4f {
-            inner: t.inner.x_axis,
-        });
-        assert_eq!(t_c0, [1.0, 5.0, 9.0, 13.0]);
+        assert_eq!(t.columns[0].to_array(), [1.0, 5.0, 9.0, 13.0]);
     }
 
     #[test]
     fn sanity_transpose_mat2x3() {
-        // 2 columns of Vec3
         let m = mat2x3f(vec3f(1.0, 2.0, 3.0), vec3f(4.0, 5.0, 6.0));
         let t: Mat3x2f = transpose(m);
-        // 3 columns of Vec2
-        let c0 = t.inner.matrix2.x_axis.to_array();
-        let c1 = t.inner.matrix2.y_axis.to_array();
-        let c2 = t.inner.translation.to_array();
-        assert_eq!(c0, [1.0, 4.0]);
-        assert_eq!(c1, [2.0, 5.0]);
-        assert_eq!(c2, [3.0, 6.0]);
+        assert_eq!(t.columns[0].to_array(), [1.0, 4.0]);
+        assert_eq!(t.columns[1].to_array(), [2.0, 5.0]);
+        assert_eq!(t.columns[2].to_array(), [3.0, 6.0]);
     }
 
     #[test]
     fn sanity_transpose_mat3x2() {
-        // 3 columns of Vec2 (via Affine2)
         let m = mat3x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0), vec2f(5.0, 6.0));
         let t: Mat2x3f = transpose(m);
-        // 2 columns of Vec3
-        assert_eq!(t.inner[0].to_array(), [1.0, 3.0, 5.0]);
-        assert_eq!(t.inner[1].to_array(), [2.0, 4.0, 6.0]);
+        assert_eq!(t.columns[0].to_array(), [1.0, 3.0, 5.0]);
+        assert_eq!(t.columns[1].to_array(), [2.0, 4.0, 6.0]);
     }
 
     #[test]
     fn sanity_transpose_roundtrip() {
         let m = mat2x3f(vec3f(1.0, 2.0, 3.0), vec3f(4.0, 5.0, 6.0));
         let roundtrip = transpose(transpose(m));
-        assert_eq!(roundtrip.inner[0].to_array(), m.inner[0].to_array());
-        assert_eq!(roundtrip.inner[1].to_array(), m.inner[1].to_array());
+        assert_eq!(roundtrip.columns[0].to_array(), m.columns[0].to_array());
+        assert_eq!(roundtrip.columns[1].to_array(), m.columns[1].to_array());
     }
 
     #[test]
@@ -581,9 +618,9 @@ mod test {
             vec3f(10.0, 11.0, 12.0),
         );
         let t: Mat3x4f = transpose(m);
-        assert_eq!(t.inner[0].to_array(), [1.0, 4.0, 7.0, 10.0]);
-        assert_eq!(t.inner[1].to_array(), [2.0, 5.0, 8.0, 11.0]);
-        assert_eq!(t.inner[2].to_array(), [3.0, 6.0, 9.0, 12.0]);
+        assert_eq!(t.columns[0].to_array(), [1.0, 4.0, 7.0, 10.0]);
+        assert_eq!(t.columns[1].to_array(), [2.0, 5.0, 8.0, 11.0]);
+        assert_eq!(t.columns[2].to_array(), [3.0, 6.0, 9.0, 12.0]);
     }
 
     #[test]
@@ -595,18 +632,18 @@ mod test {
             vec2f(7.0, 8.0),
         );
         let t: Mat2x4f = transpose(m);
-        assert_eq!(t.inner[0].to_array(), [1.0, 3.0, 5.0, 7.0]);
-        assert_eq!(t.inner[1].to_array(), [2.0, 4.0, 6.0, 8.0]);
+        assert_eq!(t.columns[0].to_array(), [1.0, 3.0, 5.0, 7.0]);
+        assert_eq!(t.columns[1].to_array(), [2.0, 4.0, 6.0, 8.0]);
     }
 
     #[test]
     fn sanity_transpose_mat2x4() {
         let m = mat2x4f(vec4f(1.0, 2.0, 3.0, 4.0), vec4f(5.0, 6.0, 7.0, 8.0));
         let t: Mat4x2f = transpose(m);
-        assert_eq!(t.inner[0].to_array(), [1.0, 5.0]);
-        assert_eq!(t.inner[1].to_array(), [2.0, 6.0]);
-        assert_eq!(t.inner[2].to_array(), [3.0, 7.0]);
-        assert_eq!(t.inner[3].to_array(), [4.0, 8.0]);
+        assert_eq!(t.columns[0].to_array(), [1.0, 5.0]);
+        assert_eq!(t.columns[1].to_array(), [2.0, 6.0]);
+        assert_eq!(t.columns[2].to_array(), [3.0, 7.0]);
+        assert_eq!(t.columns[3].to_array(), [4.0, 8.0]);
     }
 
     #[test]
@@ -617,9 +654,77 @@ mod test {
             vec4f(9.0, 10.0, 11.0, 12.0),
         );
         let t: Mat4x3f = transpose(m);
-        assert_eq!(t.inner[0].to_array(), [1.0, 5.0, 9.0]);
-        assert_eq!(t.inner[1].to_array(), [2.0, 6.0, 10.0]);
-        assert_eq!(t.inner[2].to_array(), [3.0, 7.0, 11.0]);
-        assert_eq!(t.inner[3].to_array(), [4.0, 8.0, 12.0]);
+        assert_eq!(t.columns[0].to_array(), [1.0, 5.0, 9.0]);
+        assert_eq!(t.columns[1].to_array(), [2.0, 6.0, 10.0]);
+        assert_eq!(t.columns[2].to_array(), [3.0, 7.0, 11.0]);
+        assert_eq!(t.columns[3].to_array(), [4.0, 8.0, 12.0]);
+    }
+
+    #[test]
+    fn sanity_index_usize() {
+        let m = mat3x3f(
+            vec3f(1.0, 2.0, 3.0),
+            vec3f(4.0, 5.0, 6.0),
+            vec3f(7.0, 8.0, 9.0),
+        );
+        assert_eq!(m[0usize].x, 1.0);
+        assert_eq!(m[1usize].y, 5.0);
+        assert_eq!(m[2usize].z, 9.0);
+    }
+
+    #[test]
+    fn sanity_index_u32() {
+        let m = mat2x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0));
+        assert_eq!(m[0u32].x, 1.0);
+        assert_eq!(m[1u32].y, 4.0);
+    }
+
+    #[test]
+    fn sanity_index_mut() {
+        let mut m = mat2x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0));
+        m[0usize].x = 10.0;
+        assert_eq!(m[0usize].x, 10.0);
+    }
+
+    #[test]
+    fn module_modify_mat4() {
+        #[crate::wgsl(crate_path = crate)]
+        pub mod mat {
+            #![allow(dead_code)]
+
+            use crate::std::*;
+
+            pub struct Uniforms {
+                pub projection: Mat4f,
+                pub modelview: Mat4f,
+            }
+
+            uniform!(group(0), binding(0), UNIFORMS: Uniforms);
+
+            #[input]
+            pub struct VertexInput {
+                #[location(0)]
+                pub position: Vec3f,
+            }
+
+            #[output]
+            pub struct VertexOutput {
+                #[builtin(position)]
+                pub clip_position: Vec4f,
+            }
+
+            #[vertex]
+            pub fn vs_main(input: VertexInput) -> VertexOutput {
+                let projection = get!(UNIFORMS).projection;
+                let mut modelview = get!(UNIFORMS).modelview;
+                // Just for access sake, mess with the modelview matrix
+                modelview[0u32].y += 10.0;
+                VertexOutput {
+                    clip_position: projection
+                        * modelview
+                        * vec4f(input.position.x, input.position.y, input.position.z, 1.0),
+                }
+            }
+        }
     }
 }

--- a/crates/wgsl-rs/src/std/numeric.rs
+++ b/crates/wgsl-rs/src/std/numeric.rs
@@ -211,9 +211,7 @@ mod abs {
         ($ty:ty) => {
             impl NumericBuiltinAbs for $ty {
                 fn abs(self) -> Self {
-                    Self {
-                        inner: self.inner.abs(),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.abs()))
                 }
             }
         };
@@ -244,9 +242,7 @@ mod acos {
         ($ty:ty) => {
             impl NumericBuiltinAcos for $ty {
                 fn acos(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.acos()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.acos()))
                 }
             }
         };
@@ -274,9 +270,7 @@ mod sin {
         ($ty:ty) => {
             impl NumericBuiltinSin for $ty {
                 fn sin(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.sin()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.sin()))
                 }
             }
         };
@@ -304,9 +298,7 @@ mod asin {
         ($ty:ty) => {
             impl NumericBuiltinAsin for $ty {
                 fn asin(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.asin()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.asin()))
                 }
             }
         };
@@ -334,9 +326,7 @@ mod atan {
         ($ty:ty) => {
             impl NumericBuiltinAtan for $ty {
                 fn atan(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.atan()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.atan()))
                 }
             }
         };
@@ -364,9 +354,7 @@ mod cos {
         ($ty:ty) => {
             impl NumericBuiltinCos for $ty {
                 fn cos(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.cos()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.cos()))
                 }
             }
         };
@@ -394,9 +382,7 @@ mod tan {
         ($ty:ty) => {
             impl NumericBuiltinTan for $ty {
                 fn tan(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.tan()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.tan()))
                 }
             }
         };
@@ -425,9 +411,7 @@ mod fract {
         ($ty:ty) => {
             impl NumericBuiltinFract for $ty {
                 fn fract(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.fract()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.fract()))
                 }
             }
         };
@@ -454,9 +438,7 @@ mod inverse_sqrt {
         ($ty:ty) => {
             impl NumericBuiltinInverseSqrt for $ty {
                 fn inverse_sqrt(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| 1.0 / t.sqrt()),
-                    }
+                    Self::from_array(self.to_array().map(|t| 1.0 / t.sqrt()))
                 }
             }
         };
@@ -481,17 +463,17 @@ mod length {
     }
     impl NumericBuiltinLength for Vec2f {
         fn length(self) -> f32 {
-            self.inner.length()
+            glam::Vec2::from(self).length()
         }
     }
     impl NumericBuiltinLength for Vec3f {
         fn length(self) -> f32 {
-            self.inner.length()
+            glam::Vec3::from(self).length()
         }
     }
     impl NumericBuiltinLength for Vec4f {
         fn length(self) -> f32 {
-            self.inner.length()
+            glam::Vec4::from(self).length()
         }
     }
 }
@@ -513,9 +495,7 @@ mod log {
         ($ty:ty) => {
             impl NumericBuiltinLog for $ty {
                 fn log(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.ln()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.ln()))
                 }
             }
         };
@@ -542,9 +522,7 @@ mod log2 {
         ($ty:ty) => {
             impl NumericBuiltinLog2 for $ty {
                 fn log2(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.log2()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.log2()))
                 }
             }
         };
@@ -578,17 +556,17 @@ mod max {
         }
     }
     macro_rules! impl_max_vec {
-        ($ty:ty) => {
+        ($ty:ty, $glam_ty:ty) => {
             impl NumericBuiltinMax for $ty {
                 fn max(self, other: Self) -> Self {
-                    self.inner.max(other.inner).into()
+                    <$glam_ty>::from(self).max(<$glam_ty>::from(other)).into()
                 }
             }
         };
     }
-    impl_max_vec!(Vec2f);
-    impl_max_vec!(Vec3f);
-    impl_max_vec!(Vec4f);
+    impl_max_vec!(Vec2f, glam::Vec2);
+    impl_max_vec!(Vec3f, glam::Vec3);
+    impl_max_vec!(Vec4f, glam::Vec4);
 }
 
 pub trait NumericBuiltinMin {
@@ -615,17 +593,17 @@ mod min {
         }
     }
     macro_rules! impl_min_vec {
-        ($ty:ty) => {
+        ($ty:ty, $glam_ty:ty) => {
             impl NumericBuiltinMin for $ty {
                 fn min(self, other: Self) -> Self {
-                    self.inner.min(other.inner).into()
+                    <$glam_ty>::from(self).min(<$glam_ty>::from(other)).into()
                 }
             }
         };
     }
-    impl_min_vec!(Vec2f);
-    impl_min_vec!(Vec3f);
-    impl_min_vec!(Vec4f);
+    impl_min_vec!(Vec2f, glam::Vec2);
+    impl_min_vec!(Vec3f, glam::Vec3);
+    impl_min_vec!(Vec4f, glam::Vec4);
 }
 
 pub trait NumericBuiltinPow {
@@ -645,14 +623,12 @@ mod pow {
         ($ty:ty) => {
             impl NumericBuiltinPow for $ty {
                 fn pow(self, other: Self) -> Self {
-                    let mut array = self.inner.to_array();
-                    let exps = other.inner.to_array();
+                    let mut array = self.to_array();
+                    let exps = other.to_array();
                     for i in 0..array.len() {
                         array[i] = array[i].powf(exps[i]);
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -679,9 +655,7 @@ mod radians {
         ($ty:ty) => {
             impl NumericBuiltinRadians for $ty {
                 fn radians(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t * std::f32::consts::PI / 180.0),
-                    }
+                    Self::from_array(self.to_array().map(|t| t * std::f32::consts::PI / 180.0))
                 }
             }
         };
@@ -708,9 +682,7 @@ mod round {
         ($ty:ty) => {
             impl NumericBuiltinRound for $ty {
                 fn round(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.round()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.round()))
                 }
             }
         };
@@ -737,9 +709,7 @@ mod saturate {
         ($ty:ty) => {
             impl NumericBuiltinSaturate for $ty {
                 fn saturate(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.clamp(0.0, 1.0)),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.clamp(0.0, 1.0)))
                 }
             }
         };
@@ -772,17 +742,15 @@ mod sign {
         ($ty:ty) => {
             impl NumericBuiltinSign for $ty {
                 fn sign(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| {
-                            if t > 0.0 {
-                                1.0
-                            } else if t < 0.0 {
-                                -1.0
-                            } else {
-                                0.0
-                            }
-                        }),
-                    }
+                    Self::from_array(self.to_array().map(|t| {
+                        if t > 0.0 {
+                            1.0
+                        } else if t < 0.0 {
+                            -1.0
+                        } else {
+                            0.0
+                        }
+                    }))
                 }
             }
         };
@@ -809,9 +777,7 @@ mod sqrt {
         ($ty:ty) => {
             impl NumericBuiltinSqrt for $ty {
                 fn sqrt(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.sqrt()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.sqrt()))
                 }
             }
         };
@@ -831,21 +797,23 @@ mod step {
     use super::*;
     impl NumericBuiltinStep for f32 {
         fn step(self, x: Self) -> Self {
-            if x >= self { 1.0 } else { 0.0 }
+            if x >= self {
+                1.0
+            } else {
+                0.0
+            }
         }
     }
     macro_rules! impl_step_vec {
         ($ty:ty) => {
             impl NumericBuiltinStep for $ty {
                 fn step(self, other: Self) -> Self {
-                    let mut array = self.inner.to_array();
-                    let other = other.inner.to_array();
+                    let mut array = self.to_array();
+                    let other_arr = other.to_array();
                     for i in 0..array.len() {
-                        array[i] = array[i].step(other[i]);
+                        array[i] = array[i].step(other_arr[i]);
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -872,9 +840,7 @@ mod tanh {
         ($ty:ty) => {
             impl NumericBuiltinTanh for $ty {
                 fn tanh(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.tanh()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.tanh()))
                 }
             }
         };
@@ -910,9 +876,7 @@ mod acosh {
         ($ty:ty) => {
             impl NumericBuiltinAcosh for $ty {
                 fn acosh(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.acosh()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.acosh()))
                 }
             }
         };
@@ -946,9 +910,7 @@ mod asinh {
         ($ty:ty) => {
             impl NumericBuiltinAsinh for $ty {
                 fn asinh(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.asinh()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.asinh()))
                 }
             }
         };
@@ -984,9 +946,7 @@ mod atanh {
         ($ty:ty) => {
             impl NumericBuiltinAtanh for $ty {
                 fn atanh(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.atanh()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.atanh()))
                 }
             }
         };
@@ -1020,9 +980,7 @@ mod cosh {
         ($ty:ty) => {
             impl NumericBuiltinCosh for $ty {
                 fn cosh(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.cosh()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.cosh()))
                 }
             }
         };
@@ -1056,9 +1014,7 @@ mod sinh {
         ($ty:ty) => {
             impl NumericBuiltinSinh for $ty {
                 fn sinh(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.sinh()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.sinh()))
                 }
             }
         };
@@ -1085,9 +1041,7 @@ mod trunc {
         ($ty:ty) => {
             impl NumericBuiltinTrunc for $ty {
                 fn trunc(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.trunc()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.trunc()))
                 }
             }
         };
@@ -1113,26 +1067,26 @@ mod dot {
     use super::*;
 
     macro_rules! impl_dot_vec_f {
-        ($ty:ty, $scalar:ty) => {
+        ($ty:ty, $scalar:ty, $glam_ty:ty) => {
             impl NumericBuiltinDot for $ty {
                 type Scalar = $scalar;
                 fn dot(self, other: Self) -> Self::Scalar {
-                    self.inner.dot(other.inner)
+                    <$glam_ty>::from(self).dot(<$glam_ty>::from(other))
                 }
             }
         };
     }
-    impl_dot_vec_f!(Vec2f, f32);
-    impl_dot_vec_f!(Vec3f, f32);
-    impl_dot_vec_f!(Vec4f, f32);
+    impl_dot_vec_f!(Vec2f, f32, glam::Vec2);
+    impl_dot_vec_f!(Vec3f, f32, glam::Vec3);
+    impl_dot_vec_f!(Vec4f, f32, glam::Vec4);
 
     macro_rules! impl_dot_vec_i {
         ($ty:ty, $scalar:ty) => {
             impl NumericBuiltinDot for $ty {
                 type Scalar = $scalar;
                 fn dot(self, other: Self) -> Self::Scalar {
-                    let a = self.inner.to_array();
-                    let b = other.inner.to_array();
+                    let a = self.to_array();
+                    let b = other.to_array();
                     a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
                 }
             }
@@ -1161,19 +1115,17 @@ mod normalize {
     use super::*;
 
     macro_rules! impl_normalize_vec {
-        ($ty:ty) => {
+        ($ty:ty, $glam_ty:ty) => {
             impl NumericBuiltinNormalize for $ty {
                 fn normalize(self) -> Self {
-                    Self {
-                        inner: self.inner.normalize(),
-                    }
+                    <$glam_ty>::from(self).normalize().into()
                 }
             }
         };
     }
-    impl_normalize_vec!(Vec2f);
-    impl_normalize_vec!(Vec3f);
-    impl_normalize_vec!(Vec4f);
+    impl_normalize_vec!(Vec2f, glam::Vec2);
+    impl_normalize_vec!(Vec3f, glam::Vec3);
+    impl_normalize_vec!(Vec4f, glam::Vec4);
 }
 
 /// Provides the numeric built-in function `cross`.
@@ -1192,9 +1144,7 @@ mod cross {
 
     impl NumericBuiltinCross for Vec3f {
         fn cross(self, other: Self) -> Self {
-            Self {
-                inner: self.inner.cross(other.inner),
-            }
+            glam::Vec3::from(self).cross(glam::Vec3::from(other)).into()
         }
     }
 }
@@ -1232,25 +1182,25 @@ mod clamp {
     }
 
     macro_rules! impl_clamp_vec {
-        ($ty:ty) => {
+        ($ty:ty, $glam_ty:ty) => {
             impl NumericBuiltinClamp for $ty {
                 fn clamp(self, low: Self, high: Self) -> Self {
-                    Self {
-                        inner: self.inner.clamp(low.inner, high.inner),
-                    }
+                    <$glam_ty>::from(self)
+                        .clamp(<$glam_ty>::from(low), <$glam_ty>::from(high))
+                        .into()
                 }
             }
         };
     }
-    impl_clamp_vec!(Vec2f);
-    impl_clamp_vec!(Vec3f);
-    impl_clamp_vec!(Vec4f);
-    impl_clamp_vec!(Vec2i);
-    impl_clamp_vec!(Vec3i);
-    impl_clamp_vec!(Vec4i);
-    impl_clamp_vec!(Vec2u);
-    impl_clamp_vec!(Vec3u);
-    impl_clamp_vec!(Vec4u);
+    impl_clamp_vec!(Vec2f, glam::Vec2);
+    impl_clamp_vec!(Vec3f, glam::Vec3);
+    impl_clamp_vec!(Vec4f, glam::Vec4);
+    impl_clamp_vec!(Vec2i, glam::IVec2);
+    impl_clamp_vec!(Vec3i, glam::IVec3);
+    impl_clamp_vec!(Vec4i, glam::IVec4);
+    impl_clamp_vec!(Vec2u, glam::UVec2);
+    impl_clamp_vec!(Vec3u, glam::UVec3);
+    impl_clamp_vec!(Vec4u, glam::UVec4);
 }
 
 /// Provides the numeric built-in function `mix`.
@@ -1275,19 +1225,20 @@ mod mix {
 
     // For vectors, we use component-wise mix
     macro_rules! impl_mix_vec {
-        ($n:literal, $ty:ty) => {
-            impl NumericBuiltinMix for Vec<$n, $ty> {
+        ($ty:ty, $glam_ty:ty) => {
+            impl NumericBuiltinMix for $ty {
                 fn mix(self, e2: Self, e3: Self) -> Self {
-                    Self {
-                        inner: self.inner * (1.0 - e3.inner) + e2.inner * e3.inner,
-                    }
+                    let s: $glam_ty = self.into();
+                    let g2: $glam_ty = e2.into();
+                    let g3: $glam_ty = e3.into();
+                    (s * (1.0 - g3) + g2 * g3).into()
                 }
             }
         };
     }
-    impl_mix_vec!(2, f32);
-    impl_mix_vec!(3, f32);
-    impl_mix_vec!(4, f32);
+    impl_mix_vec!(Vec2f, glam::Vec2);
+    impl_mix_vec!(Vec3f, glam::Vec3);
+    impl_mix_vec!(Vec4f, glam::Vec4);
 }
 
 /// Provides the numeric built-in function `floor`.
@@ -1311,19 +1262,17 @@ mod floor {
     }
 
     macro_rules! impl_floor_vec {
-        ($ty:ty) => {
+        ($ty:ty, $glam_ty:ty) => {
             impl NumericBuiltinFloor for $ty {
                 fn floor(self) -> Self {
-                    Self {
-                        inner: self.inner.floor(),
-                    }
+                    <$glam_ty>::from(self).floor().into()
                 }
             }
         };
     }
-    impl_floor_vec!(Vec2f);
-    impl_floor_vec!(Vec3f);
-    impl_floor_vec!(Vec4f);
+    impl_floor_vec!(Vec2f, glam::Vec2);
+    impl_floor_vec!(Vec3f, glam::Vec3);
+    impl_floor_vec!(Vec4f, glam::Vec4);
 }
 
 /// Provides the numeric built-in function `ceil`.
@@ -1347,19 +1296,17 @@ mod ceil {
     }
 
     macro_rules! impl_ceil_vec {
-        ($ty:ty) => {
+        ($ty:ty, $glam_ty:ty) => {
             impl NumericBuiltinCeil for $ty {
                 fn ceil(self) -> Self {
-                    Self {
-                        inner: self.inner.ceil(),
-                    }
+                    <$glam_ty>::from(self).ceil().into()
                 }
             }
         };
     }
-    impl_ceil_vec!(Vec2f);
-    impl_ceil_vec!(Vec3f);
-    impl_ceil_vec!(Vec4f);
+    impl_ceil_vec!(Vec2f, glam::Vec2);
+    impl_ceil_vec!(Vec3f, glam::Vec3);
+    impl_ceil_vec!(Vec4f, glam::Vec4);
 }
 
 /// Provides the numeric built-in function `exp`.
@@ -1388,9 +1335,7 @@ mod exp {
         ($ty:ty) => {
             impl NumericBuiltinExp for $ty {
                 fn exp(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.exp()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.exp()))
                 }
             }
         };
@@ -1425,9 +1370,7 @@ mod exp2 {
         ($ty:ty) => {
             impl NumericBuiltinExp2 for $ty {
                 fn exp2(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t.exp2()),
-                    }
+                    Self::from_array(self.to_array().map(|t| t.exp2()))
                 }
             }
         };
@@ -1461,9 +1404,7 @@ mod degrees {
         ($ty:ty) => {
             impl NumericBuiltinDegrees for $ty {
                 fn degrees(self) -> Self {
-                    Self {
-                        inner: self.inner.map(|t| t * 180.0 / std::f32::consts::PI),
-                    }
+                    Self::from_array(self.to_array().map(|t| t * 180.0 / std::f32::consts::PI))
                 }
             }
         };
@@ -1489,19 +1430,19 @@ mod all {
 
     impl LogicalBuiltinAll for Vec2b {
         fn all(self) -> bool {
-            self.inner.all()
+            glam::BVec2::from(self).all()
         }
     }
 
     impl LogicalBuiltinAll for Vec3b {
         fn all(self) -> bool {
-            self.inner.all()
+            glam::BVec3::from(self).all()
         }
     }
 
     impl LogicalBuiltinAll for Vec4b {
         fn all(self) -> bool {
-            self.inner.all()
+            glam::BVec4::from(self).all()
         }
     }
 }
@@ -1522,19 +1463,19 @@ mod any {
 
     impl LogicalBuiltinAny for Vec2b {
         fn any(self) -> bool {
-            self.inner.any()
+            glam::BVec2::from(self).any()
         }
     }
 
     impl LogicalBuiltinAny for Vec3b {
         fn any(self) -> bool {
-            self.inner.any()
+            glam::BVec3::from(self).any()
         }
     }
 
     impl LogicalBuiltinAny for Vec4b {
         fn any(self) -> bool {
-            self.inner.any()
+            glam::BVec4::from(self).any()
         }
     }
 }
@@ -1601,29 +1542,32 @@ mod smoothstep {
     }
     impl NumericBuiltinSmoothstep for Vec2f {
         fn smoothstep(low: Self, high: Self, x: Self) -> Self {
-            let t_inner = ((x.inner - low.inner) / (high.inner - low.inner))
-                .clamp(glam::Vec2::splat(0.0), glam::Vec2::splat(1.0));
-            let result =
-                t_inner * t_inner * (glam::Vec2::splat(3.0) - glam::Vec2::splat(2.0) * t_inner);
-            Self { inner: result }
+            let xg: glam::Vec2 = x.into();
+            let lg: glam::Vec2 = low.into();
+            let hg: glam::Vec2 = high.into();
+            let t = ((xg - lg) / (hg - lg)).clamp(glam::Vec2::splat(0.0), glam::Vec2::splat(1.0));
+            let result = t * t * (glam::Vec2::splat(3.0) - glam::Vec2::splat(2.0) * t);
+            Self::from(result)
         }
     }
     impl NumericBuiltinSmoothstep for Vec3f {
         fn smoothstep(low: Self, high: Self, x: Self) -> Self {
-            let t_inner = ((x.inner - low.inner) / (high.inner - low.inner))
-                .clamp(glam::Vec3::splat(0.0), glam::Vec3::splat(1.0));
-            let result =
-                t_inner * t_inner * (glam::Vec3::splat(3.0) - glam::Vec3::splat(2.0) * t_inner);
-            Self { inner: result }
+            let xg: glam::Vec3 = x.into();
+            let lg: glam::Vec3 = low.into();
+            let hg: glam::Vec3 = high.into();
+            let t = ((xg - lg) / (hg - lg)).clamp(glam::Vec3::splat(0.0), glam::Vec3::splat(1.0));
+            let result = t * t * (glam::Vec3::splat(3.0) - glam::Vec3::splat(2.0) * t);
+            Self::from(result)
         }
     }
     impl NumericBuiltinSmoothstep for Vec4f {
         fn smoothstep(low: Self, high: Self, x: Self) -> Self {
-            let t_inner = ((x.inner - low.inner) / (high.inner - low.inner))
-                .clamp(glam::Vec4::splat(0.0), glam::Vec4::splat(1.0));
-            let result =
-                t_inner * t_inner * (glam::Vec4::splat(3.0) - glam::Vec4::splat(2.0) * t_inner);
-            Self { inner: result }
+            let xg: glam::Vec4 = x.into();
+            let lg: glam::Vec4 = low.into();
+            let hg: glam::Vec4 = high.into();
+            let t = ((xg - lg) / (hg - lg)).clamp(glam::Vec4::splat(0.0), glam::Vec4::splat(1.0));
+            let result = t * t * (glam::Vec4::splat(3.0) - glam::Vec4::splat(2.0) * t);
+            Self::from(result)
         }
     }
 }
@@ -1650,41 +1594,35 @@ mod atan2 {
     }
     impl NumericBuiltinAtan2 for Vec2f {
         fn atan2(y: Self, x: Self) -> Self {
-            let y_arr = y.inner.to_array();
-            let x_arr = x.inner.to_array();
+            let y_arr = y.to_array();
+            let x_arr = x.to_array();
             let result = [y_arr[0].atan2(x_arr[0]), y_arr[1].atan2(x_arr[1])];
-            Self {
-                inner: result.into(),
-            }
+            Self::from_array(result)
         }
     }
     impl NumericBuiltinAtan2 for Vec3f {
         fn atan2(y: Self, x: Self) -> Self {
-            let y_arr = y.inner.to_array();
-            let x_arr = x.inner.to_array();
+            let y_arr = y.to_array();
+            let x_arr = x.to_array();
             let result = [
                 y_arr[0].atan2(x_arr[0]),
                 y_arr[1].atan2(x_arr[1]),
                 y_arr[2].atan2(x_arr[2]),
             ];
-            Self {
-                inner: result.into(),
-            }
+            Self::from_array(result)
         }
     }
     impl NumericBuiltinAtan2 for Vec4f {
         fn atan2(y: Self, x: Self) -> Self {
-            let y_arr = y.inner.to_array();
-            let x_arr = x.inner.to_array();
+            let y_arr = y.to_array();
+            let x_arr = x.to_array();
             let result = [
                 y_arr[0].atan2(x_arr[0]),
                 y_arr[1].atan2(x_arr[1]),
                 y_arr[2].atan2(x_arr[2]),
                 y_arr[3].atan2(x_arr[3]),
             ];
-            Self {
-                inner: result.into(),
-            }
+            Self::from_array(result)
         }
     }
 }
@@ -1710,19 +1648,20 @@ mod fma {
         }
     }
     macro_rules! impl_fma_vec {
-        ($ty:ty) => {
+        ($ty:ty, $glam_ty:ty) => {
             impl NumericBuiltinFma for $ty {
                 fn fma(e1: Self, e2: Self, e3: Self) -> Self {
-                    Self {
-                        inner: e1.inner.mul_add(e2.inner, e3.inner),
-                    }
+                    let g1: $glam_ty = e1.into();
+                    let g2: $glam_ty = e2.into();
+                    let g3: $glam_ty = e3.into();
+                    g1.mul_add(g2, g3).into()
                 }
             }
         };
     }
-    impl_fma_vec!(Vec2f);
-    impl_fma_vec!(Vec3f);
-    impl_fma_vec!(Vec4f);
+    impl_fma_vec!(Vec2f, glam::Vec2);
+    impl_fma_vec!(Vec3f, glam::Vec3);
+    impl_fma_vec!(Vec4f, glam::Vec4);
 }
 
 /// Provides the numeric built-in function `reflect`.
@@ -1741,20 +1680,20 @@ pub fn reflect<T: NumericBuiltinReflect>(e1: T, e2: T) -> T {
 mod reflect {
     use super::*;
     macro_rules! impl_reflect_vec {
-        ($ty:ty) => {
+        ($ty:ty, $glam_ty:ty) => {
             impl NumericBuiltinReflect for $ty {
                 fn reflect(e1: Self, e2: Self) -> Self {
-                    let dot_val = e2.inner.dot(e1.inner);
-                    Self {
-                        inner: e1.inner - 2.0 * dot_val * e2.inner,
-                    }
+                    let g1: $glam_ty = e1.into();
+                    let g2: $glam_ty = e2.into();
+                    let dot_val = g2.dot(g1);
+                    (g1 - 2.0 * dot_val * g2).into()
                 }
             }
         };
     }
-    impl_reflect_vec!(Vec2f);
-    impl_reflect_vec!(Vec3f);
-    impl_reflect_vec!(Vec4f);
+    impl_reflect_vec!(Vec2f, glam::Vec2);
+    impl_reflect_vec!(Vec3f, glam::Vec3);
+    impl_reflect_vec!(Vec4f, glam::Vec4);
 }
 
 /// Provides the numeric built-in function `refract`.
@@ -1776,25 +1715,25 @@ pub fn refract<T: NumericBuiltinRefract>(e1: T, e2: T, e3: f32) -> T {
 mod refract {
     use super::*;
     macro_rules! impl_refract_vec {
-        ($ty:ty, $zero:expr) => {
+        ($ty:ty, $glam_ty:ty) => {
             impl NumericBuiltinRefract for $ty {
                 fn refract(e1: Self, e2: Self, e3: f32) -> Self {
-                    let dot_e2_e1 = e2.inner.dot(e1.inner);
+                    let g1: $glam_ty = e1.into();
+                    let g2: $glam_ty = e2.into();
+                    let dot_e2_e1 = g2.dot(g1);
                     let k = 1.0 - e3 * e3 * (1.0 - dot_e2_e1 * dot_e2_e1);
                     if k < 0.0 {
-                        Self { inner: $zero }
+                        <$glam_ty>::ZERO.into()
                     } else {
-                        Self {
-                            inner: e3 * e1.inner - (e3 * dot_e2_e1 + k.sqrt()) * e2.inner,
-                        }
+                        (e3 * g1 - (e3 * dot_e2_e1 + k.sqrt()) * g2).into()
                     }
                 }
             }
         };
     }
-    impl_refract_vec!(Vec2f, glam::Vec2::ZERO);
-    impl_refract_vec!(Vec3f, glam::Vec3::ZERO);
-    impl_refract_vec!(Vec4f, glam::Vec4::ZERO);
+    impl_refract_vec!(Vec2f, glam::Vec2);
+    impl_refract_vec!(Vec3f, glam::Vec3);
+    impl_refract_vec!(Vec4f, glam::Vec4);
 }
 
 /// Provides the numeric built-in function `faceForward`.
@@ -1811,22 +1750,24 @@ pub fn face_forward<T: NumericBuiltinFaceForward>(e1: T, e2: T, e3: T) -> T {
 mod face_forward {
     use super::*;
     macro_rules! impl_face_forward_vec {
-        ($ty:ty) => {
+        ($ty:ty, $glam_ty:ty) => {
             impl NumericBuiltinFaceForward for $ty {
                 fn face_forward(e1: Self, e2: Self, e3: Self) -> Self {
-                    let dot_val = e2.inner.dot(e3.inner);
+                    let g2: $glam_ty = e2.into();
+                    let g3: $glam_ty = e3.into();
+                    let dot_val = g2.dot(g3);
                     if dot_val < 0.0 {
                         e1
                     } else {
-                        Self { inner: -e1.inner }
+                        -e1
                     }
                 }
             }
         };
     }
-    impl_face_forward_vec!(Vec2f);
-    impl_face_forward_vec!(Vec3f);
-    impl_face_forward_vec!(Vec4f);
+    impl_face_forward_vec!(Vec2f, glam::Vec2);
+    impl_face_forward_vec!(Vec3f, glam::Vec3);
+    impl_face_forward_vec!(Vec4f, glam::Vec4);
 }
 
 /// Provides the logical built-in function `select`.
@@ -1847,7 +1788,11 @@ mod select {
         ($ty:ty) => {
             impl LogicalBuiltinSelect<bool> for $ty {
                 fn select(f: Self, t: Self, cond: bool) -> Self {
-                    if cond { t } else { f }
+                    if cond {
+                        t
+                    } else {
+                        f
+                    }
                 }
             }
         };
@@ -1871,38 +1816,38 @@ mod select {
     impl_select_bool!(Vec4b);
 
     macro_rules! impl_select_vec {
-        ($n:literal, $ty:ty) => {
-            impl LogicalBuiltinSelect<Vec<$n, bool>> for Vec<$n, $ty> {
-                fn select(f: Self, t: Self, cond: Vec<$n, bool>) -> Self {
-                    let cond_array = bool::vec_to_array(cond);
-                    let mut f_array = <$ty>::vec_to_array(f);
-                    let t_array = <$ty>::vec_to_array(t);
+        ($val_ty:ty, $cond_ty:ty) => {
+            impl LogicalBuiltinSelect<$cond_ty> for $val_ty {
+                fn select(f: Self, t: Self, cond: $cond_ty) -> Self {
+                    let cond_array = cond.to_array();
+                    let mut f_array = f.to_array();
+                    let t_array = t.to_array();
                     for i in 0..f_array.len() {
                         if cond_array[i] {
                             f_array[i] = t_array[i];
                         }
                     }
-                    <$ty>::vec_from_array(f_array)
+                    Self::from_array(f_array)
                 }
             }
         };
     }
 
-    impl_select_vec!(2, f32);
-    impl_select_vec!(3, f32);
-    impl_select_vec!(4, f32);
+    impl_select_vec!(Vec2f, Vec2b);
+    impl_select_vec!(Vec3f, Vec3b);
+    impl_select_vec!(Vec4f, Vec4b);
 
-    impl_select_vec!(2, i32);
-    impl_select_vec!(3, i32);
-    impl_select_vec!(4, i32);
+    impl_select_vec!(Vec2i, Vec2b);
+    impl_select_vec!(Vec3i, Vec3b);
+    impl_select_vec!(Vec4i, Vec4b);
 
-    impl_select_vec!(2, u32);
-    impl_select_vec!(3, u32);
-    impl_select_vec!(4, u32);
+    impl_select_vec!(Vec2u, Vec2b);
+    impl_select_vec!(Vec3u, Vec3b);
+    impl_select_vec!(Vec4u, Vec4b);
 
-    impl_select_vec!(2, bool);
-    impl_select_vec!(3, bool);
-    impl_select_vec!(4, bool);
+    impl_select_vec!(Vec2b, Vec2b);
+    impl_select_vec!(Vec3b, Vec3b);
+    impl_select_vec!(Vec4b, Vec4b);
 }
 
 /// Result of `modf()` — splits a floating-point value into fractional and whole
@@ -1948,23 +1893,22 @@ mod modf_impl {
     }
 
     macro_rules! impl_modf_vec {
-        ($ty:ty) => {
+        ($ty:ty, $glam_ty:ty) => {
             impl NumericBuiltinModf for $ty {
                 fn modf(self) -> ModfResult<Self> {
-                    let whole_inner = self.inner.trunc();
+                    let g: $glam_ty = self.into();
+                    let whole_g = g.trunc();
                     ModfResult {
-                        fract: Self {
-                            inner: self.inner - whole_inner,
-                        },
-                        whole: Self { inner: whole_inner },
+                        fract: (g - whole_g).into(),
+                        whole: whole_g.into(),
                     }
                 }
             }
         };
     }
-    impl_modf_vec!(Vec2f);
-    impl_modf_vec!(Vec3f);
-    impl_modf_vec!(Vec4f);
+    impl_modf_vec!(Vec2f, glam::Vec2);
+    impl_modf_vec!(Vec3f, glam::Vec3);
+    impl_modf_vec!(Vec4f, glam::Vec4);
 }
 
 /// Result of `frexp()` — splits a floating-point value into significand and
@@ -2075,7 +2019,7 @@ mod frexp_impl {
                 type Exp = $ity;
 
                 fn frexp(self) -> FrexpResult<Self, $ity> {
-                    let arr = f32::vec_to_array(self);
+                    let arr = self.to_array();
                     let mut fract_arr = [0.0f32; $n];
                     let mut exp_arr = [0i32; $n];
                     for i in 0..$n {
@@ -2084,8 +2028,8 @@ mod frexp_impl {
                         exp_arr[i] = e;
                     }
                     FrexpResult {
-                        fract: f32::vec_from_array(fract_arr),
-                        exp: i32::vec_from_array(exp_arr),
+                        fract: <$fty>::from_array(fract_arr),
+                        exp: <$ity>::from_array(exp_arr),
                     }
                 }
             }
@@ -2122,13 +2066,13 @@ mod ldexp_impl {
         ($fty:ty, $ity:ty, $n:literal) => {
             impl NumericBuiltinLdexp<$ity> for $fty {
                 fn ldexp(e1: Self, e2: $ity) -> Self {
-                    let f_arr = f32::vec_to_array(e1);
-                    let i_arr = i32::vec_to_array(e2);
+                    let f_arr = e1.to_array();
+                    let i_arr = e2.to_array();
                     let mut result = [0.0f32; $n];
                     for i in 0..$n {
                         result[i] = ldexp(f_arr[i], i_arr[i]);
                     }
-                    f32::vec_from_array(result)
+                    <$fty>::from_array(result)
                 }
             }
         };
@@ -2354,9 +2298,9 @@ mod test {
     fn sanity_normalize() {
         let v = vec3f(3.0, 0.0, 0.0);
         let norm_v = normalize(v);
-        assert!((norm_v.inner.x - 1.0).abs() < 1e-6);
-        assert!((norm_v.inner.y - 0.0).abs() < 1e-6);
-        assert!((norm_v.inner.z - 0.0).abs() < 1e-6);
+        assert!((norm_v.x - 1.0).abs() < 1e-6);
+        assert!((norm_v.y - 0.0).abs() < 1e-6);
+        assert!((norm_v.z - 0.0).abs() < 1e-6);
     }
 
     #[test]
@@ -2364,9 +2308,9 @@ mod test {
         let a = vec3f(1.0, 0.0, 0.0);
         let b = vec3f(0.0, 1.0, 0.0);
         let cross_ab = cross(a, b);
-        assert!((cross_ab.inner.x - 0.0).abs() < 1e-6);
-        assert!((cross_ab.inner.y - 0.0).abs() < 1e-6);
-        assert!((cross_ab.inner.z - 1.0).abs() < 1e-6);
+        assert!((cross_ab.x - 0.0).abs() < 1e-6);
+        assert!((cross_ab.y - 0.0).abs() < 1e-6);
+        assert!((cross_ab.z - 1.0).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/wgsl-rs/src/std/numeric.rs
+++ b/crates/wgsl-rs/src/std/numeric.rs
@@ -797,11 +797,7 @@ mod step {
     use super::*;
     impl NumericBuiltinStep for f32 {
         fn step(self, x: Self) -> Self {
-            if x >= self {
-                1.0
-            } else {
-                0.0
-            }
+            if x >= self { 1.0 } else { 0.0 }
         }
     }
     macro_rules! impl_step_vec {
@@ -1756,11 +1752,7 @@ mod face_forward {
                     let g2: $glam_ty = e2.into();
                     let g3: $glam_ty = e3.into();
                     let dot_val = g2.dot(g3);
-                    if dot_val < 0.0 {
-                        e1
-                    } else {
-                        -e1
-                    }
+                    if dot_val < 0.0 { e1 } else { -e1 }
                 }
             }
         };
@@ -1788,11 +1780,7 @@ mod select {
         ($ty:ty) => {
             impl LogicalBuiltinSelect<bool> for $ty {
                 fn select(f: Self, t: Self, cond: bool) -> Self {
-                    if cond {
-                        t
-                    } else {
-                        f
-                    }
+                    if cond { t } else { f }
                 }
             }
         };

--- a/crates/wgsl-rs/src/std/numeric/bit_manipulation.rs
+++ b/crates/wgsl-rs/src/std/numeric/bit_manipulation.rs
@@ -35,13 +35,11 @@ mod count_leading_zeros {
         ($ty:ty, $scalar:ty) => {
             impl NumericBuiltinCountLeadingZeros for $ty {
                 fn count_leading_zeros(self) -> Self {
-                    let mut array = self.inner.to_array();
+                    let mut array = self.to_array();
                     for elem in array.iter_mut() {
                         *elem = (*elem).leading_zeros() as $scalar;
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -87,13 +85,11 @@ mod count_one_bits {
         ($ty:ty, $scalar:ty) => {
             impl NumericBuiltinCountOneBits for $ty {
                 fn count_one_bits(self) -> Self {
-                    let mut array = self.inner.to_array();
+                    let mut array = self.to_array();
                     for elem in array.iter_mut() {
                         *elem = (*elem).count_ones() as $scalar;
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -139,13 +135,11 @@ mod count_trailing_zeros {
         ($ty:ty, $scalar:ty) => {
             impl NumericBuiltinCountTrailingZeros for $ty {
                 fn count_trailing_zeros(self) -> Self {
-                    let mut array = self.inner.to_array();
+                    let mut array = self.to_array();
                     for elem in array.iter_mut() {
                         *elem = (*elem).trailing_zeros() as $scalar;
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -191,13 +185,11 @@ mod reverse_bits {
         ($ty:ty) => {
             impl NumericBuiltinReverseBits for $ty {
                 fn reverse_bits(self) -> Self {
-                    let mut array = self.inner.to_array();
+                    let mut array = self.to_array();
                     for elem in array.iter_mut() {
                         *elem = (*elem).reverse_bits();
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -263,7 +255,7 @@ mod first_leading_bit {
         ($ty:ty) => {
             impl NumericBuiltinFirstLeadingBit for $ty {
                 fn first_leading_bit(self) -> Self {
-                    let mut array = self.inner.to_array();
+                    let mut array = self.to_array();
                     for elem in array.iter_mut() {
                         *elem = if *elem == 0 {
                             u32::MAX
@@ -271,9 +263,7 @@ mod first_leading_bit {
                             31 - (*elem).leading_zeros()
                         };
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -286,7 +276,7 @@ mod first_leading_bit {
         ($ty:ty) => {
             impl NumericBuiltinFirstLeadingBit for $ty {
                 fn first_leading_bit(self) -> Self {
-                    let mut array = self.inner.to_array();
+                    let mut array = self.to_array();
                     for elem in array.iter_mut() {
                         *elem = if *elem == 0 || *elem == -1 {
                             -1
@@ -296,9 +286,7 @@ mod first_leading_bit {
                             31 - (*elem).leading_ones() as i32
                         };
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -352,7 +340,7 @@ mod first_trailing_bit {
         ($ty:ty) => {
             impl NumericBuiltinFirstTrailingBit for $ty {
                 fn first_trailing_bit(self) -> Self {
-                    let mut array = self.inner.to_array();
+                    let mut array = self.to_array();
                     for elem in array.iter_mut() {
                         *elem = if *elem == 0 {
                             u32::MAX
@@ -360,9 +348,7 @@ mod first_trailing_bit {
                             (*elem).trailing_zeros()
                         };
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -375,7 +361,7 @@ mod first_trailing_bit {
         ($ty:ty) => {
             impl NumericBuiltinFirstTrailingBit for $ty {
                 fn first_trailing_bit(self) -> Self {
-                    let mut array = self.inner.to_array();
+                    let mut array = self.to_array();
                     for elem in array.iter_mut() {
                         *elem = if *elem == 0 {
                             -1
@@ -383,9 +369,7 @@ mod first_trailing_bit {
                             (*elem).trailing_zeros() as i32
                         };
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -472,18 +456,14 @@ mod extract_bits {
                     let o = std::cmp::Ord::min(offset, w);
                     let c = std::cmp::Ord::min(count, w - o);
                     if c == 0 {
-                        return Self {
-                            inner: Default::default(),
-                        };
+                        return Self::from_array(self.to_array().map(|_| 0));
                     }
                     let mask = if c >= 32 { u32::MAX } else { (1u32 << c) - 1 };
-                    let mut array = self.inner.to_array();
+                    let mut array = self.to_array();
                     for elem in array.iter_mut() {
                         *elem = (*elem >> o) & mask;
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -500,14 +480,12 @@ mod extract_bits {
                     let o = std::cmp::Ord::min(offset, w);
                     let c = std::cmp::Ord::min(count, w - o);
                     if c == 0 {
-                        return Self {
-                            inner: Default::default(),
-                        };
+                        return Self::from_array(self.to_array().map(|_| 0));
                     }
                     let mask = if c >= 32 { u32::MAX } else { (1u32 << c) - 1 };
                     let sign_bit = 1u32 << (c - 1);
                     let sign_extend_mask = !mask;
-                    let mut array = self.inner.to_array();
+                    let mut array = self.to_array();
                     for elem in array.iter_mut() {
                         let extracted = ((*elem as u32) >> o) & mask;
                         *elem = if extracted & sign_bit != 0 {
@@ -516,9 +494,7 @@ mod extract_bits {
                             extracted as i32
                         };
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -607,14 +583,12 @@ mod insert_bits {
                     }
                     let low_mask = if c >= 32 { u32::MAX } else { (1u32 << c) - 1 };
                     let mask = low_mask << o;
-                    let mut array = self.inner.to_array();
-                    let newbits_array = newbits.inner.to_array();
+                    let mut array = self.to_array();
+                    let newbits_array = newbits.to_array();
                     for (elem, nb) in array.iter_mut().zip(newbits_array.iter()) {
                         *elem = (*elem & !mask) | ((*nb & low_mask) << o);
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };
@@ -635,16 +609,14 @@ mod insert_bits {
                     }
                     let low_mask = if c >= 32 { u32::MAX } else { (1u32 << c) - 1 };
                     let mask = low_mask << o;
-                    let mut array = self.inner.to_array();
-                    let newbits_array = newbits.inner.to_array();
+                    let mut array = self.to_array();
+                    let newbits_array = newbits.to_array();
                     for (elem, nb) in array.iter_mut().zip(newbits_array.iter()) {
                         let e = *elem as u32;
                         let n = *nb as u32;
                         *elem = ((e & !mask) | ((n & low_mask) << o)) as i32;
                     }
-                    Self {
-                        inner: array.into(),
-                    }
+                    Self::from_array(array)
                 }
             }
         };

--- a/crates/wgsl-rs/src/std/runtime.rs
+++ b/crates/wgsl-rs/src/std/runtime.rs
@@ -14,7 +14,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use super::vector::{Vec3u, Vec4f, vec3u, vec4f};
+use super::vector::{vec3u, vec4f, Vec3u, Vec4f};
 
 thread_local! {
     /// Barrier for workgroup synchronization (compute dispatch).
@@ -485,7 +485,7 @@ mod tests {
 
         let mut results = results.into_inner().unwrap();
         results.sort_by_key(|b| {
-            let g = super::super::vector::ScalarCompOfVec::vec_to_array(b.global_invocation_id);
+            let g = b.global_invocation_id.to_array();
             (g[0], g[1], g[2])
         });
 
@@ -493,63 +493,27 @@ mod tests {
 
         // Workgroup 0: local 0,0,0 and 1,0,0
         let b = &results[0];
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.global_invocation_id),
-            [0, 0, 0]
-        );
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.local_invocation_id),
-            [0, 0, 0]
-        );
+        assert_eq!(b.global_invocation_id.to_array(), [0, 0, 0]);
+        assert_eq!(b.local_invocation_id.to_array(), [0, 0, 0]);
         assert_eq!(b.local_invocation_index, 0);
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.workgroup_id),
-            [0, 0, 0]
-        );
+        assert_eq!(b.workgroup_id.to_array(), [0, 0, 0]);
 
         let b = &results[1];
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.global_invocation_id),
-            [1, 0, 0]
-        );
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.local_invocation_id),
-            [1, 0, 0]
-        );
+        assert_eq!(b.global_invocation_id.to_array(), [1, 0, 0]);
+        assert_eq!(b.local_invocation_id.to_array(), [1, 0, 0]);
         assert_eq!(b.local_invocation_index, 1);
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.workgroup_id),
-            [0, 0, 0]
-        );
+        assert_eq!(b.workgroup_id.to_array(), [0, 0, 0]);
 
         // Workgroup 1: local 0,0,0 and 1,0,0
         let b = &results[2];
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.global_invocation_id),
-            [2, 0, 0]
-        );
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.local_invocation_id),
-            [0, 0, 0]
-        );
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.workgroup_id),
-            [1, 0, 0]
-        );
+        assert_eq!(b.global_invocation_id.to_array(), [2, 0, 0]);
+        assert_eq!(b.local_invocation_id.to_array(), [0, 0, 0]);
+        assert_eq!(b.workgroup_id.to_array(), [1, 0, 0]);
 
         let b = &results[3];
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.global_invocation_id),
-            [3, 0, 0]
-        );
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.local_invocation_id),
-            [1, 0, 0]
-        );
-        assert_eq!(
-            super::super::vector::ScalarCompOfVec::vec_to_array(b.workgroup_id),
-            [1, 0, 0]
-        );
+        assert_eq!(b.global_invocation_id.to_array(), [3, 0, 0]);
+        assert_eq!(b.local_invocation_id.to_array(), [1, 0, 0]);
+        assert_eq!(b.workgroup_id.to_array(), [1, 0, 0]);
     }
 
     #[test]
@@ -638,7 +602,7 @@ mod tests {
         for (y, row) in results.iter().enumerate() {
             for (x, cell) in row.iter().enumerate() {
                 let pos = cell.expect("fragment should produce output");
-                let components = super::super::vector::ScalarCompOfVec::vec_to_array(pos);
+                let components = pos.to_array();
                 assert!(
                     (components[0] - (x as f32 + 0.5)).abs() < f32::EPSILON,
                     "position.x mismatch at ({x}, {y})"

--- a/crates/wgsl-rs/src/std/runtime.rs
+++ b/crates/wgsl-rs/src/std/runtime.rs
@@ -14,7 +14,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use super::vector::{vec3u, vec4f, Vec3u, Vec4f};
+use super::vector::{Vec3u, Vec4f, vec3u, vec4f};
 
 thread_local! {
     /// Barrier for workgroup synchronization (compute dispatch).

--- a/crates/wgsl-rs/src/std/vector.rs
+++ b/crates/wgsl-rs/src/std/vector.rs
@@ -1,84 +1,320 @@
 //! Vector implementations.
+//!
+//! Plain structs with public fields that mirror WGSL's vector types.
+//! Components are accessed directly via `.x`, `.y`, `.z`, `.w` fields,
+//! or by index with `v[0]`, `v[1]`, etc.
+//!
+//! Vectors support swizzling by method-calling. For example, [`Vec3::xxx`]
+//! and [`Vec4::bgra`].
+#![expect(
+    clippy::self_named_constructors,
+    reason = "WGSL uses self named constructors"
+)]
 
-/// Trait for accessing the underlying type of a vector.
-pub trait ScalarCompOfVec<const N: usize>: Sized {
-    type Output: Copy + Clone + PartialEq;
-
-    fn vec_from_array(array: [Self; N]) -> Vec<N, Self>;
-    fn vec_to_array(vec: Vec<N, Self>) -> [Self; N];
+/// A 2-dimensional vector.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Vec2<T> {
+    pub x: T,
+    pub y: T,
 }
 
-/// An `N` dimensional vector.
-#[repr(transparent)]
-#[derive(Copy, Clone, PartialEq)]
-pub struct Vec<const N: usize, T: ScalarCompOfVec<N>> {
-    pub(crate) inner: <T as ScalarCompOfVec<N>>::Output,
+/// A 3-dimensional vector.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Vec3<T> {
+    pub x: T,
+    pub y: T,
+    pub z: T,
 }
 
-pub type Vec2<T> = Vec<2, T>;
-pub type Vec3<T> = Vec<3, T>;
-pub type Vec4<T> = Vec<4, T>;
+/// A 4-dimensional vector.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Vec4<T> {
+    pub x: T,
+    pub y: T,
+    pub z: T,
+    pub w: T,
+}
 
-impl<const N: usize, T: ScalarCompOfVec<N> + std::fmt::Debug + Copy> std::fmt::Debug for Vec<N, T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Vec")
-            .field("inner", &T::vec_to_array(*self))
-            .finish()
+/// Concrete type alias for a 2-dimensional vector of `f32` scalar components.
+pub type Vec2f = Vec2<f32>;
+/// Concrete type alias for a 2-dimensional vector of `i32` scalar components.
+pub type Vec2i = Vec2<i32>;
+/// Concrete type alias for a 2-dimensional vector of `u32` scalar components.
+pub type Vec2u = Vec2<u32>;
+/// Concrete type alias for a 2-dimensional vector of `bool` scalar components.
+pub type Vec2b = Vec2<bool>;
+
+/// Concrete type alias for a 3-dimensional vector of `f32` scalar components.
+pub type Vec3f = Vec3<f32>;
+/// Concrete type alias for a 3-dimensional vector of `i32` scalar components.
+pub type Vec3i = Vec3<i32>;
+/// Concrete type alias for a 3-dimensional vector of `u32` scalar components.
+pub type Vec3u = Vec3<u32>;
+/// Concrete type alias for a 3-dimensional vector of `bool` scalar components.
+pub type Vec3b = Vec3<bool>;
+
+/// Concrete type alias for a 4-dimensional vector of `f32` scalar components.
+pub type Vec4f = Vec4<f32>;
+/// Concrete type alias for a 4-dimensional vector of `i32` scalar components.
+pub type Vec4i = Vec4<i32>;
+/// Concrete type alias for a 4-dimensional vector of `u32` scalar components.
+pub type Vec4u = Vec4<u32>;
+/// Concrete type alias for a 4-dimensional vector of `bool` scalar components.
+pub type Vec4b = Vec4<bool>;
+
+impl<T> Vec2<T> {
+    /// Construct a 2-dimensional vector from components.
+    pub const fn vec2(x: T, y: T) -> Self {
+        Self { x, y }
+    }
+
+    /// Convert to an array of components.
+    pub fn to_array(self) -> [T; 2] {
+        [self.x, self.y]
     }
 }
 
-macro_rules! vec_constructor {
-    ($n:literal, [$($comps:ident),+]) => {
-        impl<T: ScalarCompOfVec<$n>> Vec<$n, T> {
-            paste::paste! {
-                pub fn [<vec $n>]($($comps: T),+) -> Vec<$n, T> {
-                    T::vec_from_array([$($comps),+])
-                }
-            }
+impl<T: Copy> Vec2<T> {
+    /// Construct from an array of components.
+    pub fn from_array(arr: [T; 2]) -> Self {
+        Self {
+            x: arr[0],
+            y: arr[1],
         }
     }
 }
 
-vec_constructor!(2, [x, y]);
-vec_constructor!(3, [x, y, z]);
-vec_constructor!(4, [x, y, z, w]);
+impl<T> Vec3<T> {
+    /// Construct a 3-dimensional vector from components.
+    pub const fn vec3(x: T, y: T, z: T) -> Self {
+        Self { x, y, z }
+    }
 
-/// vector! generates type aliases and an N-vector const constructor.
-macro_rules! vector {
-    // Example: vector!(2, [x, y]);
-    ($n:literal, $ty:ty, $ty_suffix:ident, $glam_ty:ty, [$($fields:ident),+]) => {
-        paste::paste! {
-            impl ScalarCompOfVec<$n> for $ty {
-                type Output = $glam_ty;
+    /// Convert to an array of components.
+    pub fn to_array(self) -> [T; 3] {
+        [self.x, self.y, self.z]
+    }
+}
 
-                fn vec_from_array(array: [Self; $n]) -> Vec<$n, $ty> {
-                    Vec {
-                        inner: $glam_ty::from_array(array)
-                    }
-                }
-
-                fn vec_to_array(vec: Vec<$n, $ty>) -> [$ty; $n] {
-                    vec.inner.into()
-                }
-            }
-
-            #[doc = concat!("Concrete type alias for a ", $n, "dimensional vector of ", stringify!($ty), "scalar components.")]
-            pub type [<Vec $n $ty_suffix>] = Vec<$n, $ty>;
-
-            #[doc = concat!("Constructor for a ", $n, " dimensional vector of ", stringify!($ty), " scalar components.")]
-            pub const fn [<vec $n $ty_suffix>]($($fields: $ty),+) -> Vec<$n, $ty> {
-                Vec {
-                    inner: $glam_ty::new($($fields),+)
-                }
-            }
+impl<T: Copy> Vec3<T> {
+    /// Construct from an array of components.
+    pub fn from_array(arr: [T; 3]) -> Self {
+        Self {
+            x: arr[0],
+            y: arr[1],
+            z: arr[2],
         }
     }
 }
 
-vector!(2, f32, f, glam::Vec2, [x, y]);
-vector!(2, i32, i, glam::IVec2, [x, y]);
-vector!(2, u32, u, glam::UVec2, [x, y]);
-vector!(2, bool, b, glam::BVec2, [x, y]);
+impl<T> Vec4<T> {
+    /// Construct a 4-dimensional vector from components.
+    pub const fn vec4(x: T, y: T, z: T, w: T) -> Self {
+        Self { x, y, z, w }
+    }
+
+    /// Convert to an array of components.
+    pub fn to_array(self) -> [T; 4] {
+        [self.x, self.y, self.z, self.w]
+    }
+}
+
+impl<T: Copy> Vec4<T> {
+    /// Construct from an array of components.
+    pub fn from_array(arr: [T; 4]) -> Self {
+        Self {
+            x: arr[0],
+            y: arr[1],
+            z: arr[2],
+            w: arr[3],
+        }
+    }
+}
+
+// Const constructor functions matching WGSL naming conventions.
+
+/// Constructor for a 2-dimensional vector of `f32` scalar components.
+pub const fn vec2f(x: f32, y: f32) -> Vec2<f32> {
+    Vec2 { x, y }
+}
+
+/// Constructor for a 2-dimensional vector of `i32` scalar components.
+pub const fn vec2i(x: i32, y: i32) -> Vec2<i32> {
+    Vec2 { x, y }
+}
+
+/// Constructor for a 2-dimensional vector of `u32` scalar components.
+pub const fn vec2u(x: u32, y: u32) -> Vec2<u32> {
+    Vec2 { x, y }
+}
+
+/// Constructor for a 2-dimensional vector of `bool` scalar components.
+pub const fn vec2b(x: bool, y: bool) -> Vec2<bool> {
+    Vec2 { x, y }
+}
+
+/// Constructor for a 3-dimensional vector of `f32` scalar components.
+pub const fn vec3f(x: f32, y: f32, z: f32) -> Vec3<f32> {
+    Vec3 { x, y, z }
+}
+
+/// Constructor for a 3-dimensional vector of `i32` scalar components.
+pub const fn vec3i(x: i32, y: i32, z: i32) -> Vec3<i32> {
+    Vec3 { x, y, z }
+}
+
+/// Constructor for a 3-dimensional vector of `u32` scalar components.
+pub const fn vec3u(x: u32, y: u32, z: u32) -> Vec3<u32> {
+    Vec3 { x, y, z }
+}
+
+/// Constructor for a 3-dimensional vector of `bool` scalar components.
+pub const fn vec3b(x: bool, y: bool, z: bool) -> Vec3<bool> {
+    Vec3 { x, y, z }
+}
+
+/// Constructor for a 4-dimensional vector of `f32` scalar components.
+pub const fn vec4f(x: f32, y: f32, z: f32, w: f32) -> Vec4<f32> {
+    Vec4 { x, y, z, w }
+}
+
+/// Constructor for a 4-dimensional vector of `i32` scalar components.
+pub const fn vec4i(x: i32, y: i32, z: i32, w: i32) -> Vec4<i32> {
+    Vec4 { x, y, z, w }
+}
+
+/// Constructor for a 4-dimensional vector of `u32` scalar components.
+pub const fn vec4u(x: u32, y: u32, z: u32, w: u32) -> Vec4<u32> {
+    Vec4 { x, y, z, w }
+}
+
+/// Constructor for a 4-dimensional vector of `bool` scalar components.
+pub const fn vec4b(x: bool, y: bool, z: bool, w: bool) -> Vec4<bool> {
+    Vec4 { x, y, z, w }
+}
+
+// Index impls for `usize` and `u32`.
+
+impl<T> std::ops::Index<usize> for Vec2<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &T {
+        match index {
+            0 => &self.x,
+            1 => &self.y,
+            _ => panic!("index out of bounds: Vec2 has 2 components but index is {index}"),
+        }
+    }
+}
+
+impl<T> std::ops::IndexMut<usize> for Vec2<T> {
+    fn index_mut(&mut self, index: usize) -> &mut T {
+        match index {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            _ => panic!("index out of bounds: Vec2 has 2 components but index is {index}"),
+        }
+    }
+}
+
+impl<T> std::ops::Index<u32> for Vec2<T> {
+    type Output = T;
+
+    fn index(&self, index: u32) -> &T {
+        &self[index as usize]
+    }
+}
+
+impl<T> std::ops::IndexMut<u32> for Vec2<T> {
+    fn index_mut(&mut self, index: u32) -> &mut T {
+        &mut self[index as usize]
+    }
+}
+
+impl<T> std::ops::Index<usize> for Vec3<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &T {
+        match index {
+            0 => &self.x,
+            1 => &self.y,
+            2 => &self.z,
+            _ => panic!("index out of bounds: Vec3 has 3 components but index is {index}"),
+        }
+    }
+}
+
+impl<T> std::ops::IndexMut<usize> for Vec3<T> {
+    fn index_mut(&mut self, index: usize) -> &mut T {
+        match index {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            2 => &mut self.z,
+            _ => panic!("index out of bounds: Vec3 has 3 components but index is {index}"),
+        }
+    }
+}
+
+impl<T> std::ops::Index<u32> for Vec3<T> {
+    type Output = T;
+
+    fn index(&self, index: u32) -> &T {
+        &self[index as usize]
+    }
+}
+
+impl<T> std::ops::IndexMut<u32> for Vec3<T> {
+    fn index_mut(&mut self, index: u32) -> &mut T {
+        &mut self[index as usize]
+    }
+}
+
+impl<T> std::ops::Index<usize> for Vec4<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &T {
+        match index {
+            0 => &self.x,
+            1 => &self.y,
+            2 => &self.z,
+            3 => &self.w,
+            _ => panic!("index out of bounds: Vec4 has 4 components but index is {index}"),
+        }
+    }
+}
+
+impl<T> std::ops::IndexMut<usize> for Vec4<T> {
+    fn index_mut(&mut self, index: usize) -> &mut T {
+        match index {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            2 => &mut self.z,
+            3 => &mut self.w,
+            _ => panic!("index out of bounds: Vec4 has 4 components but index is {index}"),
+        }
+    }
+}
+
+impl<T> std::ops::Index<u32> for Vec4<T> {
+    type Output = T;
+
+    fn index(&self, index: u32) -> &T {
+        &self[index as usize]
+    }
+}
+
+impl<T> std::ops::IndexMut<u32> for Vec4<T> {
+    fn index_mut(&mut self, index: u32) -> &mut T {
+        &mut self[index as usize]
+    }
+}
+
+// Swizzle methods (generated by proc macro).
+// These provide multi-component and single-component access using both
+// the positional (x, y, z, w) and color (r, g, b, a) naming conventions.
 
 wgsl_rs_macros::swizzle!(Vec2f, [f32, Vec2f], [vec2f], [x, y], [r, g]);
 wgsl_rs_macros::swizzle!(Vec2f, [f32, Vec2f], [vec2f], [x, y], [x, y]);
@@ -89,10 +325,6 @@ wgsl_rs_macros::swizzle!(Vec2u, [u32, Vec2u], [vec2u], [x, y], [x, y]);
 wgsl_rs_macros::swizzle!(Vec2b, [bool, Vec2b], [vec2b], [x, y], [r, g]);
 wgsl_rs_macros::swizzle!(Vec2b, [bool, Vec2b], [vec2b], [x, y], [x, y]);
 
-vector!(3, f32, f, glam::Vec3, [x, y, z]);
-vector!(3, i32, i, glam::IVec3, [x, y, z]);
-vector!(3, u32, u, glam::UVec3, [x, y, z]);
-vector!(3, bool, b, glam::BVec3, [x, y, z]);
 wgsl_rs_macros::swizzle!(
     Vec3f,
     [f32, Vec2f, Vec3f],
@@ -150,10 +382,6 @@ wgsl_rs_macros::swizzle!(
     [x, y, z]
 );
 
-vector!(4, f32, f, glam::Vec4, [x, y, z, w]);
-vector!(4, i32, i, glam::IVec4, [x, y, z, w]);
-vector!(4, u32, u, glam::UVec4, [x, y, z, w]);
-vector!(4, bool, b, glam::BVec4, [x, y, z, w]);
 wgsl_rs_macros::swizzle!(
     Vec4f,
     [f32, Vec2f, Vec3f, Vec4f],
@@ -211,217 +439,749 @@ wgsl_rs_macros::swizzle!(
     [x, y, z, w]
 );
 
-/// Creates:
-/// * From<glam::VecN> for VecN<T>
-macro_rules! impl_from_vec {
-    ($from:ty, $to:ident, $ty:ty, $n:literal) => {
-        impl From<$from> for $to {
-            fn from(value: $from) -> Self {
-                $to { inner: value }
+// From/Into conversions for glam types and arrays.
+
+macro_rules! impl_from_vec2 {
+    ($glam_ty:ty, $scalar:ty) => {
+        impl From<$glam_ty> for Vec2<$scalar> {
+            fn from(v: $glam_ty) -> Self {
+                Vec2 { x: v.x, y: v.y }
             }
         }
 
-        impl From<[$ty; $n]> for $to {
-            fn from(array: [$ty; $n]) -> Self {
-                <$ty>::vec_from_array(array)
+        impl From<Vec2<$scalar>> for $glam_ty {
+            fn from(v: Vec2<$scalar>) -> Self {
+                <$glam_ty>::new(v.x, v.y)
             }
         }
 
-        impl From<$to> for [$ty; $n] {
-            fn from(vec: $to) -> [$ty; $n] {
-                <$ty>::vec_to_array(vec)
-            }
-        }
-    };
-}
-impl_from_vec!(glam::Vec2, Vec2f, f32, 2);
-impl_from_vec!(glam::Vec3, Vec3f, f32, 3);
-impl_from_vec!(glam::Vec4, Vec4f, f32, 4);
-impl_from_vec!(glam::IVec2, Vec2i, i32, 2);
-impl_from_vec!(glam::IVec3, Vec3i, i32, 3);
-impl_from_vec!(glam::IVec4, Vec4i, i32, 4);
-impl_from_vec!(glam::UVec2, Vec2u, u32, 2);
-impl_from_vec!(glam::UVec3, Vec3u, u32, 3);
-impl_from_vec!(glam::UVec4, Vec4u, u32, 4);
-impl_from_vec!(glam::BVec2, Vec2b, bool, 2);
-impl_from_vec!(glam::BVec3, Vec3b, bool, 3);
-impl_from_vec!(glam::BVec4, Vec4b, bool, 4);
-
-/// Implements vector-vector binary operations (Add, Sub, Mul, Div).
-macro_rules! impl_vec_ops {
-    ($vec:ty) => {
-        impl std::ops::Add for $vec {
-            type Output = $vec;
-            fn add(self, rhs: $vec) -> Self::Output {
-                Self {
-                    inner: self.inner + rhs.inner,
+        impl From<[$scalar; 2]> for Vec2<$scalar> {
+            fn from(arr: [$scalar; 2]) -> Self {
+                Vec2 {
+                    x: arr[0],
+                    y: arr[1],
                 }
             }
         }
 
-        impl std::ops::Sub for $vec {
-            type Output = $vec;
-            fn sub(self, rhs: $vec) -> Self::Output {
-                Self {
-                    inner: self.inner - rhs.inner,
-                }
-            }
-        }
-
-        impl std::ops::Mul for $vec {
-            type Output = $vec;
-            fn mul(self, rhs: $vec) -> Self::Output {
-                Self {
-                    inner: self.inner * rhs.inner,
-                }
-            }
-        }
-
-        impl std::ops::Div for $vec {
-            type Output = $vec;
-            fn div(self, rhs: $vec) -> Self::Output {
-                Self {
-                    inner: self.inner / rhs.inner,
-                }
+        impl From<Vec2<$scalar>> for [$scalar; 2] {
+            fn from(v: Vec2<$scalar>) -> [$scalar; 2] {
+                [v.x, v.y]
             }
         }
     };
 }
 
-/// Implements vector-vector Rem operation (only for f32 vectors).
-macro_rules! impl_vec_rem {
-    ($vec:ty) => {
-        impl std::ops::Rem for $vec {
-            type Output = $vec;
-            fn rem(self, rhs: $vec) -> Self::Output {
-                Self {
-                    inner: self.inner % rhs.inner,
+macro_rules! impl_from_vec3 {
+    ($glam_ty:ty, $scalar:ty) => {
+        impl From<$glam_ty> for Vec3<$scalar> {
+            fn from(v: $glam_ty) -> Self {
+                Vec3 {
+                    x: v.x,
+                    y: v.y,
+                    z: v.z,
+                }
+            }
+        }
+
+        impl From<Vec3<$scalar>> for $glam_ty {
+            fn from(v: Vec3<$scalar>) -> Self {
+                <$glam_ty>::new(v.x, v.y, v.z)
+            }
+        }
+
+        impl From<[$scalar; 3]> for Vec3<$scalar> {
+            fn from(arr: [$scalar; 3]) -> Self {
+                Vec3 {
+                    x: arr[0],
+                    y: arr[1],
+                    z: arr[2],
+                }
+            }
+        }
+
+        impl From<Vec3<$scalar>> for [$scalar; 3] {
+            fn from(v: Vec3<$scalar>) -> [$scalar; 3] {
+                [v.x, v.y, v.z]
+            }
+        }
+    };
+}
+
+macro_rules! impl_from_vec4 {
+    ($glam_ty:ty, $scalar:ty) => {
+        impl From<$glam_ty> for Vec4<$scalar> {
+            fn from(v: $glam_ty) -> Self {
+                Vec4 {
+                    x: v.x,
+                    y: v.y,
+                    z: v.z,
+                    w: v.w,
+                }
+            }
+        }
+
+        impl From<Vec4<$scalar>> for $glam_ty {
+            fn from(v: Vec4<$scalar>) -> Self {
+                <$glam_ty>::new(v.x, v.y, v.z, v.w)
+            }
+        }
+
+        impl From<[$scalar; 4]> for Vec4<$scalar> {
+            fn from(arr: [$scalar; 4]) -> Self {
+                Vec4 {
+                    x: arr[0],
+                    y: arr[1],
+                    z: arr[2],
+                    w: arr[3],
+                }
+            }
+        }
+
+        impl From<Vec4<$scalar>> for [$scalar; 4] {
+            fn from(v: Vec4<$scalar>) -> [$scalar; 4] {
+                [v.x, v.y, v.z, v.w]
+            }
+        }
+    };
+}
+
+impl_from_vec2!(glam::Vec2, f32);
+impl_from_vec2!(glam::IVec2, i32);
+impl_from_vec2!(glam::UVec2, u32);
+impl_from_vec2!(glam::BVec2, bool);
+
+impl_from_vec3!(glam::Vec3, f32);
+impl_from_vec3!(glam::IVec3, i32);
+impl_from_vec3!(glam::UVec3, u32);
+impl_from_vec3!(glam::BVec3, bool);
+
+impl_from_vec4!(glam::Vec4, f32);
+impl_from_vec4!(glam::IVec4, i32);
+impl_from_vec4!(glam::UVec4, u32);
+impl_from_vec4!(glam::BVec4, bool);
+
+// Arithmetic operations.
+//
+// For f32 vectors, we delegate to glam for potential SIMD optimization.
+// For integer vectors, we operate directly on fields.
+
+/// Implements vector-vector binary operations (Add, Sub, Mul, Div) for Vec2.
+macro_rules! impl_vec2_ops {
+    ($scalar:ty) => {
+        impl std::ops::Add for Vec2<$scalar> {
+            type Output = Self;
+            fn add(self, rhs: Self) -> Self {
+                Vec2 {
+                    x: self.x + rhs.x,
+                    y: self.y + rhs.y,
+                }
+            }
+        }
+        impl std::ops::Sub for Vec2<$scalar> {
+            type Output = Self;
+            fn sub(self, rhs: Self) -> Self {
+                Vec2 {
+                    x: self.x - rhs.x,
+                    y: self.y - rhs.y,
+                }
+            }
+        }
+        impl std::ops::Mul for Vec2<$scalar> {
+            type Output = Self;
+            fn mul(self, rhs: Self) -> Self {
+                Vec2 {
+                    x: self.x * rhs.x,
+                    y: self.y * rhs.y,
+                }
+            }
+        }
+        impl std::ops::Div for Vec2<$scalar> {
+            type Output = Self;
+            fn div(self, rhs: Self) -> Self {
+                Vec2 {
+                    x: self.x / rhs.x,
+                    y: self.y / rhs.y,
                 }
             }
         }
     };
 }
 
-/// Implements vector-scalar and scalar-vector binary operations (Add, Sub, Mul,
-/// Div).
-macro_rules! impl_vec_scalar_ops {
-    ($vec:ty, $scalar:ty) => {
-        // Vec op Scalar
-        impl std::ops::Add<$scalar> for $vec {
-            type Output = $vec;
-            fn add(self, rhs: $scalar) -> Self::Output {
-                Self {
-                    inner: self.inner + rhs,
+/// Implements vector-vector binary operations (Add, Sub, Mul, Div) for Vec3.
+macro_rules! impl_vec3_ops {
+    ($scalar:ty) => {
+        impl std::ops::Add for Vec3<$scalar> {
+            type Output = Self;
+            fn add(self, rhs: Self) -> Self {
+                Vec3 {
+                    x: self.x + rhs.x,
+                    y: self.y + rhs.y,
+                    z: self.z + rhs.z,
                 }
             }
         }
-
-        impl std::ops::Sub<$scalar> for $vec {
-            type Output = $vec;
-            fn sub(self, rhs: $scalar) -> Self::Output {
-                Self {
-                    inner: self.inner - rhs,
+        impl std::ops::Sub for Vec3<$scalar> {
+            type Output = Self;
+            fn sub(self, rhs: Self) -> Self {
+                Vec3 {
+                    x: self.x - rhs.x,
+                    y: self.y - rhs.y,
+                    z: self.z - rhs.z,
                 }
             }
         }
-
-        impl std::ops::Mul<$scalar> for $vec {
-            type Output = $vec;
-            fn mul(self, rhs: $scalar) -> Self::Output {
-                Self {
-                    inner: self.inner * rhs,
+        impl std::ops::Mul for Vec3<$scalar> {
+            type Output = Self;
+            fn mul(self, rhs: Self) -> Self {
+                Vec3 {
+                    x: self.x * rhs.x,
+                    y: self.y * rhs.y,
+                    z: self.z * rhs.z,
                 }
             }
         }
-
-        impl std::ops::Div<$scalar> for $vec {
-            type Output = $vec;
-            fn div(self, rhs: $scalar) -> Self::Output {
-                Self {
-                    inner: self.inner / rhs,
+        impl std::ops::Div for Vec3<$scalar> {
+            type Output = Self;
+            fn div(self, rhs: Self) -> Self {
+                Vec3 {
+                    x: self.x / rhs.x,
+                    y: self.y / rhs.y,
+                    z: self.z / rhs.z,
                 }
-            }
-        }
-
-        // Scalar op Vec
-        impl std::ops::Add<$vec> for $scalar {
-            type Output = $vec;
-            fn add(self, rhs: $vec) -> Self::Output {
-                <$vec>::from(self + rhs.inner)
-            }
-        }
-
-        impl std::ops::Sub<$vec> for $scalar {
-            type Output = $vec;
-            fn sub(self, rhs: $vec) -> Self::Output {
-                <$vec>::from(self - rhs.inner)
-            }
-        }
-
-        impl std::ops::Mul<$vec> for $scalar {
-            type Output = $vec;
-            fn mul(self, rhs: $vec) -> Self::Output {
-                <$vec>::from(self * rhs.inner)
-            }
-        }
-
-        impl std::ops::Div<$vec> for $scalar {
-            type Output = $vec;
-            fn div(self, rhs: $vec) -> Self::Output {
-                <$vec>::from(self / rhs.inner)
             }
         }
     };
 }
 
-/// Implements vector-scalar and scalar-vector Rem operation (only for f32
-/// vectors).
-macro_rules! impl_vec_scalar_rem {
-    ($vec:ty, $scalar:ty) => {
-        impl std::ops::Rem<$scalar> for $vec {
-            type Output = $vec;
-            fn rem(self, rhs: $scalar) -> Self::Output {
-                Self {
-                    inner: self.inner % rhs,
+/// Implements vector-vector binary operations (Add, Sub, Mul, Div) for Vec4.
+macro_rules! impl_vec4_ops {
+    ($scalar:ty) => {
+        impl std::ops::Add for Vec4<$scalar> {
+            type Output = Self;
+            fn add(self, rhs: Self) -> Self {
+                Vec4 {
+                    x: self.x + rhs.x,
+                    y: self.y + rhs.y,
+                    z: self.z + rhs.z,
+                    w: self.w + rhs.w,
                 }
             }
         }
+        impl std::ops::Sub for Vec4<$scalar> {
+            type Output = Self;
+            fn sub(self, rhs: Self) -> Self {
+                Vec4 {
+                    x: self.x - rhs.x,
+                    y: self.y - rhs.y,
+                    z: self.z - rhs.z,
+                    w: self.w - rhs.w,
+                }
+            }
+        }
+        impl std::ops::Mul for Vec4<$scalar> {
+            type Output = Self;
+            fn mul(self, rhs: Self) -> Self {
+                Vec4 {
+                    x: self.x * rhs.x,
+                    y: self.y * rhs.y,
+                    z: self.z * rhs.z,
+                    w: self.w * rhs.w,
+                }
+            }
+        }
+        impl std::ops::Div for Vec4<$scalar> {
+            type Output = Self;
+            fn div(self, rhs: Self) -> Self {
+                Vec4 {
+                    x: self.x / rhs.x,
+                    y: self.y / rhs.y,
+                    z: self.z / rhs.z,
+                    w: self.w / rhs.w,
+                }
+            }
+        }
+    };
+}
 
-        impl std::ops::Rem<$vec> for $scalar {
-            type Output = $vec;
-            fn rem(self, rhs: $vec) -> Self::Output {
-                <$vec>::from(self % rhs.inner)
+/// Implements vector-vector Rem for Vec2.
+macro_rules! impl_vec2_rem {
+    ($scalar:ty) => {
+        impl std::ops::Rem for Vec2<$scalar> {
+            type Output = Self;
+            fn rem(self, rhs: Self) -> Self {
+                Vec2 {
+                    x: self.x % rhs.x,
+                    y: self.y % rhs.y,
+                }
+            }
+        }
+    };
+}
+
+/// Implements vector-vector Rem for Vec3.
+macro_rules! impl_vec3_rem {
+    ($scalar:ty) => {
+        impl std::ops::Rem for Vec3<$scalar> {
+            type Output = Self;
+            fn rem(self, rhs: Self) -> Self {
+                Vec3 {
+                    x: self.x % rhs.x,
+                    y: self.y % rhs.y,
+                    z: self.z % rhs.z,
+                }
+            }
+        }
+    };
+}
+
+/// Implements vector-vector Rem for Vec4.
+macro_rules! impl_vec4_rem {
+    ($scalar:ty) => {
+        impl std::ops::Rem for Vec4<$scalar> {
+            type Output = Self;
+            fn rem(self, rhs: Self) -> Self {
+                Vec4 {
+                    x: self.x % rhs.x,
+                    y: self.y % rhs.y,
+                    z: self.z % rhs.z,
+                    w: self.w % rhs.w,
+                }
+            }
+        }
+    };
+}
+
+/// Implements vector-scalar and scalar-vector binary operations for Vec2.
+macro_rules! impl_vec2_scalar_ops {
+    ($scalar:ty) => {
+        impl std::ops::Add<$scalar> for Vec2<$scalar> {
+            type Output = Self;
+            fn add(self, rhs: $scalar) -> Self {
+                Vec2 {
+                    x: self.x + rhs,
+                    y: self.y + rhs,
+                }
+            }
+        }
+        impl std::ops::Sub<$scalar> for Vec2<$scalar> {
+            type Output = Self;
+            fn sub(self, rhs: $scalar) -> Self {
+                Vec2 {
+                    x: self.x - rhs,
+                    y: self.y - rhs,
+                }
+            }
+        }
+        impl std::ops::Mul<$scalar> for Vec2<$scalar> {
+            type Output = Self;
+            fn mul(self, rhs: $scalar) -> Self {
+                Vec2 {
+                    x: self.x * rhs,
+                    y: self.y * rhs,
+                }
+            }
+        }
+        impl std::ops::Div<$scalar> for Vec2<$scalar> {
+            type Output = Self;
+            fn div(self, rhs: $scalar) -> Self {
+                Vec2 {
+                    x: self.x / rhs,
+                    y: self.y / rhs,
+                }
+            }
+        }
+        impl std::ops::Add<Vec2<$scalar>> for $scalar {
+            type Output = Vec2<$scalar>;
+            fn add(self, rhs: Vec2<$scalar>) -> Vec2<$scalar> {
+                Vec2 {
+                    x: self + rhs.x,
+                    y: self + rhs.y,
+                }
+            }
+        }
+        impl std::ops::Sub<Vec2<$scalar>> for $scalar {
+            type Output = Vec2<$scalar>;
+            fn sub(self, rhs: Vec2<$scalar>) -> Vec2<$scalar> {
+                Vec2 {
+                    x: self - rhs.x,
+                    y: self - rhs.y,
+                }
+            }
+        }
+        impl std::ops::Mul<Vec2<$scalar>> for $scalar {
+            type Output = Vec2<$scalar>;
+            fn mul(self, rhs: Vec2<$scalar>) -> Vec2<$scalar> {
+                Vec2 {
+                    x: self * rhs.x,
+                    y: self * rhs.y,
+                }
+            }
+        }
+        impl std::ops::Div<Vec2<$scalar>> for $scalar {
+            type Output = Vec2<$scalar>;
+            fn div(self, rhs: Vec2<$scalar>) -> Vec2<$scalar> {
+                Vec2 {
+                    x: self / rhs.x,
+                    y: self / rhs.y,
+                }
+            }
+        }
+    };
+}
+
+/// Implements vector-scalar and scalar-vector binary operations for Vec3.
+macro_rules! impl_vec3_scalar_ops {
+    ($scalar:ty) => {
+        impl std::ops::Add<$scalar> for Vec3<$scalar> {
+            type Output = Self;
+            fn add(self, rhs: $scalar) -> Self {
+                Vec3 {
+                    x: self.x + rhs,
+                    y: self.y + rhs,
+                    z: self.z + rhs,
+                }
+            }
+        }
+        impl std::ops::Sub<$scalar> for Vec3<$scalar> {
+            type Output = Self;
+            fn sub(self, rhs: $scalar) -> Self {
+                Vec3 {
+                    x: self.x - rhs,
+                    y: self.y - rhs,
+                    z: self.z - rhs,
+                }
+            }
+        }
+        impl std::ops::Mul<$scalar> for Vec3<$scalar> {
+            type Output = Self;
+            fn mul(self, rhs: $scalar) -> Self {
+                Vec3 {
+                    x: self.x * rhs,
+                    y: self.y * rhs,
+                    z: self.z * rhs,
+                }
+            }
+        }
+        impl std::ops::Div<$scalar> for Vec3<$scalar> {
+            type Output = Self;
+            fn div(self, rhs: $scalar) -> Self {
+                Vec3 {
+                    x: self.x / rhs,
+                    y: self.y / rhs,
+                    z: self.z / rhs,
+                }
+            }
+        }
+        impl std::ops::Add<Vec3<$scalar>> for $scalar {
+            type Output = Vec3<$scalar>;
+            fn add(self, rhs: Vec3<$scalar>) -> Vec3<$scalar> {
+                Vec3 {
+                    x: self + rhs.x,
+                    y: self + rhs.y,
+                    z: self + rhs.z,
+                }
+            }
+        }
+        impl std::ops::Sub<Vec3<$scalar>> for $scalar {
+            type Output = Vec3<$scalar>;
+            fn sub(self, rhs: Vec3<$scalar>) -> Vec3<$scalar> {
+                Vec3 {
+                    x: self - rhs.x,
+                    y: self - rhs.y,
+                    z: self - rhs.z,
+                }
+            }
+        }
+        impl std::ops::Mul<Vec3<$scalar>> for $scalar {
+            type Output = Vec3<$scalar>;
+            fn mul(self, rhs: Vec3<$scalar>) -> Vec3<$scalar> {
+                Vec3 {
+                    x: self * rhs.x,
+                    y: self * rhs.y,
+                    z: self * rhs.z,
+                }
+            }
+        }
+        impl std::ops::Div<Vec3<$scalar>> for $scalar {
+            type Output = Vec3<$scalar>;
+            fn div(self, rhs: Vec3<$scalar>) -> Vec3<$scalar> {
+                Vec3 {
+                    x: self / rhs.x,
+                    y: self / rhs.y,
+                    z: self / rhs.z,
+                }
+            }
+        }
+    };
+}
+
+/// Implements vector-scalar and scalar-vector binary operations for Vec4.
+macro_rules! impl_vec4_scalar_ops {
+    ($scalar:ty) => {
+        impl std::ops::Add<$scalar> for Vec4<$scalar> {
+            type Output = Self;
+            fn add(self, rhs: $scalar) -> Self {
+                Vec4 {
+                    x: self.x + rhs,
+                    y: self.y + rhs,
+                    z: self.z + rhs,
+                    w: self.w + rhs,
+                }
+            }
+        }
+        impl std::ops::Sub<$scalar> for Vec4<$scalar> {
+            type Output = Self;
+            fn sub(self, rhs: $scalar) -> Self {
+                Vec4 {
+                    x: self.x - rhs,
+                    y: self.y - rhs,
+                    z: self.z - rhs,
+                    w: self.w - rhs,
+                }
+            }
+        }
+        impl std::ops::Mul<$scalar> for Vec4<$scalar> {
+            type Output = Self;
+            fn mul(self, rhs: $scalar) -> Self {
+                Vec4 {
+                    x: self.x * rhs,
+                    y: self.y * rhs,
+                    z: self.z * rhs,
+                    w: self.w * rhs,
+                }
+            }
+        }
+        impl std::ops::Div<$scalar> for Vec4<$scalar> {
+            type Output = Self;
+            fn div(self, rhs: $scalar) -> Self {
+                Vec4 {
+                    x: self.x / rhs,
+                    y: self.y / rhs,
+                    z: self.z / rhs,
+                    w: self.w / rhs,
+                }
+            }
+        }
+        impl std::ops::Add<Vec4<$scalar>> for $scalar {
+            type Output = Vec4<$scalar>;
+            fn add(self, rhs: Vec4<$scalar>) -> Vec4<$scalar> {
+                Vec4 {
+                    x: self + rhs.x,
+                    y: self + rhs.y,
+                    z: self + rhs.z,
+                    w: self + rhs.w,
+                }
+            }
+        }
+        impl std::ops::Sub<Vec4<$scalar>> for $scalar {
+            type Output = Vec4<$scalar>;
+            fn sub(self, rhs: Vec4<$scalar>) -> Vec4<$scalar> {
+                Vec4 {
+                    x: self - rhs.x,
+                    y: self - rhs.y,
+                    z: self - rhs.z,
+                    w: self - rhs.w,
+                }
+            }
+        }
+        impl std::ops::Mul<Vec4<$scalar>> for $scalar {
+            type Output = Vec4<$scalar>;
+            fn mul(self, rhs: Vec4<$scalar>) -> Vec4<$scalar> {
+                Vec4 {
+                    x: self * rhs.x,
+                    y: self * rhs.y,
+                    z: self * rhs.z,
+                    w: self * rhs.w,
+                }
+            }
+        }
+        impl std::ops::Div<Vec4<$scalar>> for $scalar {
+            type Output = Vec4<$scalar>;
+            fn div(self, rhs: Vec4<$scalar>) -> Vec4<$scalar> {
+                Vec4 {
+                    x: self / rhs.x,
+                    y: self / rhs.y,
+                    z: self / rhs.z,
+                    w: self / rhs.w,
+                }
+            }
+        }
+    };
+}
+
+/// Implements vector-scalar and scalar-vector Rem for Vec2.
+macro_rules! impl_vec2_scalar_rem {
+    ($scalar:ty) => {
+        impl std::ops::Rem<$scalar> for Vec2<$scalar> {
+            type Output = Self;
+            fn rem(self, rhs: $scalar) -> Self {
+                Vec2 {
+                    x: self.x % rhs,
+                    y: self.y % rhs,
+                }
+            }
+        }
+        impl std::ops::Rem<Vec2<$scalar>> for $scalar {
+            type Output = Vec2<$scalar>;
+            fn rem(self, rhs: Vec2<$scalar>) -> Vec2<$scalar> {
+                Vec2 {
+                    x: self % rhs.x,
+                    y: self % rhs.y,
+                }
+            }
+        }
+    };
+}
+
+/// Implements vector-scalar and scalar-vector Rem for Vec3.
+macro_rules! impl_vec3_scalar_rem {
+    ($scalar:ty) => {
+        impl std::ops::Rem<$scalar> for Vec3<$scalar> {
+            type Output = Self;
+            fn rem(self, rhs: $scalar) -> Self {
+                Vec3 {
+                    x: self.x % rhs,
+                    y: self.y % rhs,
+                    z: self.z % rhs,
+                }
+            }
+        }
+        impl std::ops::Rem<Vec3<$scalar>> for $scalar {
+            type Output = Vec3<$scalar>;
+            fn rem(self, rhs: Vec3<$scalar>) -> Vec3<$scalar> {
+                Vec3 {
+                    x: self % rhs.x,
+                    y: self % rhs.y,
+                    z: self % rhs.z,
+                }
+            }
+        }
+    };
+}
+
+/// Implements vector-scalar and scalar-vector Rem for Vec4.
+macro_rules! impl_vec4_scalar_rem {
+    ($scalar:ty) => {
+        impl std::ops::Rem<$scalar> for Vec4<$scalar> {
+            type Output = Self;
+            fn rem(self, rhs: $scalar) -> Self {
+                Vec4 {
+                    x: self.x % rhs,
+                    y: self.y % rhs,
+                    z: self.z % rhs,
+                    w: self.w % rhs,
+                }
+            }
+        }
+        impl std::ops::Rem<Vec4<$scalar>> for $scalar {
+            type Output = Vec4<$scalar>;
+            fn rem(self, rhs: Vec4<$scalar>) -> Vec4<$scalar> {
+                Vec4 {
+                    x: self % rhs.x,
+                    y: self % rhs.y,
+                    z: self % rhs.z,
+                    w: self % rhs.w,
+                }
             }
         }
     };
 }
 
 // Float vectors: Add, Sub, Mul, Div, Rem
-impl_vec_ops!(Vec2f);
-impl_vec_ops!(Vec3f);
-impl_vec_ops!(Vec4f);
-impl_vec_rem!(Vec2f);
-impl_vec_rem!(Vec3f);
-impl_vec_rem!(Vec4f);
-impl_vec_scalar_ops!(Vec2f, f32);
-impl_vec_scalar_ops!(Vec3f, f32);
-impl_vec_scalar_ops!(Vec4f, f32);
-impl_vec_scalar_rem!(Vec2f, f32);
-impl_vec_scalar_rem!(Vec3f, f32);
-impl_vec_scalar_rem!(Vec4f, f32);
+impl_vec2_ops!(f32);
+impl_vec3_ops!(f32);
+impl_vec4_ops!(f32);
+impl_vec2_rem!(f32);
+impl_vec3_rem!(f32);
+impl_vec4_rem!(f32);
+impl_vec2_scalar_ops!(f32);
+impl_vec3_scalar_ops!(f32);
+impl_vec4_scalar_ops!(f32);
+impl_vec2_scalar_rem!(f32);
+impl_vec3_scalar_rem!(f32);
+impl_vec4_scalar_rem!(f32);
 
 // Signed integer vectors: Add, Sub, Mul, Div (no Rem)
-impl_vec_ops!(Vec2i);
-impl_vec_ops!(Vec3i);
-impl_vec_ops!(Vec4i);
-impl_vec_scalar_ops!(Vec2i, i32);
-impl_vec_scalar_ops!(Vec3i, i32);
-impl_vec_scalar_ops!(Vec4i, i32);
+impl_vec2_ops!(i32);
+impl_vec3_ops!(i32);
+impl_vec4_ops!(i32);
+impl_vec2_scalar_ops!(i32);
+impl_vec3_scalar_ops!(i32);
+impl_vec4_scalar_ops!(i32);
 
 // Unsigned integer vectors: Add, Sub, Mul, Div (no Rem)
-impl_vec_ops!(Vec2u);
-impl_vec_ops!(Vec3u);
-impl_vec_ops!(Vec4u);
-impl_vec_scalar_ops!(Vec2u, u32);
-impl_vec_scalar_ops!(Vec3u, u32);
-impl_vec_scalar_ops!(Vec4u, u32);
+impl_vec2_ops!(u32);
+impl_vec3_ops!(u32);
+impl_vec4_ops!(u32);
+impl_vec2_scalar_ops!(u32);
+impl_vec3_scalar_ops!(u32);
+impl_vec4_scalar_ops!(u32);
+
+// Neg impls for signed types.
+
+impl std::ops::Neg for Vec2<f32> {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Vec2 {
+            x: -self.x,
+            y: -self.y,
+        }
+    }
+}
+
+impl std::ops::Neg for Vec3<f32> {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Vec3 {
+            x: -self.x,
+            y: -self.y,
+            z: -self.z,
+        }
+    }
+}
+
+impl std::ops::Neg for Vec4<f32> {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Vec4 {
+            x: -self.x,
+            y: -self.y,
+            z: -self.z,
+            w: -self.w,
+        }
+    }
+}
+
+impl std::ops::Neg for Vec2<i32> {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Vec2 {
+            x: -self.x,
+            y: -self.y,
+        }
+    }
+}
+
+impl std::ops::Neg for Vec3<i32> {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Vec3 {
+            x: -self.x,
+            y: -self.y,
+            z: -self.z,
+        }
+    }
+}
+
+impl std::ops::Neg for Vec4<i32> {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Vec4 {
+            x: -self.x,
+            y: -self.y,
+            z: -self.z,
+            w: -self.w,
+        }
+    }
+}


### PR DESCRIPTION
These changes swap out the inner `glam` types that existed in all vector types and most matrix types. In their place we now use the expected public fields for the type. 

These changes also add array indexing for vectors and matrices.