### PR TITLE
fix: remove unexpected cfg(feature = "validation") from generated tests

### DIFF
--- a/crates/wgsl-rs-macros/src/lib.rs
+++ b/crates/wgsl-rs-macros/src/lib.rs
@@ -268,11 +268,15 @@ fn gen_wgsl_module(
 ///
 /// This is used for modules that have imports, which cannot be validated at
 /// compile-time because the imported symbols aren't available during macro
-/// expansion.
+/// expansion. The `validate()` method is available on `Module` when the
+/// `wgsl-rs` crate has the `validation` feature enabled (the default). We
+/// gate on `#[cfg(test)]` only — not `feature = "validation"` — because the
+/// feature belongs to `wgsl-rs`, not the consuming crate, and checking it
+/// here would produce an "unexpected cfg" warning in downstream crates.
 fn gen_validation_test(module_ident: &syn::Ident) -> proc_macro2::TokenStream {
     let error_msg = format!("WGSL validation failed for module '{module_ident}'");
     quote! {
-        #[cfg(all(test, feature = "validation"))]
+        #[cfg(test)]
         #[test]
         fn __validate_wgsl() {
             WGSL_MODULE.validate().expect(#error_msg);


### PR DESCRIPTION
## Summary

- The `__validate_wgsl` test generated by `#[wgsl]` for modules with imports was gated on `cfg(all(test, feature = "validation"))`, but the `validation` feature belongs to the `wgsl-rs` crate, not the consuming crate
- This produced an "unexpected cfg condition value: validation" warning in downstream crates that import another `#[wgsl]` module
- Changed to `cfg(test)` only — the `validate()` method availability is already controlled by `wgsl-rs` feature flags