### PR TITLE
fix: use mangler for naming and types

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -460,3 +460,22 @@ const initializers with trybuild test.
 - Removed stray doc comment above `collect_linkage_constraints` in builder.rs.
 - Replied to all Copilot review comments (validate Err, validation gating,
   README correction, doc cleanup).
+
+### 2026-05-18: Robust name mangling (issue #112)
+
+- Replaced ad-hoc `{a}_{b}` concatenation with a centralized
+  `wgsl_rs_ir::mangle` module that adopts a simplified subset of
+  wesl-rs's `EscapeMangler`: each component containing `N>0` underscores
+  is rewritten as `_N{comp}` before components are joined with `_`,
+  making mangling a bijection. Migrated all sites: `render.rs`
+  (impl-method/const, enum variant, `FnPath::TypeMethod`,
+  `Expr::TypePath`), `monomorphize.rs` (`mangle_name`, `mangle_type`,
+  `type_to_key`, all 9 duplicate `{self_ty}_{method}` sites), and the
+  runtime instance-name builder in `wgsl-rs/src/lib.rs`. Entry-point
+  type-param slot encoding `{fn}_{i}` is intentionally left raw — its
+  collision risk is already covered by the reserved-names check and
+  changing it would break the public dispatch API surface. Added 9
+  collision-pair regression tests covering the cases from the issue
+  (`Foo_bar::baz` vs `Foo::bar_baz`, `Color_Red::Hot` vs
+  `Color::Red_Hot`, underscored consts, underscored methods on
+  underscored types, etc.).

--- a/crates/wgsl-rs-ir/src/lib.rs
+++ b/crates/wgsl-rs-ir/src/lib.rs
@@ -22,10 +22,12 @@
 //! args, impl method name mangling, builtin name translation, enum
 //! discriminant auto-increment) lives in the [`render`] module.
 
+pub mod mangle;
 mod render;
 mod substitute;
 mod types;
 
+pub use mangle::{mangle, unmangle};
 pub use render::{
     render_block, render_expr, render_item, render_items, render_module, render_stmt, render_type,
 };

--- a/crates/wgsl-rs-ir/src/mangle.rs
+++ b/crates/wgsl-rs-ir/src/mangle.rs
@@ -1,0 +1,191 @@
+//! Robust name mangling for WGSL identifiers.
+//!
+//! `wgsl-rs` composes WGSL identifiers from multiple Rust identifier
+//! components in several places (impl methods, impl constants, enum
+//! variants, monomorphized generics). A naive `{a}_{b}` join is ambiguous
+//! when components themselves contain underscores: `("Foo_bar", "baz")`
+//! and `("Foo", "bar_baz")` both produce `Foo_bar_baz`.
+//!
+//! This module implements a simplified subset of the
+//! [wesl-rs `EscapeMangler`](https://github.com/webgpu-tools/wesl-rs/blob/main/crates/wesl/src/mangle.rs)
+//! scheme: each component that contains `N>0` underscores is rewritten as
+//! `_N{component}` before the components are joined with `_`. This makes
+//! the mangling a bijection.
+//!
+//! # Examples
+//!
+//! ```
+//! use wgsl_rs_ir::mangle::{mangle, unmangle};
+//!
+//! assert_eq!(mangle(&["Foo", "bar"]), "Foo_bar");
+//! assert_eq!(mangle(&["Foo_bar", "baz"]), "_1Foo_bar_baz");
+//! assert_eq!(mangle(&["Foo", "bar_baz"]), "Foo__1bar_baz");
+//!
+//! assert_eq!(
+//!     unmangle("Foo_bar").as_deref(),
+//!     Some(&["Foo".to_string(), "bar".to_string()][..])
+//! );
+//! ```
+//!
+//! Inputs are required to be valid Rust identifiers (matching
+//! `[A-Za-z_][A-Za-z0-9_]*`). No other characters are escaped.
+//!
+//! For nested mangling (e.g. building a mangled name from a type tree),
+//! treat each inner mangled string as one opaque component and call
+//! [`mangle`] again at the outer level. Inner underscores will be
+//! re-counted and escaped at the outer level so the composition remains
+//! unambiguous.
+
+/// Escape a single identifier component. Components containing `_` are
+/// prefixed with `_N` where `N` is the underscore count.
+fn escape_component(comp: &str) -> String {
+    let n = comp.chars().filter(|c| *c == '_').count();
+    if n == 0 {
+        comp.to_string()
+    } else {
+        format!("_{n}{comp}")
+    }
+}
+
+/// Reverse `escape_component`, consuming as many `_`-separated parts from
+/// `parts` as needed to reconstruct a single original component.
+///
+/// `part` is the current part; if empty, the next part begins with the
+/// count digits and we consume `count` additional parts after the first
+/// in order to glue them back with `_`.
+fn unescape_component<'a>(part: &str, parts: &mut impl Iterator<Item = &'a str>) -> Option<String> {
+    if !part.is_empty() {
+        // Component with no underscores: pass through unchanged.
+        return Some(part.to_string());
+    }
+    // An empty `part` signals that the next part starts with a digit
+    // count followed by the first chunk of the original component.
+    let first = parts.next()?;
+    let digits: usize = first.chars().take_while(|c| c.is_ascii_digit()).count();
+    if digits == 0 {
+        return None;
+    }
+    let count: usize = first[..digits].parse().ok()?;
+    let rem = &first[digits..];
+    let mut chunks: Vec<String> = Vec::with_capacity(count + 1);
+    chunks.push(rem.to_string());
+    for _ in 0..count {
+        chunks.push(parts.next()?.to_string());
+    }
+    Some(chunks.join("_"))
+}
+
+/// Mangle a list of identifier components into a single WGSL-safe
+/// identifier.
+///
+/// Each component containing underscores is rewritten as `_N{component}`
+/// (where `N` is the underscore count) before the components are joined
+/// with `_`. The result is a valid WGSL identifier and the mangling is
+/// reversible via [`unmangle`].
+pub fn mangle(components: &[&str]) -> String {
+    let mut out = String::new();
+    for (i, c) in components.iter().enumerate() {
+        if i > 0 {
+            out.push('_');
+        }
+        out.push_str(&escape_component(c));
+    }
+    out
+}
+
+/// Reverse of [`mangle`]. Returns `None` if `s` is not a well-formed
+/// mangled string.
+pub fn unmangle(s: &str) -> Option<Vec<String>> {
+    let mut components = Vec::new();
+    let mut parts = s.split('_');
+    while let Some(part) = parts.next() {
+        components.push(unescape_component(part, &mut parts)?);
+    }
+    Some(components)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_underscore_components_unchanged() {
+        assert_eq!(mangle(&["Foo", "bar"]), "Foo_bar");
+        assert_eq!(mangle(&["Color", "Red"]), "Color_Red");
+    }
+
+    #[test]
+    fn underscore_in_first_component_escapes() {
+        assert_eq!(mangle(&["Foo_bar", "baz"]), "_1Foo_bar_baz");
+        assert_eq!(mangle(&["My_Struct", "do_thing"]), "_1My_Struct__1do_thing");
+    }
+
+    #[test]
+    fn underscore_in_second_component_escapes() {
+        assert_eq!(mangle(&["Foo", "bar_baz"]), "Foo__1bar_baz");
+    }
+
+    #[test]
+    fn many_underscores_use_correct_count() {
+        assert_eq!(mangle(&["a_b_c"]), "_2a_b_c");
+        assert_eq!(mangle(&["___"]), "_3___");
+    }
+
+    /// The canonical collision case from issue #112: an impl on a
+    /// underscored type vs. an impl method with an underscored name must
+    /// produce distinct mangled names.
+    #[test]
+    fn collision_pair_impl_method_underscored_type_vs_method() {
+        let a = mangle(&["Foo_bar", "baz"]);
+        let b = mangle(&["Foo", "bar_baz"]);
+        assert_ne!(a, b, "{a} == {b}");
+    }
+
+    #[test]
+    fn collision_pair_enum_variant_underscored_name() {
+        let a = mangle(&["Color_Red", "Hot"]);
+        let b = mangle(&["Color", "Red_Hot"]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn unmangle_inverts_mangle() {
+        let cases: &[&[&str]] = &[
+            &["Foo", "bar"],
+            &["Foo_bar", "baz"],
+            &["Foo", "bar_baz"],
+            &["My_Struct", "do_thing"],
+            &["only_one"],
+            &["plain"],
+            &["a_b_c", "d", "e_f"],
+            &["___", "x"],
+        ];
+        for case in cases {
+            let m = mangle(case);
+            let parts: Vec<String> = case.iter().map(|s| s.to_string()).collect();
+            assert_eq!(
+                unmangle(&m),
+                Some(parts.clone()),
+                "round-trip failed for {case:?} -> {m}"
+            );
+        }
+    }
+
+    #[test]
+    fn unmangle_rejects_garbage() {
+        // A leading `_` without a following digit count is invalid.
+        assert_eq!(unmangle("_xFoo"), None);
+    }
+
+    /// Composition: an outer mangle of an inner mangled string must
+    /// remain a bijection — and the resulting outer mangling is still
+    /// roundtrippable as a flat component list at the outer level.
+    #[test]
+    fn nested_composition_is_unambiguous() {
+        let inner_a = mangle(&["array", "f32"]); // "array_f32"
+        let inner_b = mangle(&["array_f32"]); // "_1array_f32" (forced distinct)
+        let outer_a = mangle(&["wrap", &inner_a]);
+        let outer_b = mangle(&["wrap", &inner_b]);
+        assert_ne!(outer_a, outer_b);
+    }
+}

--- a/crates/wgsl-rs-ir/src/render.rs
+++ b/crates/wgsl-rs-ir/src/render.rs
@@ -11,7 +11,7 @@
 //!   [`builtin_lookup`]).
 //! * `Expr::Struct` field names are dropped and emitted positionally.
 //! * `Impl` blocks have their methods / constants name-mangled to
-//!   `StructName_member`.
+//!   `StructName_member` (via [`crate::mangle`], which escapes underscores).
 //! * Enum discriminants auto-increment starting from 0.
 //! * `let mut` (`Local::mutable == true`) renders as `var`; `let` renders as
 //!   `let`.
@@ -256,7 +256,7 @@ fn write_item(w: &mut Writer, item: &Item) {
             for ii in &i.items {
                 match ii {
                     ImplItem::Const(c) => {
-                        let mangled = format!("{}_{}", i.self_ty, c.name);
+                        let mangled = mangle(&[&i.self_ty, &c.name]);
                         let mc = ItemConst {
                             name: mangled,
                             ty: c.ty.clone(),
@@ -267,7 +267,7 @@ fn write_item(w: &mut Writer, item: &Item) {
                         w.newline();
                     }
                     ImplItem::Fn(f) => {
-                        let mangled = format!("{}_{}", i.self_ty, f.name);
+                        let mangled = mangle(&[&i.self_ty, &f.name]);
                         w.blank_line();
                         write_fn(w, f, Some(&mangled));
                     }
@@ -288,11 +288,10 @@ fn write_item(w: &mut Writer, item: &Item) {
                 } else {
                     next
                 };
+                let variant_name = mangle(&[&e.name, &v.name]);
                 w.start_line();
                 w.write("const ");
-                w.write(&e.name);
-                w.write("_");
-                w.write(&v.name);
+                w.write(&variant_name);
                 w.write(": u32 = ");
                 w.write(&format!("{value}u"));
                 w.write(";");
@@ -747,9 +746,7 @@ fn write_expr(w: &mut Writer, e: &Expr) {
             w.write(field);
         }
         Expr::TypePath { ty, member } => {
-            w.write(ty);
-            w.write("_");
-            w.write(member);
+            w.write(&mangle(&[ty, member]));
         }
         Expr::Reference(inner) => {
             w.write("&");
@@ -774,9 +771,7 @@ fn write_fn_path(w: &mut Writer, p: &FnPath) {
             w.write(translated);
         }
         FnPath::TypeMethod { ty, method } => {
-            w.write(ty);
-            w.write("_");
-            w.write(method);
+            w.write(&mangle(&[ty, method]));
         }
     }
 }

--- a/crates/wgsl-rs-ir/tests/smoke.rs
+++ b/crates/wgsl-rs-ir/tests/smoke.rs
@@ -146,7 +146,9 @@ fn renders_struct_and_impl() {
     };
     let wgsl = render_module(&m);
     assert!(wgsl.contains("struct Point {"), "got: {wgsl}");
-    assert!(wgsl.contains("fn Point_x_only(p: Point)"), "got: {wgsl}");
+    // `x_only` contains an underscore, so under the robust mangling
+    // scheme (issue #112) the joined impl-method name is escaped.
+    assert!(wgsl.contains("fn Point__1x_only(p: Point)"), "got: {wgsl}");
 }
 
 #[test]

--- a/crates/wgsl-rs-macros/src/builder.rs
+++ b/crates/wgsl-rs-macros/src/builder.rs
@@ -121,6 +121,9 @@ pub(crate) fn gen_builder(crate_path: &syn::Path, wgsl_module: &parse::ItemMod) 
         };
         let fn_name_str = f.ident.to_string();
         for (i, tp) in f.type_params.iter().enumerate() {
+            // Entry-point slot encoding `{fn}_{i}` is intentionally not
+            // run through `wgsl_rs_ir::mangle`; see comment in
+            // `parse.rs` near the matching site and issue #112.
             let encoded = format!("{fn_name_str}_{i}");
             let name = format_ident!("{}_{}", tp, fn_name_str);
             ep_slots.push(EntryPointSlot {

--- a/crates/wgsl-rs-macros/src/lib.rs
+++ b/crates/wgsl-rs-macros/src/lib.rs
@@ -246,6 +246,9 @@ fn collect_entry_point_type_params(wgsl_module: &parse::ItemMod) -> Vec<String> 
         }
         let fn_name = f.ident.to_string();
         for (i, _tp) in f.type_params.iter().enumerate() {
+            // Entry-point slot encoding `{fn}_{i}` is intentionally not
+            // run through `wgsl_rs_ir::mangle`; see comment in
+            // `parse.rs` near the matching site and issue #112.
             let encoded = format!("{fn_name}_{i}");
             if seen.insert(encoded.clone()) {
                 params.push(encoded);

--- a/crates/wgsl-rs-macros/src/monomorphize.rs
+++ b/crates/wgsl-rs-macros/src/monomorphize.rs
@@ -18,6 +18,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use proc_macro2::Span;
 use syn::Ident;
+use wgsl_rs_ir::mangle;
 
 use crate::{
     parse::{Block, Expr, FnPath, Item, ItemFn, ItemImpl, ItemMod, ItemStruct, ReturnType, Type},
@@ -236,7 +237,10 @@ impl MonoCtx {
                         for ii in &impl_item.items {
                             match ii {
                                 crate::parse::ImplItem::Fn(f) => {
-                                    let mangled = format!("{}_{}", impl_item.self_ty, f.ident);
+                                    let mangled = mangle(&[
+                                        &impl_item.self_ty.to_string(),
+                                        &f.ident.to_string(),
+                                    ]);
                                     if !reserved_names.insert(mangled.clone()) {
                                         return Err(crate::parse::Error::unsupported(
                                             f.ident.span(),
@@ -248,7 +252,10 @@ impl MonoCtx {
                                     }
                                 }
                                 crate::parse::ImplItem::Const(c) => {
-                                    let mangled = format!("{}_{}", impl_item.self_ty, c.ident);
+                                    let mangled = mangle(&[
+                                        &impl_item.self_ty.to_string(),
+                                        &c.ident.to_string(),
+                                    ]);
                                     if !reserved_names.insert(mangled.clone()) {
                                         return Err(crate::parse::Error::unsupported(
                                             c.ident.span(),
@@ -550,7 +557,8 @@ impl MonoCtx {
                 for ii in &impl_template.items {
                     match ii {
                         crate::parse::ImplItem::Fn(f) => {
-                            let method_mangled_name = format!("{}_{}", mangled_name, f.ident);
+                            let method_mangled_name =
+                                mangle(&[&mangled_name, &f.ident.to_string()]);
 
                             if self.reserved_names.contains(&method_mangled_name) {
                                 return Err(crate::parse::Error::unsupported(
@@ -583,7 +591,7 @@ impl MonoCtx {
                             self.generated.push(Item::Fn(Box::new(mono_fn)));
                         }
                         crate::parse::ImplItem::Const(c) => {
-                            let const_mangled_name = format!("{}_{}", mangled_name, c.ident);
+                            let const_mangled_name = mangle(&[&mangled_name, &c.ident.to_string()]);
 
                             let mut mono_const = (**c).clone();
                             mono_const.ident = Ident::new(&const_mangled_name, c.ident.span());
@@ -695,7 +703,9 @@ impl ParseVisitorMut for MonoCtx {
         {
             let fn_name = match path {
                 FnPath::Ident(id) => id.to_string(),
-                FnPath::TypeMethod { ty, method, .. } => format!("{}_{}", ty, method),
+                FnPath::TypeMethod { ty, method, .. } => {
+                    mangle(&[&ty.to_string(), &method.to_string()])
+                }
             };
             let span = match path {
                 FnPath::Ident(id) => id.span(),
@@ -942,7 +952,9 @@ impl ParseVisitorMut for RewriteNamesVisitor<'_> {
                 // where `Type::method` is a known template fn).
                 let fn_name = match &*path {
                     FnPath::Ident(id) => id.to_string(),
-                    FnPath::TypeMethod { ty, method, .. } => format!("{}_{}", ty, method),
+                    FnPath::TypeMethod { ty, method, .. } => {
+                        mangle(&[&ty.to_string(), &method.to_string()])
+                    }
                 };
                 if self.fn_templates.contains_key(&fn_name) {
                     let mangled = mangle_name(&fn_name, type_args)
@@ -960,7 +972,7 @@ impl ParseVisitorMut for RewriteNamesVisitor<'_> {
                     if self.struct_templates.contains_key(&ty_name) && !type_args.is_empty() {
                         let mangled_struct = mangle_name(&ty_name, type_args)
                             .expect("mangle_name should not fail for concrete types");
-                        let mangled_fn = format!("{}_{}", mangled_struct, method);
+                        let mangled_fn = mangle(&[&mangled_struct, &method.to_string()]);
                         let span = ty.span();
                         *path = FnPath::Ident(Ident::new(&mangled_fn, span));
                         type_args.clear();
@@ -1150,7 +1162,7 @@ impl ParseVisitorMut for CrossModuleVisitor<'_> {
                 // `OtherStruct` is a cross-module generic struct.
                 if let FnPath::TypeMethod { ty, method, .. } = &*path {
                     let ty_name = ty.to_string();
-                    let combined = format!("{ty_name}_{method}");
+                    let combined = mangle(&[&ty_name, &method.to_string()]);
                     if !self.local_struct_templates.contains_key(&ty_name)
                         && !self.local_templates.contains_key(&combined)
                     {
@@ -1160,7 +1172,7 @@ impl ParseVisitorMut for CrossModuleVisitor<'_> {
                             .collect::<Result<_, _>>()?;
                         let parse_type_args: Vec<Type> = type_args.clone();
                         let mangled_struct = mangle_name(&ty_name, type_args)?;
-                        let mangled_fn = format!("{}_{}", mangled_struct, method);
+                        let mangled_fn = mangle(&[&mangled_struct, &method.to_string()]);
                         let span = ty.span();
                         *path = FnPath::Ident(Ident::new(&mangled_fn, span));
                         type_args.clear();
@@ -1183,7 +1195,9 @@ impl ParseVisitorMut for CrossModuleVisitor<'_> {
                 if !type_args.is_empty() {
                     let fn_name = match &*path {
                         FnPath::Ident(id) => id.to_string(),
-                        FnPath::TypeMethod { ty, method, .. } => format!("{}_{}", ty, method),
+                        FnPath::TypeMethod { ty, method, .. } => {
+                            mangle(&[&ty.to_string(), &method.to_string()])
+                        }
                     };
                     if !self.local_templates.contains_key(&fn_name) {
                         if self.import_paths.is_empty() {
@@ -1413,16 +1427,33 @@ fn type_to_ident(ty: &Type, span: Span) -> Ident {
 }
 
 // ===== Name mangling =====
+//
+// Uses [`wgsl_rs_ir::mangle`] to compose components. Each component that
+// contains underscores is escaped as `_N{comp}` so that mangled names are
+// unambiguous. See issue #112 for motivation.
 
+/// Mangle a generic instantiation name. The result is
+/// `mangle(&[base, &arg1_mangled, &arg2_mangled, ...])`. Each
+/// `argN_mangled` is itself the output of [`mangle_type`] and is treated
+/// here as a single opaque component (the outer [`mangle`] will re-escape
+/// any internal underscores).
 fn mangle_name(base: &str, type_args: &[Type]) -> Result<String, crate::parse::Error> {
-    let mut name = base.to_string();
-    for ty in type_args {
-        name.push('_');
-        name.push_str(&mangle_type(ty)?);
+    let mangled_args: Vec<String> = type_args
+        .iter()
+        .map(mangle_type)
+        .collect::<Result<_, _>>()?;
+    let mut components: Vec<&str> = Vec::with_capacity(1 + mangled_args.len());
+    components.push(base);
+    for s in &mangled_args {
+        components.push(s.as_str());
     }
-    Ok(name)
+    Ok(mangle(&components))
 }
 
+/// Mangle a [`Type`] to a single component string suitable for use as a
+/// component in [`mangle`]. Compound types (e.g. `array<f32, 3>`) are
+/// themselves composed via [`mangle`] so their structure is preserved
+/// unambiguously through nesting.
 fn mangle_type(ty: &Type) -> Result<String, crate::parse::Error> {
     Ok(match ty {
         Type::Scalar { ty: scalar, .. } => scalar.wgsl_name().to_string(),
@@ -1440,14 +1471,28 @@ fn mangle_type(ty: &Type) -> Result<String, crate::parse::Error> {
                     .iter()
                     .map(mangle_type)
                     .collect::<Result<_, _>>()?;
-                format!("{}_{}", ident, mangled_args.join("_"))
+                let ident_str = ident.to_string();
+                let mut components: Vec<&str> = Vec::with_capacity(1 + mangled_args.len());
+                components.push(&ident_str);
+                for s in &mangled_args {
+                    components.push(s.as_str());
+                }
+                mangle(&components)
             }
         }
         Type::Array { elem, len, .. } => {
-            format!("array_{}_{}", mangle_type(elem)?, len_to_string(len))
+            let elem_m = mangle_type(elem)?;
+            let len_s = len_to_string(len);
+            mangle(&["array", &elem_m, &len_s])
         }
-        Type::RuntimeArray { elem, .. } => format!("array_{}", mangle_type(elem)?),
-        Type::Atomic { elem, .. } => format!("atomic_{}", mangle_type(elem)?),
+        Type::RuntimeArray { elem, .. } => {
+            let elem_m = mangle_type(elem)?;
+            mangle(&["array", &elem_m])
+        }
+        Type::Atomic { elem, .. } => {
+            let elem_m = mangle_type(elem)?;
+            mangle(&["atomic", &elem_m])
+        }
         Type::Sampler { .. } => "sampler".to_string(),
         Type::SamplerComparison { .. } => "sampler_comparison".to_string(),
         Type::Texture { kind, .. } => kind.wgsl_name().replace("texture_", "tex_"),
@@ -1465,7 +1510,8 @@ fn mangle_type(ty: &Type) -> Result<String, crate::parse::Error> {
                 crate::parse::AddressSpace::Private => "private",
                 crate::parse::AddressSpace::Workgroup => "workgroup",
             };
-            format!("ptr_{}_{}", space, mangle_type(elem)?)
+            let elem_m = mangle_type(elem)?;
+            mangle(&["ptr", space, &elem_m])
         }
         Type::TypeParam { ident } => {
             // This shouldn't happen for fully resolved instantiations
@@ -1508,7 +1554,13 @@ fn type_to_key(ty: &Type) -> Result<TypeKey, crate::parse::Error> {
                     .iter()
                     .map(mangle_type)
                     .collect::<Result<_, _>>()?;
-                TypeKey::Struct(format!("{}_{}", ident, mangled_args.join("_")))
+                let ident_str = ident.to_string();
+                let mut components: Vec<&str> = Vec::with_capacity(1 + mangled_args.len());
+                components.push(&ident_str);
+                for s in &mangled_args {
+                    components.push(s.as_str());
+                }
+                TypeKey::Struct(mangle(&components))
             }
         }
         Type::Array { elem, len, .. } => {
@@ -2139,8 +2191,11 @@ mod test {
             wgsl.contains("struct Pair_f32"),
             "Expected monomorphized struct, got:\n{wgsl}"
         );
+        // The monomorphized struct name `Pair_f32` contains an
+        // underscore, so the method-mangling step (issue #112) escapes
+        // it to `_1Pair_f32_first`.
         assert!(
-            wgsl.contains("fn Pair_f32_first("),
+            wgsl.contains("fn _1Pair_f32_first("),
             "Expected monomorphized method, got:\n{wgsl}"
         );
         // The method should take Pair_f32 and return f32

--- a/crates/wgsl-rs-macros/src/parse.rs
+++ b/crates/wgsl-rs-macros/src/parse.rs
@@ -4123,6 +4123,11 @@ impl TryFrom<&syn::ItemFn> for ItemFn {
             ParseContext::from_type_params(type_params.iter().cloned())
         } else {
             let fn_name = sig.ident.to_string();
+            // Entry-point type-param slot encoding: `{fn}_{i}`. This is
+            // intentionally NOT routed through `wgsl_rs_ir::mangle` so that
+            // the public slot-name surface used by the dispatch APIs stays
+            // stable. Collisions with user identifiers are caught by the
+            // reserved-names check in `monomorphize`. See issue #112.
             let renamed = type_params.iter().enumerate().map(|(i, id)| {
                 let source = id.to_string();
                 let encoded = format!("{fn_name}_{i}");
@@ -6902,6 +6907,163 @@ mod test {
             wgsl.contains("fn Light_get"),
             "Expected 'fn Light_get' in WGSL output, got: {}",
             wgsl
+        );
+    }
+
+    // ===== Regression tests for issue #112 (robust mangling) =====
+    //
+    // These tests demonstrate that name pairs which would have collided
+    // under the old `{a}_{b}` scheme now produce distinct WGSL identifiers
+    // under the `wgsl_rs_ir::mangle` escape scheme.
+
+    #[test]
+    fn impl_method_on_underscored_type_is_escaped() {
+        // `impl My_Light { fn intensity() }` — `My_Light` contains an
+        // underscore, so the joined method name must be escaped.
+        let item: syn::Item = syn::parse_quote! {
+            impl My_Light {
+                pub fn intensity(l: My_Light) -> f32 { l.x }
+            }
+        };
+        let item = Item::try_from(&item).unwrap();
+        let wgsl = item.to_wgsl();
+        assert!(
+            wgsl.contains("fn _1My_Light_intensity"),
+            "Expected escaped method name, got: {wgsl}"
+        );
+    }
+
+    #[test]
+    fn impl_method_with_underscored_name_is_escaped() {
+        // `impl Light { fn get_intensity() }` — the method name contains
+        // an underscore, so it must be escaped at the second position.
+        let item: syn::Item = syn::parse_quote! {
+            impl Light {
+                pub fn get_intensity(l: Light) -> f32 { l.x }
+            }
+        };
+        let item = Item::try_from(&item).unwrap();
+        let wgsl = item.to_wgsl();
+        assert!(
+            wgsl.contains("fn Light__1get_intensity"),
+            "Expected escaped method name, got: {wgsl}"
+        );
+    }
+
+    /// The canonical collision case from issue #112:
+    /// `impl Foo_bar { fn baz() }` vs. `impl Foo { fn bar_baz() }`. Under
+    /// the old scheme both produced `Foo_bar_baz`; under the new scheme
+    /// they must differ.
+    #[test]
+    fn collision_pair_underscored_type_vs_underscored_method() {
+        let a_item: syn::Item = syn::parse_quote! {
+            impl Foo_bar {
+                pub fn baz(x: Foo_bar) -> f32 { x.v }
+            }
+        };
+        let b_item: syn::Item = syn::parse_quote! {
+            impl Foo {
+                pub fn bar_baz(x: Foo) -> f32 { x.v }
+            }
+        };
+        let a_wgsl = Item::try_from(&a_item).unwrap().to_wgsl();
+        let b_wgsl = Item::try_from(&b_item).unwrap().to_wgsl();
+
+        // Extract the function names.
+        let a_has = a_wgsl.contains("fn _1Foo_bar_baz");
+        let b_has = b_wgsl.contains("fn Foo__1bar_baz");
+        assert!(a_has, "a: {a_wgsl}");
+        assert!(b_has, "b: {b_wgsl}");
+
+        // And critically, neither produces the old colliding name.
+        assert!(
+            !a_wgsl.contains("fn Foo_bar_baz"),
+            "a should not emit the legacy colliding name: {a_wgsl}"
+        );
+        assert!(
+            !b_wgsl.contains("fn Foo_bar_baz"),
+            "b should not emit the legacy colliding name: {b_wgsl}"
+        );
+    }
+
+    #[test]
+    fn impl_const_with_underscored_name_is_escaped() {
+        // `impl Light { const DEFAULT_INTENSITY: f32 = ... }`.
+        let item: syn::Item = syn::parse_quote! {
+            impl Light {
+                pub const DEFAULT_INTENSITY: f32 = 1.0;
+            }
+        };
+        let item = Item::try_from(&item).unwrap();
+        let wgsl = item.to_wgsl();
+        assert!(
+            wgsl.contains("const Light__1DEFAULT_INTENSITY"),
+            "Expected escaped const name, got: {wgsl}"
+        );
+    }
+
+    #[test]
+    fn type_path_with_underscored_const_is_escaped() {
+        // A reference `Light::DEFAULT_INTENSITY` must also use the
+        // escaping rule so it matches its definition.
+        let expr: syn::Expr = syn::parse_quote! { Light::DEFAULT_INTENSITY };
+        let expr = Expr::try_from(&expr).unwrap();
+        let wgsl = expr.to_wgsl();
+        assert_eq!(wgsl, "Light__1DEFAULT_INTENSITY");
+    }
+
+    #[test]
+    fn type_method_call_with_underscored_method_is_escaped() {
+        // A reference `Light::get_intensity(...)` must match its def.
+        let expr: syn::Expr = syn::parse_quote! { Light::get_intensity(l) };
+        let expr = Expr::try_from(&expr).unwrap();
+        let wgsl = expr.to_wgsl();
+        assert!(
+            wgsl.starts_with("Light__1get_intensity("),
+            "Expected escaped method call, got: {wgsl}"
+        );
+    }
+
+    #[test]
+    fn enum_variant_with_underscore_is_escaped() {
+        // `enum Color { Red_Hot }` — variant name contains an underscore.
+        let item: syn::Item = syn::parse_quote! {
+            #[repr(u32)]
+            pub enum Color {
+                Red_Hot,
+            }
+        };
+        let item = Item::try_from(&item).unwrap();
+        let wgsl = item.to_wgsl();
+        assert!(
+            wgsl.contains("const Color__1Red_Hot"),
+            "Expected escaped enum variant, got: {wgsl}"
+        );
+    }
+
+    #[test]
+    fn collision_pair_enum_variant_vs_underscored_enum_name() {
+        // `enum Color { Red_Hot }` vs. `enum Color_Red { Hot }`.
+        // Old scheme: both produce `Color_Red_Hot`. New scheme: distinct.
+        let a: syn::Item = syn::parse_quote! {
+            #[repr(u32)] pub enum Color { Red_Hot, }
+        };
+        let b: syn::Item = syn::parse_quote! {
+            #[repr(u32)] pub enum Color_Red { Hot, }
+        };
+        let a_wgsl = Item::try_from(&a).unwrap().to_wgsl();
+        let b_wgsl = Item::try_from(&b).unwrap().to_wgsl();
+
+        assert!(a_wgsl.contains("const Color__1Red_Hot"), "a: {a_wgsl}");
+        assert!(b_wgsl.contains("const _1Color_Red_Hot"), "b: {b_wgsl}");
+
+        assert!(
+            !a_wgsl.contains("const Color_Red_Hot:"),
+            "a should not emit the legacy colliding name: {a_wgsl}"
+        );
+        assert!(
+            !b_wgsl.contains("const Color_Red_Hot:"),
+            "b should not emit the legacy colliding name: {b_wgsl}"
         );
     }
 

--- a/crates/wgsl-rs/src/lib.rs
+++ b/crates/wgsl-rs/src/lib.rs
@@ -296,15 +296,19 @@ fn instantiate_template_into(
     ir::substitute_items(&mut items, &subst);
 
     // Mangle the template's name to a concrete instance name so multiple
-    // monomorphizations can coexist. The new name is
-    // `{template_name}_{mangled_arg1}_{mangled_arg2}_...`. Rewrite that
-    // name everywhere it appears in the items (struct headers, impl
-    // self_ty, free fn names, references in expressions/types).
-    let mut instance_name = template.name.to_string();
-    for arg in mangled_type_args {
-        instance_name.push('_');
-        instance_name.push_str(arg);
-    }
+    // monomorphizations can coexist. Uses `ir::mangle` so that names with
+    // underscores in either the template name or the type-arg-mangled
+    // strings are escaped unambiguously (see issue #112).
+    let instance_name = if mangled_type_args.is_empty() {
+        template.name.to_string()
+    } else {
+        let mut components: Vec<&str> = Vec::with_capacity(1 + mangled_type_args.len());
+        components.push(template.name);
+        for s in mangled_type_args {
+            components.push(s.as_str());
+        }
+        ir::mangle(&components)
+    };
     if instance_name != template.name {
         ir::rename_items(&mut items, template.name, &instance_name);
     }
@@ -470,15 +474,18 @@ mod test {
             "trait_provider should contain f32_scale, got:\n{provider_src}"
         );
 
-        // Verify consumer module generates apply_scale_f32 that calls f32_scale
+        // Verify consumer module generates the monomorphized `apply_scale<f32>`
+        // and that it calls `f32_scale`. Under the robust mangling scheme
+        // (issue #112), `apply_scale` has an underscore so the joined name
+        // is `_1apply_scale_f32`, not `apply_scale_f32`.
         let consumer_src = trait_consumer::WGSL_MODULE.wgsl_source();
         assert!(
-            consumer_src.contains("fn apply_scale_f32("),
-            "trait_consumer should contain apply_scale_f32, got:\n{consumer_src}"
+            consumer_src.contains("fn _1apply_scale_f32("),
+            "trait_consumer should contain _1apply_scale_f32, got:\n{consumer_src}"
         );
         assert!(
             consumer_src.contains("f32_scale("),
-            "apply_scale_f32 should call f32_scale, got:\n{consumer_src}"
+            "_1apply_scale_f32 should call f32_scale, got:\n{consumer_src}"
         );
         assert!(
             consumer_src.contains("fn f32_scale("),

--- a/crates/wgsl-rs/tests/multiple_import_resolution.rs
+++ b/crates/wgsl-rs/tests/multiple_import_resolution.rs
@@ -30,8 +30,10 @@ mod consumer {
 fn resolves_template_instantiation_from_correct_import() {
     let _ = consumer::apply();
     let full_src = consumer::WGSL_MODULE.wgsl_source();
+    // Under the robust mangling scheme (issue #112) the underscore in
+    // `external_identity` causes it to be escaped to `_1external_identity`.
     assert!(
-        full_src.contains("fn external_identity_f32("),
-        "Expected instantiated external_identity_f32 in output, got:\n{full_src}"
+        full_src.contains("fn _1external_identity_f32("),
+        "Expected instantiated _1external_identity_f32 in output, got:\n{full_src}"
     );
 }


### PR DESCRIPTION
Fixes #112 