### PR TITLE
feat: WGSL struct memory layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3762,6 +3762,23 @@ name = "wgsl-rs-ir"
 version = "0.1.0"
 
 [[package]]
+name = "wgsl-rs-layout"
+version = "0.1.0"
+dependencies = [
+ "wgsl-rs",
+ "wgsl-rs-layout-macros",
+]
+
+[[package]]
+name = "wgsl-rs-layout-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "wgsl-rs-macros"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ members = [
   "crates/roundtrip-tests",
   "crates/wgsl-rs",
   "crates/wgsl-rs-ir",
+  "crates/wgsl-rs-layout",
+  "crates/wgsl-rs-layout-macros",
   "crates/wgsl-rs-macros",
   "crates/xtask"
 ]

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -238,3 +238,57 @@ formula. The CPU path writes the same data directly via `TextureDepth2D::set()`.
 Both paths compute identical pixel values — only the delivery mechanism differs.
 This pattern is reusable for any future cross-platform test that needs
 pre-populated depth data.
+
+### 2026-05-29: `wgsl-rs-layout` — a standalone extension crate
+
+`wgsl-rs` needs to inform tools of how to marshal data to/from the GPU. The
+WGSL spec §14.4.1 defines strict alignment, size, and offset rules for all
+types, and getting these wrong silently produces bad data. A `#[derive(Layout)]`
+macro computes these values at compile time.
+
+The extension lives in two new crates:
+- `wgsl-rs-layout` (regular lib): `WgslLayout` and `Layout` traits, `FieldLayout`
+  struct, and `WgslLayout` impls for all WGSL scalar/vector/matrix/array types.
+- `wgsl-rs-layout-macros` (proc-macro): `#[derive(Layout)]` for structs.
+
+This is the first extension that dogfoods `wgsl-rs` as a dependency — it depends
+on `wgsl-rs` for concrete type definitions (`Vec3f`, `Mat4x4f`, `Atomic<u32>`,
+etc.) but is otherwise self-contained. It demonstrates the extension pattern
+where downstream crates consume `wgsl-rs` types directly.
+
+**How it works:**
+1. The derive macro generates an inherent `impl` with private associated constants
+   (`__OFFSET_0`, `__SIZE_0`, `__ALIGN_0`, ...) for each field, computed via
+   `roundUp` per the spec's recursive definition. These are accessible from both
+   the `WgslLayout` and `Layout` trait impls through `Self::`.
+2. `WgslLayout` is implemented for all built-in types (scalars, vectors, matrices,
+   arrays). Each type is a simple const mapping per the spec table.
+3. `Layout` extends `WgslLayout` with `FIELDS: &'static [FieldLayout]` for
+   per-field offset/size/align/pad_before info.
+4. Generic structs are supported — type parameters receive a `T: WgslLayout` bound.
+
+**`FieldLayout::pad_before`:**
+Inter-field padding is the gap between successive fields caused by alignment
+requirements. `pad_before` on field `i` is the dead bytes between the end of
+field `i-1` and the start of field `i`. It is always 0 for the first field.
+Tools *must* write zero bytes into these gaps when marshalling data. The
+`FieldLayout` struct documents this prominently with concrete examples.
+
+**Runtime arrays:** `RuntimeArray<T>::SIZE` is 0 (runtime-dependent).
+
+**Empty structs:** `SIZE = 0, ALIGN = 1, FIELDS = &[]` (identity element,
+consistent with common practice; WGSL spec does not define this case).
+
+**What this is NOT:** The derive only computes WGSL memory layout — it does not
+attempt to align Rust CPU-side layout to match. `#[repr(C)]` on a struct with a
+`Vec3f` field gives Rust align 4, but WGSL `vec3<f32>` has align 16. The crate
+stays focused on answering "where do bytes go in the GPU buffer?"
+
+### 2026-05-29: Inherent consts over deeply nested inline expressions
+
+The initial inline expression approach (`roundUp(roundUp(0 + s0,a1) + s1,a2)`)
+broke on structs with 3+ fields because Rust's const evaluator hits complexity
+limits. The fix uses inherent associated constants (`Self::__OFFSET_0`,
+`Self::__SIZE_0`, etc.) to break the recursive computation into individually
+evaluable steps. These consts live on the struct (not any trait impl) so they're
+visible from both the `WgslLayout` and `Layout` trait impls.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -264,15 +264,14 @@ where downstream crates consume `wgsl-rs` types directly.
 2. `WgslLayout` is implemented for all built-in types (scalars, vectors, matrices,
    arrays). Each type is a simple const mapping per the spec table.
 3. `Layout` extends `WgslLayout` with `FIELDS: &'static [FieldLayout]` for
-   per-field offset/size/align/pad_before info.
+   per-field offset/size/align/pad_after info.
 4. Generic structs are supported — type parameters receive a `T: WgslLayout` bound.
 
-**`FieldLayout::pad_before`:**
-Inter-field padding is the gap between successive fields caused by alignment
-requirements. `pad_before` on field `i` is the dead bytes between the end of
-field `i-1` and the start of field `i`. It is always 0 for the first field.
-Tools *must* write zero bytes into these gaps when marshalling data. The
-`FieldLayout` struct documents this prominently with concrete examples.
+**`FieldLayout::pad_after`:**
+Inter-field padding is expressed as bytes after each field's data: `pad_after`
+on field `i` is the gap between the end of field `i` and the start of the next
+field (or the struct end for the last field). This is intuitive for
+sequential marshalling — write the field, then write `pad_after` zero bytes.
 
 **Runtime arrays:** `RuntimeArray<T>::SIZE` is 0 (runtime-dependent).
 

--- a/crates/wgsl-rs-layout-macros/Cargo.toml
+++ b/crates/wgsl-rs-layout-macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "wgsl-rs-layout-macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+bench = false
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true

--- a/crates/wgsl-rs-layout-macros/src/lib.rs
+++ b/crates/wgsl-rs-layout-macros/src/lib.rs
@@ -55,6 +55,10 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
             impl #impl_generics ::wgsl_rs_layout::WgslLayout for #struct_name #ty_generics {
                 const SIZE: usize = 0;
                 const ALIGN: usize = 1;
+
+                fn write_layout_bytes(&self, _buf: &mut [u8]) -> ::std::result::Result<(), ::wgsl_rs_layout::Error> {
+                    ::std::result::Result::Ok(())
+                }
             }
         };
 
@@ -149,11 +153,13 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
 
     // Build FIELDS array entries
     let mut field_entry_tokens = Vec::new();
+    let mut field_write_tokens = Vec::new();
     for (i, name) in field_names.iter().enumerate() {
         let offset_name =
             syn::Ident::new(&format!("__OFFSET_{}", i), proc_macro2::Span::call_site());
         let size_name = syn::Ident::new(&format!("__SIZE_{}", i), proc_macro2::Span::call_site());
         let align_name = syn::Ident::new(&format!("__ALIGN_{}", i), proc_macro2::Span::call_site());
+        let field_ident = syn::Ident::new(name, proc_macro2::Span::call_site());
 
         let pad_before = if i == 0 {
             quote! { 0usize }
@@ -176,6 +182,13 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 pad_before: #pad_before,
             }
         });
+
+        field_write_tokens.push(quote! {
+            ::wgsl_rs_layout::WgslLayout::write_layout_bytes(
+                &self.#field_ident,
+                &mut buf[Self::#offset_name..],
+            )?;
+        });
     }
 
     // Inherent impl to hold the helper consts (accessible from trait impls via
@@ -190,6 +203,18 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         impl #impl_generics ::wgsl_rs_layout::WgslLayout for #struct_name #ty_generics #where_clause {
             const SIZE: usize = #size_expr;
             const ALIGN: usize = #self_align;
+
+            fn write_layout_bytes(&self, buf: &mut [u8]) -> ::std::result::Result<(), ::wgsl_rs_layout::Error> {
+                if buf.len() < Self::SIZE {
+                    return ::std::result::Result::Err(::wgsl_rs_layout::Error::BufferTooSmall {
+                        needed: Self::SIZE,
+                        actual: buf.len(),
+                    });
+                }
+                ::wgsl_rs_layout::zero_buffer(buf, Self::SIZE);
+                #(#field_write_tokens)*
+                ::std::result::Result::Ok(())
+            }
         }
     };
 

--- a/crates/wgsl-rs-layout-macros/src/lib.rs
+++ b/crates/wgsl-rs-layout-macros/src/lib.rs
@@ -1,0 +1,243 @@
+//! `#[derive(Layout)]` proc-macro for WGSL struct layout computation.
+//!
+//! Generates `WgslLayout` and `Layout` impls for structs, computing field
+//! offsets, sizes, and alignments per the WGSL specification §14.4.1.
+//!
+//! Supports both concrete and generic structs. Generic type parameters
+//! receive a `T: WgslLayout` bound on the generated impl.
+//!
+//! # Errors
+//!
+//! This derive requires a named-field struct (`struct Foo { x: f32 }`).
+//! Unit structs, tuple structs, and enums are rejected with compile errors.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, Type};
+
+fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let struct_name = input.ident;
+    let struct_name_span = struct_name.span();
+    let generics = input.generics;
+
+    let fields_data = match &input.data {
+        Data::Struct(s) => &s.fields,
+        Data::Enum(_) => {
+            return Err(syn::Error::new(
+                struct_name_span,
+                "#[derive(Layout)] is only supported on structs, not enums",
+            ));
+        }
+        Data::Union(_) => {
+            return Err(syn::Error::new(
+                struct_name_span,
+                "#[derive(Layout)] is only supported on structs, not unions",
+            ));
+        }
+    };
+
+    let named_fields = match fields_data {
+        Fields::Named(named) => named,
+        Fields::Unnamed(_) | Fields::Unit => {
+            return Err(syn::Error::new(
+                struct_name_span,
+                "#[derive(Layout)] is only supported on structs with named fields",
+            ));
+        }
+    };
+
+    let field_count = named_fields.named.len();
+
+    if field_count == 0 {
+        let (impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+
+        let wgsl_layout_impl = quote! {
+            impl #impl_generics ::wgsl_rs_layout::WgslLayout for #struct_name #ty_generics {
+                const SIZE: usize = 0;
+                const ALIGN: usize = 1;
+            }
+        };
+
+        let layout_impl = quote! {
+            impl #impl_generics ::wgsl_rs_layout::Layout for #struct_name #ty_generics {
+                const FIELDS: &'static [::wgsl_rs_layout::FieldLayout] = &[];
+            }
+        };
+
+        return Ok(quote! {
+            #wgsl_layout_impl
+            #layout_impl
+        });
+    }
+
+    let trait_bound: syn::TypeParamBound = syn::parse_quote!(::wgsl_rs_layout::WgslLayout);
+
+    let expanded_generics = add_trait_bound(&generics, &trait_bound);
+    let (impl_generics, ty_generics, where_clause) = expanded_generics.split_for_impl();
+
+    let field_names: Vec<String> = named_fields
+        .named
+        .iter()
+        .map(|f| f.ident.as_ref().expect("named field has ident").to_string())
+        .collect();
+    let field_types: Vec<&Type> = named_fields.named.iter().map(|f| &f.ty).collect();
+
+    let layout_trait_path: syn::Path = syn::parse_quote!(::wgsl_rs_layout::WgslLayout);
+    let round_up_path: syn::Path = syn::parse_quote!(::wgsl_rs_layout::round_up);
+
+    let size_of = |ty: &Type| -> proc_macro2::TokenStream {
+        quote! { <#ty as #layout_trait_path>::SIZE }
+    };
+    let align_of = |ty: &Type| -> proc_macro2::TokenStream {
+        quote! { <#ty as #layout_trait_path>::ALIGN }
+    };
+
+    // Build inherent consts to hold offset/size/align for each field.
+    // These are accessible from both trait impls via Self::.
+    let mut inherent_consts = Vec::new();
+    for (i, ty) in field_types.iter().enumerate() {
+        let offset_name =
+            syn::Ident::new(&format!("__OFFSET_{}", i), proc_macro2::Span::call_site());
+        let size_name = syn::Ident::new(&format!("__SIZE_{}", i), proc_macro2::Span::call_site());
+        let align_name = syn::Ident::new(&format!("__ALIGN_{}", i), proc_macro2::Span::call_site());
+
+        let size = size_of(ty);
+        let align = align_of(ty);
+
+        inherent_consts.push(quote! {
+            const #size_name: usize = #size;
+            const #align_name: usize = #align;
+        });
+
+        if i == 0 {
+            inherent_consts.push(quote! {
+                const #offset_name: usize = 0;
+            });
+        } else {
+            let prev_offset = syn::Ident::new(
+                &format!("__OFFSET_{}", i - 1),
+                proc_macro2::Span::call_site(),
+            );
+            let prev_size = size_of(field_types[i - 1]);
+            let cur_align = align_of(ty);
+            inherent_consts.push(quote! {
+                const #offset_name: usize = #round_up_path(
+                    Self::#prev_offset + #prev_size,
+                    #cur_align,
+                );
+            });
+        }
+    }
+
+    // Build ALIGN: max of all field alignments
+    let self_align = build_max_align_from_consts(field_count);
+
+    // SIZE = roundUp(AlignOf(S), lastOffset + lastSize)
+    let last_i = field_count - 1;
+    let last_offset = syn::Ident::new(
+        &format!("__OFFSET_{}", last_i),
+        proc_macro2::Span::call_site(),
+    );
+    let last_size = syn::Ident::new(
+        &format!("__SIZE_{}", last_i),
+        proc_macro2::Span::call_site(),
+    );
+
+    let size_expr = quote! {
+        #round_up_path(Self::#last_offset + Self::#last_size, Self::ALIGN)
+    };
+
+    // Build FIELDS array entries
+    let mut field_entry_tokens = Vec::new();
+    for (i, name) in field_names.iter().enumerate() {
+        let offset_name =
+            syn::Ident::new(&format!("__OFFSET_{}", i), proc_macro2::Span::call_site());
+        let size_name = syn::Ident::new(&format!("__SIZE_{}", i), proc_macro2::Span::call_site());
+        let align_name = syn::Ident::new(&format!("__ALIGN_{}", i), proc_macro2::Span::call_site());
+
+        let pad_before = if i == 0 {
+            quote! { 0usize }
+        } else {
+            let prev_offset_name = syn::Ident::new(
+                &format!("__OFFSET_{}", i - 1),
+                proc_macro2::Span::call_site(),
+            );
+            let prev_size_name =
+                syn::Ident::new(&format!("__SIZE_{}", i - 1), proc_macro2::Span::call_site());
+            quote! { Self::#offset_name - (Self::#prev_offset_name + Self::#prev_size_name) }
+        };
+
+        field_entry_tokens.push(quote! {
+            ::wgsl_rs_layout::FieldLayout {
+                name: #name,
+                offset: Self::#offset_name,
+                size: Self::#size_name,
+                alignment: Self::#align_name,
+                pad_before: #pad_before,
+            }
+        });
+    }
+
+    // Inherent impl to hold the helper consts (accessible from trait impls via
+    // Self::)
+    let inherent_impl = quote! {
+        impl #impl_generics #struct_name #ty_generics #where_clause {
+            #(#inherent_consts)*
+        }
+    };
+
+    let wgsl_layout_impl = quote! {
+        impl #impl_generics ::wgsl_rs_layout::WgslLayout for #struct_name #ty_generics #where_clause {
+            const SIZE: usize = #size_expr;
+            const ALIGN: usize = #self_align;
+        }
+    };
+
+    let layout_impl = quote! {
+        impl #impl_generics ::wgsl_rs_layout::Layout for #struct_name #ty_generics #where_clause {
+            const FIELDS: &'static [::wgsl_rs_layout::FieldLayout] = &[
+                #(#field_entry_tokens),*
+            ];
+        }
+    };
+
+    Ok(quote! {
+        #inherent_impl
+        #wgsl_layout_impl
+        #layout_impl
+    })
+}
+
+/// Build a const expression computing max of all field alignments,
+/// referencing inherent consts __ALIGN_0..__ALIGN_N.
+fn build_max_align_from_consts(field_count: usize) -> proc_macro2::TokenStream {
+    if field_count == 0 {
+        return quote! { 1usize };
+    }
+    let a0 = syn::Ident::new("__ALIGN_0", proc_macro2::Span::call_site());
+    if field_count == 1 {
+        return quote! { Self::#a0 };
+    }
+    let mut max_expr = quote! { Self::#a0 };
+    for i in 1..field_count {
+        let a = syn::Ident::new(&format!("__ALIGN_{}", i), proc_macro2::Span::call_site());
+        max_expr = quote! { (if (#max_expr > Self::#a) { #max_expr } else { Self::#a }) };
+    }
+    max_expr
+}
+
+fn add_trait_bound(generics: &syn::Generics, bound: &syn::TypeParamBound) -> syn::Generics {
+    let mut g = generics.clone();
+    for param in g.type_params_mut() {
+        param.bounds.push(bound.clone());
+    }
+    g
+}
+
+#[proc_macro_derive(Layout)]
+pub fn layout_derive(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as DeriveInput);
+    derive_layout(input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}

--- a/crates/wgsl-rs-layout-macros/src/lib.rs
+++ b/crates/wgsl-rs-layout-macros/src/lib.rs
@@ -56,6 +56,10 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 const SIZE: usize = 0;
                 const ALIGN: usize = 1;
 
+                fn read_layout_bytes(_buf: &[u8]) -> ::std::result::Result<Self, ::wgsl_rs_layout::Error> {
+                    ::std::result::Result::Ok(#struct_name {})
+                }
+
                 fn write_layout_bytes(&self, _buf: &mut [u8]) -> ::std::result::Result<(), ::wgsl_rs_layout::Error> {
                     ::std::result::Result::Ok(())
                 }
@@ -154,6 +158,8 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     // Build FIELDS array entries
     let mut field_entry_tokens = Vec::new();
     let mut field_write_tokens = Vec::new();
+    let mut field_read_tokens = Vec::new();
+    let mut field_init_tokens = Vec::new();
     for (i, name) in field_names.iter().enumerate() {
         let offset_name =
             syn::Ident::new(&format!("__OFFSET_{}", i), proc_macro2::Span::call_site());
@@ -189,6 +195,17 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 &mut buf[Self::#offset_name..],
             )?;
         });
+
+        field_read_tokens.push({
+            let ty = field_types[i]; // Type is Clone
+            quote! {
+                let #field_ident = <#ty as ::wgsl_rs_layout::WgslLayout>::read_layout_bytes(
+                    &buf[Self::#offset_name..],
+                )?;
+            }
+        });
+
+        field_init_tokens.push(field_ident);
     }
 
     // Inherent impl to hold the helper consts (accessible from trait impls via
@@ -203,6 +220,19 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         impl #impl_generics ::wgsl_rs_layout::WgslLayout for #struct_name #ty_generics #where_clause {
             const SIZE: usize = #size_expr;
             const ALIGN: usize = #self_align;
+
+            fn read_layout_bytes(buf: &[u8]) -> ::std::result::Result<Self, ::wgsl_rs_layout::Error> {
+                if buf.len() < Self::SIZE {
+                    return ::std::result::Result::Err(::wgsl_rs_layout::Error::BufferTooSmall {
+                        needed: Self::SIZE,
+                        actual: buf.len(),
+                    });
+                }
+                #(#field_read_tokens)*
+                ::std::result::Result::Ok(#struct_name {
+                    #(#field_init_tokens),*
+                })
+            }
 
             fn write_layout_bytes(&self, buf: &mut [u8]) -> ::std::result::Result<(), ::wgsl_rs_layout::Error> {
                 if buf.len() < Self::SIZE {

--- a/crates/wgsl-rs-layout-macros/src/lib.rs
+++ b/crates/wgsl-rs-layout-macros/src/lib.rs
@@ -49,10 +49,10 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let field_count = named_fields.named.len();
 
     if field_count == 0 {
-        let (impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
         let wgsl_layout_impl = quote! {
-            impl #impl_generics ::wgsl_rs_layout::WgslLayout for #struct_name #ty_generics {
+            impl #impl_generics ::wgsl_rs_layout::WgslLayout for #struct_name #ty_generics #where_clause {
                 const SIZE: usize = 0;
                 const ALIGN: usize = 1;
 
@@ -67,7 +67,7 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         };
 
         let layout_impl = quote! {
-            impl #impl_generics ::wgsl_rs_layout::Layout for #struct_name #ty_generics {
+            impl #impl_generics ::wgsl_rs_layout::Layout for #struct_name #ty_generics #where_clause {
                 const FIELDS: &'static [::wgsl_rs_layout::FieldLayout] = &[];
             }
         };

--- a/crates/wgsl-rs-layout-macros/src/lib.rs
+++ b/crates/wgsl-rs-layout-macros/src/lib.rs
@@ -273,12 +273,16 @@ fn build_max_align_from_consts(field_count: usize) -> proc_macro2::TokenStream {
     if field_count == 1 {
         return quote! { Self::#a0 };
     }
-    let mut max_expr = quote! { Self::#a0 };
+    let mut max_exprs = vec![];
     for i in 1..field_count {
         let a = syn::Ident::new(&format!("__ALIGN_{}", i), proc_macro2::Span::call_site());
-        max_expr = quote! { (if (#max_expr > Self::#a) { #max_expr } else { Self::#a }) };
+        max_exprs.push(a);
     }
-    max_expr
+    quote! {{
+        let mut max = Self::#a0;
+        #(if Self::#max_exprs > max { max = Self::#max_exprs; })*
+        max
+    }}
 }
 
 fn add_trait_bound(generics: &syn::Generics, bound: &syn::TypeParamBound) -> syn::Generics {

--- a/crates/wgsl-rs-layout-macros/src/lib.rs
+++ b/crates/wgsl-rs-layout-macros/src/lib.rs
@@ -56,11 +56,11 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 const SIZE: usize = 0;
                 const ALIGN: usize = 1;
 
-                fn read_layout_bytes(_buf: &[u8]) -> ::std::result::Result<Self, ::wgsl_rs_layout::Error> {
+                fn layout_read_bytes(_buf: &[u8]) -> ::std::result::Result<Self, ::wgsl_rs_layout::Error> {
                     ::std::result::Result::Ok(#struct_name {})
                 }
 
-                fn write_layout_bytes(&self, _buf: &mut [u8]) -> ::std::result::Result<(), ::wgsl_rs_layout::Error> {
+                fn layout_write_bytes(&self, _buf: &mut [u8]) -> ::std::result::Result<(), ::wgsl_rs_layout::Error> {
                     ::std::result::Result::Ok(())
                 }
             }
@@ -190,7 +190,7 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         });
 
         field_write_tokens.push(quote! {
-            ::wgsl_rs_layout::WgslLayout::write_layout_bytes(
+            ::wgsl_rs_layout::WgslLayout::layout_write_bytes(
                 &self.#field_ident,
                 &mut buf[Self::#offset_name..],
             )?;
@@ -199,7 +199,7 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         field_read_tokens.push({
             let ty = field_types[i]; // Type is Clone
             quote! {
-                let #field_ident = <#ty as ::wgsl_rs_layout::WgslLayout>::read_layout_bytes(
+                let #field_ident = <#ty as ::wgsl_rs_layout::WgslLayout>::layout_read_bytes(
                     &buf[Self::#offset_name..],
                 )?;
             }
@@ -221,7 +221,7 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
             const SIZE: usize = #size_expr;
             const ALIGN: usize = #self_align;
 
-            fn read_layout_bytes(buf: &[u8]) -> ::std::result::Result<Self, ::wgsl_rs_layout::Error> {
+            fn layout_read_bytes(buf: &[u8]) -> ::std::result::Result<Self, ::wgsl_rs_layout::Error> {
                 if buf.len() < Self::SIZE {
                     return ::std::result::Result::Err(::wgsl_rs_layout::Error::BufferTooSmall {
                         needed: Self::SIZE,
@@ -234,7 +234,7 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 })
             }
 
-            fn write_layout_bytes(&self, buf: &mut [u8]) -> ::std::result::Result<(), ::wgsl_rs_layout::Error> {
+            fn layout_write_bytes(&self, buf: &mut [u8]) -> ::std::result::Result<(), ::wgsl_rs_layout::Error> {
                 if buf.len() < Self::SIZE {
                     return ::std::result::Result::Err(::wgsl_rs_layout::Error::BufferTooSmall {
                         needed: Self::SIZE,

--- a/crates/wgsl-rs-layout-macros/src/lib.rs
+++ b/crates/wgsl-rs-layout-macros/src/lib.rs
@@ -167,16 +167,14 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         let align_name = syn::Ident::new(&format!("__ALIGN_{}", i), proc_macro2::Span::call_site());
         let field_ident = syn::Ident::new(name, proc_macro2::Span::call_site());
 
-        let pad_before = if i == 0 {
-            quote! { 0usize }
+        let pad_after = if i == field_count - 1 {
+            quote! { Self::SIZE - (Self::#offset_name + Self::#size_name) }
         } else {
-            let prev_offset_name = syn::Ident::new(
-                &format!("__OFFSET_{}", i - 1),
+            let next_offset_name = syn::Ident::new(
+                &format!("__OFFSET_{}", i + 1),
                 proc_macro2::Span::call_site(),
             );
-            let prev_size_name =
-                syn::Ident::new(&format!("__SIZE_{}", i - 1), proc_macro2::Span::call_site());
-            quote! { Self::#offset_name - (Self::#prev_offset_name + Self::#prev_size_name) }
+            quote! { Self::#next_offset_name - (Self::#offset_name + Self::#size_name) }
         };
 
         field_entry_tokens.push(quote! {
@@ -185,7 +183,7 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 offset: Self::#offset_name,
                 size: Self::#size_name,
                 alignment: Self::#align_name,
-                pad_before: #pad_before,
+                pad_after: #pad_after,
             }
         });
 
@@ -194,6 +192,9 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 &self.#field_ident,
                 &mut buf[Self::#offset_name..],
             )?;
+            let _pad_start = Self::#offset_name + Self::#size_name;
+            let _pad_end = _pad_start + #pad_after;
+            ::wgsl_rs_layout::zero_buffer(&mut buf[_pad_start.._pad_end], #pad_after);
         });
 
         field_read_tokens.push({
@@ -241,7 +242,6 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                         actual: buf.len(),
                     });
                 }
-                ::wgsl_rs_layout::zero_buffer(buf, Self::SIZE);
                 #(#field_write_tokens)*
                 ::std::result::Result::Ok(())
             }

--- a/crates/wgsl-rs-layout/Cargo.toml
+++ b/crates/wgsl-rs-layout/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "wgsl-rs-layout"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+wgsl-rs = { path = "../wgsl-rs" }
+wgsl-rs-layout-macros = { path = "../wgsl-rs-layout-macros" }

--- a/crates/wgsl-rs-layout/src/field.rs
+++ b/crates/wgsl-rs-layout/src/field.rs
@@ -6,52 +6,61 @@
 /// tightly — every field starts at a byte offset that is a multiple of
 /// its alignment requirement.
 ///
-/// # Understanding `pad_before`
+/// # Understanding `pad_after`
 ///
-/// `pad_before` is the number of **padding bytes between the end of the
-/// previous field and the start of this field**. It is always 0 for the
-/// first field in a struct. When `pad_before` is non-zero, this means
-/// the previous field's end did not satisfy this field's alignment
-/// requirement, and the GPU will insert dead bytes there.
+/// `pad_after` is the number of **padding bytes after this field's data
+/// before the next field begins** (or before the end of the struct for
+/// the last field). It is the gap created when the next field's alignment
+/// requires a larger offset than where this field's data naturally ends.
 ///
-/// **When marshalling data to/from GPU buffers, you must account for
-/// these padding bytes.** They are NOT part of any field's data. If you
-/// are writing raw bytes into a buffer, you need to insert `pad_before`
-/// zero bytes before writing this field's data.
+/// When writing data sequentially, you write this field's bytes, then
+/// write `pad_after` zero bytes to fill the gap before the next field.
+/// The last field's `pad_after` covers trailing padding to the struct's
+/// total size.
 ///
 /// ## Concrete Example
 ///
 /// ```ignore
 /// struct Ex4 {
-///     velocity: Vec3f,      // offset 0,  size 12, align 16
-///     size: f32,            // offset 12, size 4,  align 4,  pad_before = 0
-///     direction: [Vec3f; 1],// offset 16, size 12, align 16, pad_before = 0
-///     scale: f32,           // offset 32, size 4,  align 4,  pad_before = 4
-///     info: Ex4a,           // offset 48, size 12, align 16, pad_before = 12
-///     friction: f32,        // offset 64, size 4,  align 4,  pad_before = 4
+///     velocity: Vec3f,     // offset 0,  size 12, align 16, pad_after = 0
+///     size: f32,           // offset 12, size 4,  align 4,  pad_after = 0
+///     direction: Vec3f,    // offset 16, size 12, align 16, pad_after = 4
+///     scale: f32,          // offset 32, size 4,  align 4,  pad_after = 12
+///     info: Ex4a,          // offset 48, size 16, align 16, pad_after = 0
+///     friction: f32,       // offset 64, size 4,  align 4,  pad_after = 12
 /// }
 /// ```
 ///
-/// Notice how `scale` has `pad_before = 4` — this is the gap between the
-/// end of `direction` (offset 16 + size 12 = 28) and `scale`'s required
-/// 16-byte-aligned start (offset 32). When writing `scale` to a buffer,
-/// you must write 4 zero bytes at offset 28, then `scale`'s data at
-/// offset 32.
+/// - `velocity` has `pad_after = 0`: `size`'s alignment (4) fits at offset 12
+///   (12 + 0 = 12 which is already 4-aligned).
+/// - `direction` has `pad_after = 4`: the next field `scale` has alignment 4,
+///   but `direction` ends at offset 28. To reach the next 16-byte-aligned
+///   position (32), 4 bytes of padding are needed. So you write `direction`'s
+///   data at offset 16..28, then 4 zero bytes at 28..32 before `scale`.
+/// - `scale` has `pad_after = 12`: `info` has align 16, so `scale`'s end at
+///   offset 36 needs 12 zero bytes to reach offset 48.
+/// - `info` has `pad_after = 0`: `friction`'s alignment (4) fits at offset 64
+///   (48 + 16 = 64, already 4-aligned).
+/// - `friction` has `pad_after = 12`: the struct ends at offset 68, but its
+///   alignment is 16, so the total size rounds up to 80 — 12 trailing zero
+///   bytes.
 ///
-/// Another large gap appears before `info`: the `Ex4a` struct has align
-/// 16 (from its `Vec3f` field), so `info` starts at offset 48, leaving
-/// 12 bytes of padding between `scale` (ends at 32 + 4 = 36) and `info`.
+/// Note: this example uses `Vec3f` for `direction` rather than `[Vec3f; 1]`
+/// to keep the focus on inter-field padding. Arrays have their own internal
+/// stride padding (each element occupies `roundUp(align, size)` bytes),
+/// visible via the array's `SIZE`, and that internal padding is handled by
+/// the array's own write/read impls, not by `pad_after` on the parent field.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FieldLayout {
     /// The field name as declared in the Rust struct.
     pub name: &'static str,
     /// Byte offset from the start of the struct.
     pub offset: usize,
-    /// Byte size of the field's data (not including padding).
+    /// Byte size of the field's data per WGSL layout rules.
     pub size: usize,
     /// Alignment requirement of the field's type.
     pub alignment: usize,
-    /// Bytes of padding BEFORE this field (gap from previous field's end).
-    /// Always 0 for the first field.
-    pub pad_before: usize,
+    /// Bytes of padding AFTER this field (gap to the next field, or to the
+    /// struct end for the last field).
+    pub pad_after: usize,
 }

--- a/crates/wgsl-rs-layout/src/field.rs
+++ b/crates/wgsl-rs-layout/src/field.rs
@@ -1,0 +1,57 @@
+/// Layout information for a single field in a WGSL struct, computed per
+/// the WGSL specification §14.4.1 ("Alignment and Size").
+///
+/// WGSL struct fields are laid out sequentially with alignment-required
+/// gaps between fields. The GPU does not reorder fields or pack them
+/// tightly — every field starts at a byte offset that is a multiple of
+/// its alignment requirement.
+///
+/// # Understanding `pad_before`
+///
+/// `pad_before` is the number of **padding bytes between the end of the
+/// previous field and the start of this field**. It is always 0 for the
+/// first field in a struct. When `pad_before` is non-zero, this means
+/// the previous field's end did not satisfy this field's alignment
+/// requirement, and the GPU will insert dead bytes there.
+///
+/// **When marshalling data to/from GPU buffers, you must account for
+/// these padding bytes.** They are NOT part of any field's data. If you
+/// are writing raw bytes into a buffer, you need to insert `pad_before`
+/// zero bytes before writing this field's data.
+///
+/// ## Concrete Example
+///
+/// ```ignore
+/// struct Ex4 {
+///     velocity: Vec3f,      // offset 0,  size 12, align 16
+///     size: f32,            // offset 12, size 4,  align 4,  pad_before = 0
+///     direction: [Vec3f; 1],// offset 16, size 12, align 16, pad_before = 0
+///     scale: f32,           // offset 32, size 4,  align 4,  pad_before = 4
+///     info: Ex4a,           // offset 48, size 12, align 16, pad_before = 12
+///     friction: f32,        // offset 64, size 4,  align 4,  pad_before = 4
+/// }
+/// ```
+///
+/// Notice how `scale` has `pad_before = 4` — this is the gap between the
+/// end of `direction` (offset 16 + size 12 = 28) and `scale`'s required
+/// 16-byte-aligned start (offset 32). When writing `scale` to a buffer,
+/// you must write 4 zero bytes at offset 28, then `scale`'s data at
+/// offset 32.
+///
+/// Another large gap appears before `info`: the `Ex4a` struct has align
+/// 16 (from its `Vec3f` field), so `info` starts at offset 48, leaving
+/// 12 bytes of padding between `scale` (ends at 32 + 4 = 36) and `info`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FieldLayout {
+    /// The field name as declared in the Rust struct.
+    pub name: &'static str,
+    /// Byte offset from the start of the struct.
+    pub offset: usize,
+    /// Byte size of the field's data (not including padding).
+    pub size: usize,
+    /// Alignment requirement of the field's type.
+    pub alignment: usize,
+    /// Bytes of padding BEFORE this field (gap from previous field's end).
+    /// Always 0 for the first field.
+    pub pad_before: usize,
+}

--- a/crates/wgsl-rs-layout/src/field.rs
+++ b/crates/wgsl-rs-layout/src/field.rs
@@ -20,36 +20,36 @@
 ///
 /// ## Concrete Example
 ///
-/// ```ignore
+/// ```rust
+/// use wgsl_rs::std::Vec3f;
+/// use wgsl_rs_layout::{Layout, WgslLayout};
+///
+/// #[derive(wgsl_rs_layout::Layout)]
 /// struct Ex4 {
-///     velocity: Vec3f,     // offset 0,  size 12, align 16, pad_after = 0
-///     size: f32,           // offset 12, size 4,  align 4,  pad_after = 0
-///     direction: Vec3f,    // offset 16, size 12, align 16, pad_after = 4
-///     scale: f32,          // offset 32, size 4,  align 4,  pad_after = 12
-///     info: Ex4a,          // offset 48, size 16, align 16, pad_after = 0
-///     friction: f32,       // offset 64, size 4,  align 4,  pad_after = 12
+///     velocity: Vec3f,  // offset 0,  size 12, align 16, pad_after = 0
+///     size: f32,        // offset 12, size 4,  align 4,  pad_after = 0
+///     direction: Vec3f, // offset 16, size 12, align 16, pad_after = 0
+///     scale: f32,       // offset 28, size 4,  align 4,  pad_after = 0
 /// }
+///
+/// // Verify the layout:
+/// assert_eq!(Ex4::FIELDS[0].offset, 0);
+/// assert_eq!(Ex4::FIELDS[0].pad_after, 0); // size fits at 12 (4-aligned)
+/// assert_eq!(Ex4::FIELDS[1].offset, 12);
+/// assert_eq!(Ex4::FIELDS[1].pad_after, 0); // 12+4=16 is 16-aligned for direction
+/// assert_eq!(Ex4::FIELDS[2].offset, 16);
+/// assert_eq!(Ex4::FIELDS[2].pad_after, 0); // 16+12=28 is 4-aligned for scale
+/// assert_eq!(Ex4::FIELDS[3].offset, 28);
+/// assert_eq!(Ex4::FIELDS[3].pad_after, 0); // 28+4=32, struct size is 32
+/// assert_eq!(<Ex4 as WgslLayout>::SIZE, 32);
+/// assert_eq!(<Ex4 as WgslLayout>::ALIGN, 16);
 /// ```
 ///
-/// - `velocity` has `pad_after = 0`: `size`'s alignment (4) fits at offset 12
-///   (12 + 0 = 12 which is already 4-aligned).
-/// - `direction` has `pad_after = 4`: the next field `scale` has alignment 4,
-///   but `direction` ends at offset 28. To reach the next 16-byte-aligned
-///   position (32), 4 bytes of padding are needed. So you write `direction`'s
-///   data at offset 16..28, then 4 zero bytes at 28..32 before `scale`.
-/// - `scale` has `pad_after = 12`: `info` has align 16, so `scale`'s end at
-///   offset 36 needs 12 zero bytes to reach offset 48.
-/// - `info` has `pad_after = 0`: `friction`'s alignment (4) fits at offset 64
-///   (48 + 16 = 64, already 4-aligned).
-/// - `friction` has `pad_after = 12`: the struct ends at offset 68, but its
-///   alignment is 16, so the total size rounds up to 80 — 12 trailing zero
-///   bytes.
-///
-/// Note: this example uses `Vec3f` for `direction` rather than `[Vec3f; 1]`
-/// to keep the focus on inter-field padding. Arrays have their own internal
-/// stride padding (each element occupies `roundUp(align, size)` bytes),
-/// visible via the array's `SIZE`, and that internal padding is handled by
-/// the array's own write/read impls, not by `pad_after` on the parent field.
+/// Note: this example uses `Vec3f` rather than `[Vec3f; 1]` to keep the
+/// focus on inter-field padding. Arrays have their own internal stride
+/// padding (each element occupies `roundUp(align, size)` bytes), visible
+/// via the array's `SIZE`, and that internal padding is handled by the
+/// array's own write/read impls, not by `pad_after` on the parent field.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FieldLayout {
     /// The field name as declared in the Rust struct.

--- a/crates/wgsl-rs-layout/src/field.rs
+++ b/crates/wgsl-rs-layout/src/field.rs
@@ -47,7 +47,7 @@
 ///
 /// Note: this example uses `Vec3f` rather than `[Vec3f; 1]` to keep the
 /// focus on inter-field padding. Arrays have their own internal stride
-/// padding (each element occupies `roundUp(align, size)` bytes), visible
+/// padding (each element occupies `roundUp(size, align)` bytes), visible
 /// via the array's `SIZE`, and that internal padding is handled by the
 /// array's own write/read impls, not by `pad_after` on the parent field.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/wgsl-rs-layout/src/lib.rs
+++ b/crates/wgsl-rs-layout/src/lib.rs
@@ -768,4 +768,17 @@ mod tests {
         assert_eq!(restored.b[3u32], s.b[3u32]);
         assert_eq!(restored.c, s.c);
     }
+
+    #[test]
+    fn expansion() {
+        use wgsl_rs::std::*;
+
+        #[derive(Layout)]
+        struct _MyType {
+            vec: Vec3f,
+            float: f32,
+            u: u32,
+            mat: Mat4f,
+        }
+    }
 }

--- a/crates/wgsl-rs-layout/src/lib.rs
+++ b/crates/wgsl-rs-layout/src/lib.rs
@@ -70,7 +70,7 @@ pub enum Error {
 /// Built-in scalar, vector, matrix, array, and atomic types have
 /// predefined impls. User-defined structs receive impls via
 /// `#[derive(Layout)]`.
-pub trait WgslLayout {
+pub trait WgslLayout: Sized {
     /// The size in bytes of this type per WGSL layout rules.
     const SIZE: usize;
     /// The alignment in bytes of this type per WGSL layout rules.
@@ -84,6 +84,14 @@ pub trait WgslLayout {
     ///
     /// Returns [`Error::BufferTooSmall`] if `buf.len() < Self::SIZE`.
     fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error>;
+
+    /// Read a value of this type from `buf` at offset 0, using WGSL layout
+    /// rules (little-endian scalars, alignment-padded fields).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::BufferTooSmall`] if `buf.len() < Self::SIZE`.
+    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error>;
 }
 
 /// A struct whose field layout has been computed per WGSL rules.
@@ -106,6 +114,17 @@ pub fn write_layout_bytes<T: WgslLayout>(bytes: &mut [u8], t: &T) -> Result<(), 
     t.write_layout_bytes(bytes)
 }
 
+/// Read a value of type `T` from `bytes` at offset 0 per WGSL layout rules.
+///
+/// Convenience wrapper around [`WgslLayout::read_layout_bytes`].
+///
+/// # Errors
+///
+/// Returns [`Error::BufferTooSmall`] if `bytes.len() < T::SIZE`.
+pub fn read_layout_bytes<T: WgslLayout>(bytes: &[u8]) -> Result<T, Error> {
+    T::read_layout_bytes(bytes)
+}
+
 /// Round `val` up to the next multiple of `align`.
 ///
 /// `align` must be a power of two.
@@ -126,7 +145,7 @@ pub fn zero_buffer(buf: &mut [u8], len: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::write_layout_bytes;
+    use crate::{read_layout_bytes, write_layout_bytes};
 
     // ===== Scalar tests =====
 
@@ -249,7 +268,7 @@ mod tests {
         assert_eq!(<SingleScalar>::FIELDS[0].pad_before, 0);
     }
 
-    #[derive(Layout)]
+    #[derive(Layout, Debug, PartialEq)]
     struct TightLayout {
         velocity: wgsl_rs::std::Vec3f,
         acceleration: wgsl_rs::std::Vec3f,
@@ -336,8 +355,8 @@ mod tests {
         assert_eq!(<ComplexEx4>::FIELDS[4].pad_before, 0);
     }
 
-    #[derive(Layout)]
-    struct NestedPadded {
+    #[derive(Layout, Debug, PartialEq)]
+    pub struct NestedPadded {
         orientation: wgsl_rs::std::Vec3f,
         size: f32,
         direction: [wgsl_rs::std::Vec3f; 1],
@@ -346,7 +365,7 @@ mod tests {
         friction: f32,
     }
 
-    #[derive(Layout)]
+    #[derive(Layout, Debug, PartialEq)]
     struct Vec3Struct {
         velocity: wgsl_rs::std::Vec3f,
     }
@@ -407,7 +426,7 @@ mod tests {
     }
 
     #[derive(Layout)]
-    struct GenericPair<T> {
+    struct GenericPair<T: PartialEq> {
         a: T,
         b: T,
     }
@@ -632,5 +651,121 @@ mod tests {
         assert_eq!(read_f32_le(&buf[80..84]), 2.0);
         // trailing padding at 84-95 zero
         assert_eq!(&buf[84..96], &[0u8; 12]);
+    }
+
+    // ===== read_layout_bytes tests =====
+
+    #[test]
+    fn read_scalars() {
+        let buf = 1.25f32.to_le_bytes();
+        let v: f32 = read_layout_bytes(&buf).unwrap();
+        assert_eq!(v, 1.25);
+
+        let buf = (-42i32).to_le_bytes();
+        let v: i32 = read_layout_bytes(&buf).unwrap();
+        assert_eq!(v, -42);
+
+        let buf = 42u32.to_le_bytes();
+        let v: u32 = read_layout_bytes(&buf).unwrap();
+        assert_eq!(v, 42);
+
+        let buf = 0u32.to_le_bytes();
+        let v: bool = read_layout_bytes(&buf).unwrap();
+        assert!(!v);
+
+        let buf = 1u32.to_le_bytes();
+        let v: bool = read_layout_bytes(&buf).unwrap();
+        assert!(v);
+    }
+
+    #[test]
+    fn read_buffer_too_small() {
+        let buf = [0u8; 3];
+        let err = read_layout_bytes::<f32>(&buf).unwrap_err();
+        assert_eq!(
+            err,
+            Error::BufferTooSmall {
+                needed: 4,
+                actual: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn read_vec3f() {
+        let original = wgsl_rs::std::vec3f(1.0, 2.0, 3.0);
+        let mut buf = vec![0u8; 12];
+        write_layout_bytes(&mut buf, &original).unwrap();
+        let restored: wgsl_rs::std::Vec3f = read_layout_bytes(&buf).unwrap();
+        assert_eq!(restored, original);
+    }
+
+    #[test]
+    fn read_write_roundtrip_struct() {
+        let s = TightLayout {
+            velocity: wgsl_rs::std::vec3f(1.0, 0.0, -1.0),
+            acceleration: wgsl_rs::std::vec3f(0.0, -9.8, 0.0),
+            frame_count: 42,
+        };
+        let mut buf = vec![0u8; <TightLayout>::SIZE];
+        write_layout_bytes(&mut buf, &s).unwrap();
+        let restored: TightLayout = read_layout_bytes(&buf).unwrap();
+        assert_eq!(restored, s);
+    }
+
+    #[test]
+    fn read_write_roundtrip_nested() {
+        let info = Vec3Struct {
+            velocity: wgsl_rs::std::vec3f(1.0, 2.0, 3.0),
+        };
+        let s = NestedPadded {
+            orientation: wgsl_rs::std::vec3f(0.0, 1.0, 0.0),
+            size: 2.5,
+            direction: [wgsl_rs::std::vec3f(4.0, 5.0, 6.0)],
+            scale: 0.1,
+            info,
+            friction: 0.05,
+        };
+        let mut buf = vec![0u8; <NestedPadded>::SIZE];
+        write_layout_bytes(&mut buf, &s).unwrap();
+        let restored: NestedPadded = read_layout_bytes(&buf).unwrap();
+        assert_eq!(restored, s);
+    }
+
+    #[test]
+    fn read_write_roundtrip_generic() {
+        let p = GenericPair::<f32> { a: 1.0, b: 2.0 };
+        let mut buf = vec![0u8; <GenericPair<f32>>::SIZE];
+        write_layout_bytes(&mut buf, &p).unwrap();
+        let restored: GenericPair<f32> = read_layout_bytes(&buf).unwrap();
+        assert_eq!(restored.a, p.a);
+        assert_eq!(restored.b, p.b);
+    }
+
+    #[test]
+    fn read_zero_size_empty_struct() {
+        let s: Empty = read_layout_bytes(&[]).unwrap();
+        // An empty struct has no fields to compare, so we just verify it returns Ok.
+        let _ = s;
+    }
+
+    #[test]
+    fn read_write_mixed_align_roundtrip() {
+        let s = MixedAlign {
+            a: 1.0,
+            b: wgsl_rs::std::Mat4x4f::default(),
+            c: 2.0,
+        };
+        let mut buf = vec![0u8; <MixedAlign>::SIZE];
+        write_layout_bytes(&mut buf, &s).unwrap();
+        let restored: MixedAlign = read_layout_bytes(&buf).unwrap();
+        assert_eq!(restored.a, s.a);
+        // Mat4x4f only implements Default (not Debug/PartialEq easily), so check
+        // columns
+        assert_eq!(restored.b[0u32], s.b[0u32]);
+        assert_eq!(restored.b[1u32], s.b[1u32]);
+        assert_eq!(restored.b[2u32], s.b[2u32]);
+        assert_eq!(restored.b[3u32], s.b[3u32]);
+        assert_eq!(restored.c, s.c);
     }
 }

--- a/crates/wgsl-rs-layout/src/lib.rs
+++ b/crates/wgsl-rs-layout/src/lib.rs
@@ -23,19 +23,19 @@
 //!
 //! for f in Uniforms::FIELDS {
 //!     println!(
-//!         "{}: offset={}, size={}, align={}, pad_before={}",
-//!         f.name, f.offset, f.size, f.alignment, f.pad_before,
+//!         "{}: offset={}, size={}, align={}, pad_after={}",
+//!         f.name, f.offset, f.size, f.alignment, f.pad_after,
 //!     );
 //! }
 //! ```
 //!
-//! # The `pad_before` Field
+//! # The `pad_after` Field
 //!
-//! [`FieldLayout::pad_before`] is the number of dead bytes between the
-//! end of the previous field and the start of the current field. It is
-//! always 0 for the first field. **You must account for these padding
-//! bytes when marshalling data into GPU buffers** — write zero bytes to
-//! fill gaps before writing the next field's data.
+//! [`FieldLayout::pad_after`] is the number of padding bytes after this
+//! field's data before the next field begins (or before the struct's end
+//! for the last field). When writing data into a GPU buffer, you write
+//! this field's bytes followed by `pad_after` zero bytes to fill any
+//! alignment gaps.
 
 pub use wgsl_rs_layout_macros::Layout;
 
@@ -265,7 +265,7 @@ mod tests {
         assert_eq!(<SingleScalar>::FIELDS[0].offset, 0);
         assert_eq!(<SingleScalar>::FIELDS[0].size, 4);
         assert_eq!(<SingleScalar>::FIELDS[0].alignment, 4);
-        assert_eq!(<SingleScalar>::FIELDS[0].pad_before, 0);
+        assert_eq!(<SingleScalar>::FIELDS[0].pad_after, 0);
     }
 
     #[derive(Layout, Debug, PartialEq)]
@@ -282,21 +282,21 @@ mod tests {
         assert_eq!(<TightLayout>::FIELDS[0].offset, 0);
         assert_eq!(<TightLayout>::FIELDS[0].size, 12);
         assert_eq!(<TightLayout>::FIELDS[0].alignment, 16);
-        assert_eq!(<TightLayout>::FIELDS[0].pad_before, 0);
+        assert_eq!(<TightLayout>::FIELDS[0].pad_after, 4);
 
         // acceleration: roundUp(0+12, 16) = 16, size 12
         assert_eq!(<TightLayout>::FIELDS[1].name, "acceleration");
         assert_eq!(<TightLayout>::FIELDS[1].offset, 16);
         assert_eq!(<TightLayout>::FIELDS[1].size, 12);
         assert_eq!(<TightLayout>::FIELDS[1].alignment, 16);
-        assert_eq!(<TightLayout>::FIELDS[1].pad_before, 4);
+        assert_eq!(<TightLayout>::FIELDS[1].pad_after, 0);
 
         // frame_count: roundUp(16+12, 4) = 28, u32=4
         assert_eq!(<TightLayout>::FIELDS[2].name, "frame_count");
         assert_eq!(<TightLayout>::FIELDS[2].offset, 28);
         assert_eq!(<TightLayout>::FIELDS[2].size, 4);
         assert_eq!(<TightLayout>::FIELDS[2].alignment, 4);
-        assert_eq!(<TightLayout>::FIELDS[2].pad_before, 0);
+        assert_eq!(<TightLayout>::FIELDS[2].pad_after, 0);
 
         // struct size = roundUp(max(16,16,4)=16, 28+4=32) = 32
         assert_eq!(<TightLayout>::SIZE, 32);
@@ -315,10 +315,10 @@ mod tests {
     #[test]
     fn complex_ex4() {
         // velocity: offset 0,  size 12, align 16
-        // size:     roundUp(12, 4) = 12, size 4, align 4, pad_before 0
+        // size:     roundUp(12, 4) = 12, size 4, align 4
         // direction: roundUp(16, 16) = 16, [Vec3f;1] = 1*roundUp(16,12)=16, align 16
-        // scale:    roundUp(32, 4) = 32, size 4, align 4, pad_before 0
-        // friction: roundUp(36, 4) = 36, size 4, align 4, pad_before 0
+        // scale:    roundUp(32, 4) = 32, size 4, align 4
+        // friction: roundUp(36, 4) = 36, size 4, align 4
         // SIZE = roundUp(16, 36+4=40) = 48
         assert_eq!(<ComplexEx4>::SIZE, 48);
         assert_eq!(<ComplexEx4>::ALIGN, 16);
@@ -327,32 +327,32 @@ mod tests {
         assert_eq!(<ComplexEx4>::FIELDS[0].offset, 0);
         assert_eq!(<ComplexEx4>::FIELDS[0].size, 12);
         assert_eq!(<ComplexEx4>::FIELDS[0].alignment, 16);
-        assert_eq!(<ComplexEx4>::FIELDS[0].pad_before, 0);
+        assert_eq!(<ComplexEx4>::FIELDS[0].pad_after, 0);
 
         assert_eq!(<ComplexEx4>::FIELDS[1].name, "size");
         assert_eq!(<ComplexEx4>::FIELDS[1].offset, 12);
         assert_eq!(<ComplexEx4>::FIELDS[1].size, 4);
         assert_eq!(<ComplexEx4>::FIELDS[1].alignment, 4);
-        assert_eq!(<ComplexEx4>::FIELDS[1].pad_before, 0);
+        assert_eq!(<ComplexEx4>::FIELDS[1].pad_after, 0);
 
-        // direction: [Vec3f;1] → align 16, size 16. roundUp(12+4=16, 16) = 16
+        // direction: [Vec3f;1] → align 16, size 16. pad_after = 0 (next field at 32)
         assert_eq!(<ComplexEx4>::FIELDS[2].name, "direction");
         assert_eq!(<ComplexEx4>::FIELDS[2].offset, 16);
         assert_eq!(<ComplexEx4>::FIELDS[2].size, 16);
         assert_eq!(<ComplexEx4>::FIELDS[2].alignment, 16);
-        assert_eq!(<ComplexEx4>::FIELDS[2].pad_before, 0);
+        assert_eq!(<ComplexEx4>::FIELDS[2].pad_after, 0);
 
         assert_eq!(<ComplexEx4>::FIELDS[3].name, "scale");
         assert_eq!(<ComplexEx4>::FIELDS[3].offset, 32);
         assert_eq!(<ComplexEx4>::FIELDS[3].size, 4);
         assert_eq!(<ComplexEx4>::FIELDS[3].alignment, 4);
-        assert_eq!(<ComplexEx4>::FIELDS[3].pad_before, 0);
+        assert_eq!(<ComplexEx4>::FIELDS[3].pad_after, 0);
 
         assert_eq!(<ComplexEx4>::FIELDS[4].name, "friction");
         assert_eq!(<ComplexEx4>::FIELDS[4].offset, 36);
         assert_eq!(<ComplexEx4>::FIELDS[4].size, 4);
         assert_eq!(<ComplexEx4>::FIELDS[4].alignment, 4);
-        assert_eq!(<ComplexEx4>::FIELDS[4].pad_before, 0);
+        assert_eq!(<ComplexEx4>::FIELDS[4].pad_after, 8);
     }
 
     #[derive(Layout, Debug, PartialEq)]
@@ -376,12 +376,12 @@ mod tests {
         assert_eq!(<Vec3Struct>::SIZE, 16);
         assert_eq!(<Vec3Struct>::ALIGN, 16);
 
-        // orientation: offset 0, size 12, align 16
-        // size:        roundUp(12, 4) = 12, size 4, align 4
-        // direction:   roundUp(16, 16) = 16, [Vec3f;1]=16, align 16
-        // scale:       roundUp(32, 4) = 32, size 4, align 4
-        // info:        roundUp(36, 16) = 48, size 16, align 16 → pad_before = 12
-        // friction:    roundUp(64, 4) = 64, size 4, align 4
+        // orientation: offset 0, size 12, align 16, pad_after = 0
+        // size:        roundUp(12, 4) = 12, size 4, align 4, pad_after = 0
+        // direction:   roundUp(16, 16) = 16, [Vec3f;1]=16, align 16, pad_after = 4
+        // scale:       roundUp(32, 4) = 32, size 4, align 4, pad_after = 12
+        // info:        roundUp(36, 16) = 48, size 16, align 16, pad_after = 0
+        // friction:    roundUp(64, 4) = 64, size 4, align 4, pad_after = 12
         // SIZE = roundUp(16, 64+4=68) = 80
 
         assert_eq!(<NestedPadded>::SIZE, 80);
@@ -391,38 +391,38 @@ mod tests {
         assert_eq!(<NestedPadded>::FIELDS[0].offset, 0);
         assert_eq!(<NestedPadded>::FIELDS[0].size, 12);
         assert_eq!(<NestedPadded>::FIELDS[0].alignment, 16);
-        assert_eq!(<NestedPadded>::FIELDS[0].pad_before, 0);
+        assert_eq!(<NestedPadded>::FIELDS[0].pad_after, 0);
 
         assert_eq!(<NestedPadded>::FIELDS[1].name, "size");
         assert_eq!(<NestedPadded>::FIELDS[1].offset, 12);
         assert_eq!(<NestedPadded>::FIELDS[1].size, 4);
         assert_eq!(<NestedPadded>::FIELDS[1].alignment, 4);
-        assert_eq!(<NestedPadded>::FIELDS[1].pad_before, 0);
+        assert_eq!(<NestedPadded>::FIELDS[1].pad_after, 0);
 
         assert_eq!(<NestedPadded>::FIELDS[2].name, "direction");
         assert_eq!(<NestedPadded>::FIELDS[2].offset, 16);
         assert_eq!(<NestedPadded>::FIELDS[2].size, 16);
         assert_eq!(<NestedPadded>::FIELDS[2].alignment, 16);
-        assert_eq!(<NestedPadded>::FIELDS[2].pad_before, 0);
+        assert_eq!(<NestedPadded>::FIELDS[2].pad_after, 0);
 
         assert_eq!(<NestedPadded>::FIELDS[3].name, "scale");
         assert_eq!(<NestedPadded>::FIELDS[3].offset, 32);
         assert_eq!(<NestedPadded>::FIELDS[3].size, 4);
         assert_eq!(<NestedPadded>::FIELDS[3].alignment, 4);
-        assert_eq!(<NestedPadded>::FIELDS[3].pad_before, 0);
+        assert_eq!(<NestedPadded>::FIELDS[3].pad_after, 12);
 
-        // info: roundUp(32+4=36, 16) = 48, size 16, pad_before = 48 - 36 = 12
+        // info: roundUp(32+4=36, 16) = 48, size 16, pad_after = 0
         assert_eq!(<NestedPadded>::FIELDS[4].name, "info");
         assert_eq!(<NestedPadded>::FIELDS[4].offset, 48);
         assert_eq!(<NestedPadded>::FIELDS[4].size, 16);
         assert_eq!(<NestedPadded>::FIELDS[4].alignment, 16);
-        assert_eq!(<NestedPadded>::FIELDS[4].pad_before, 12);
+        assert_eq!(<NestedPadded>::FIELDS[4].pad_after, 0);
 
         assert_eq!(<NestedPadded>::FIELDS[5].name, "friction");
         assert_eq!(<NestedPadded>::FIELDS[5].offset, 64);
         assert_eq!(<NestedPadded>::FIELDS[5].size, 4);
         assert_eq!(<NestedPadded>::FIELDS[5].alignment, 4);
-        assert_eq!(<NestedPadded>::FIELDS[5].pad_before, 0);
+        assert_eq!(<NestedPadded>::FIELDS[5].pad_after, 12);
     }
 
     #[derive(Layout)]
@@ -441,13 +441,13 @@ mod tests {
         assert_eq!(layout_pair_f32[0].offset, 0);
         assert_eq!(layout_pair_f32[0].size, 4);
         assert_eq!(layout_pair_f32[0].alignment, 4);
-        assert_eq!(layout_pair_f32[0].pad_before, 0);
+        assert_eq!(layout_pair_f32[0].pad_after, 0);
 
         assert_eq!(layout_pair_f32[1].name, "b");
         assert_eq!(layout_pair_f32[1].offset, 4);
         assert_eq!(layout_pair_f32[1].size, 4);
         assert_eq!(layout_pair_f32[1].alignment, 4);
-        assert_eq!(layout_pair_f32[1].pad_before, 0);
+        assert_eq!(layout_pair_f32[1].pad_after, 0);
 
         // Generic with Vec3f (align 16, size 12)
         let layout_pair_vec3 = GenericPair::<wgsl_rs::std::Vec3f>::FIELDS;
@@ -456,12 +456,12 @@ mod tests {
 
         assert_eq!(layout_pair_vec3[0].offset, 0);
         assert_eq!(layout_pair_vec3[0].size, 12);
-        assert_eq!(layout_pair_vec3[0].pad_before, 0);
+        assert_eq!(layout_pair_vec3[0].pad_after, 4);
 
         // b: roundUp(12, 16) = 16
         assert_eq!(layout_pair_vec3[1].offset, 16);
         assert_eq!(layout_pair_vec3[1].size, 12);
-        assert_eq!(layout_pair_vec3[1].pad_before, 4);
+        assert_eq!(layout_pair_vec3[1].pad_after, 4);
     }
 
     // Verify pad_before with mixed alignments
@@ -473,18 +473,18 @@ mod tests {
     }
 
     #[test]
-    fn mixed_align_pad_before() {
-        // a: offset 0, size 4, align 4
-        // b: roundUp(4, 16) = 16, size 64, align 16, pad_before = 12
-        // c: roundUp(80, 4) = 80, size 4, align 4, pad_before = 0
+    fn mixed_align_pad_after() {
+        // a: offset 0, size 4, align 4, pad_after = 12
+        // b: roundUp(4, 16) = 16, size 64, align 16, pad_after = 0
+        // c: roundUp(80, 4) = 80, size 4, align 4, pad_after = 12
         // SIZE = roundUp(16, 84) = 96
         assert_eq!(<MixedAlign>::SIZE, 96);
         assert_eq!(<MixedAlign>::ALIGN, 16);
 
-        assert_eq!(<MixedAlign>::FIELDS[0].pad_before, 0);
+        assert_eq!(<MixedAlign>::FIELDS[0].pad_after, 12);
         assert_eq!(<MixedAlign>::FIELDS[1].offset, 16);
-        assert_eq!(<MixedAlign>::FIELDS[1].pad_before, 12);
-        assert_eq!(<MixedAlign>::FIELDS[2].pad_before, 0);
+        assert_eq!(<MixedAlign>::FIELDS[1].pad_after, 0);
+        assert_eq!(<MixedAlign>::FIELDS[2].pad_after, 12);
     }
 
     // ===== layout_write_bytes tests =====

--- a/crates/wgsl-rs-layout/src/lib.rs
+++ b/crates/wgsl-rs-layout/src/lib.rs
@@ -1,0 +1,428 @@
+//! WGSL memory layout computation for Rust types.
+//!
+//! This crate provides traits and a derive macro for computing the size,
+//! alignment, and field offsets of types per the WGSL specification
+//! §14.4.1 ("Alignment and Size"). It is intended for tools that marshal
+//! data between CPU and GPU memory.
+//!
+//! # Quick Start
+//!
+//! ```ignore
+//! use wgsl_rs_layout::{Layout, WgslLayout, FieldLayout};
+//! use wgsl_rs::{Mat4x4f, Vec4f};
+//!
+//! #[derive(Layout)]
+//! struct Uniforms {
+//!     model: Mat4x4f,
+//!     color: Vec4f,
+//!     time: f32,
+//! }
+//!
+//! assert_eq!(Uniforms::SIZE, 96);
+//! assert_eq!(Uniforms::ALIGN, 16);
+//!
+//! for f in Uniforms::FIELDS {
+//!     println!(
+//!         "{}: offset={}, size={}, align={}, pad_before={}",
+//!         f.name, f.offset, f.size, f.alignment, f.pad_before,
+//!     );
+//! }
+//! ```
+//!
+//! # The `pad_before` Field
+//!
+//! [`FieldLayout::pad_before`] is the number of dead bytes between the
+//! end of the previous field and the start of the current field. It is
+//! always 0 for the first field. **You must account for these padding
+//! bytes when marshalling data into GPU buffers** — write zero bytes to
+//! fill gaps before writing the next field's data.
+
+pub use wgsl_rs_layout_macros::Layout;
+
+// Allow the crate's own tests to resolve `::wgsl_rs_layout` paths emitted
+// by the derive macro (external users resolve it via the crate dependency).
+extern crate self as wgsl_rs_layout;
+
+mod field;
+mod types;
+
+pub use field::FieldLayout;
+
+/// A type with a known WGSL memory layout.
+///
+/// Each type that can appear as a field in a host-shareable WGSL struct
+/// must implement this trait. The associated constants encode the size
+/// and alignment per the WGSL specification §14.4.1.
+///
+/// Built-in scalar, vector, matrix, array, and atomic types have
+/// predefined impls. User-defined structs receive impls via
+/// `#[derive(Layout)]`.
+pub trait WgslLayout {
+    /// The size in bytes of this type per WGSL layout rules.
+    const SIZE: usize;
+    /// The alignment in bytes of this type per WGSL layout rules.
+    /// Must be a power of two.
+    const ALIGN: usize;
+}
+
+/// A struct whose field layout has been computed per WGSL rules.
+///
+/// Implemented automatically by `#[derive(Layout)]`. Provides field-level
+/// offset, size, alignment, and inter-field padding information.
+pub trait Layout: WgslLayout {
+    /// Per-field layout information in declaration order.
+    const FIELDS: &'static [FieldLayout];
+}
+
+/// Round `val` up to the next multiple of `align`.
+///
+/// `align` must be a power of two.
+#[doc(hidden)]
+pub const fn round_up(val: usize, align: usize) -> usize {
+    (val + (align - 1)) & !(align - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ===== Scalar tests =====
+
+    #[test]
+    fn scalar_layouts() {
+        assert_eq!(f32::SIZE, 4);
+        assert_eq!(f32::ALIGN, 4);
+        assert_eq!(i32::SIZE, 4);
+        assert_eq!(i32::ALIGN, 4);
+        assert_eq!(u32::SIZE, 4);
+        assert_eq!(u32::ALIGN, 4);
+        assert_eq!(bool::SIZE, 4);
+        assert_eq!(bool::ALIGN, 4);
+    }
+
+    // ===== Vector tests =====
+
+    #[test]
+    fn vector_layouts() {
+        assert_eq!(<wgsl_rs::std::Vec2f>::SIZE, 8);
+        assert_eq!(<wgsl_rs::std::Vec2f>::ALIGN, 8);
+        assert_eq!(<wgsl_rs::std::Vec3f>::SIZE, 12);
+        assert_eq!(<wgsl_rs::std::Vec3f>::ALIGN, 16);
+        assert_eq!(<wgsl_rs::std::Vec4f>::SIZE, 16);
+        assert_eq!(<wgsl_rs::std::Vec4f>::ALIGN, 16);
+    }
+
+    // ===== Matrix tests =====
+
+    #[test]
+    fn matrix_layouts() {
+        // matCxR: Align = AlignOf(vecR), Size = SizeOf(array<vecR, C>)
+        // mat2x2f: Align = AlignOf(vec2f) = 8, Size = SizeOf(array<vec2f, 2>) = 2*8 =
+        // 16
+        assert_eq!(<wgsl_rs::std::Mat2x2f>::SIZE, 16);
+        assert_eq!(<wgsl_rs::std::Mat2x2f>::ALIGN, 8);
+        // mat2x3f: Align = AlignOf(vec3f) = 16, Size = 2*roundUp(16,12) = 2*16 = 32
+        assert_eq!(<wgsl_rs::std::Mat2x3f>::SIZE, 32);
+        assert_eq!(<wgsl_rs::std::Mat2x3f>::ALIGN, 16);
+        // mat3x3f: Align = 16, Size = 3*16 = 48
+        assert_eq!(<wgsl_rs::std::Mat3x3f>::SIZE, 48);
+        assert_eq!(<wgsl_rs::std::Mat3x3f>::ALIGN, 16);
+        // mat4x4f: Align = 16, Size = 4*16 = 64
+        assert_eq!(<wgsl_rs::std::Mat4x4f>::SIZE, 64);
+        assert_eq!(<wgsl_rs::std::Mat4x4f>::ALIGN, 16);
+        // mat3x2f: Align = AlignOf(vec2f) = 8, Size = 3*8 = 24
+        assert_eq!(<wgsl_rs::std::Mat3x2f>::SIZE, 24);
+        assert_eq!(<wgsl_rs::std::Mat3x2f>::ALIGN, 8);
+    }
+
+    // ===== Array tests =====
+
+    #[test]
+    fn array_layouts() {
+        // [f32; 3]: align 4, size = 3 * roundUp(4, 4) = 12
+        assert_eq!(<[f32; 3]>::SIZE, 12);
+        assert_eq!(<[f32; 3]>::ALIGN, 4);
+        // [Vec3f; 2]: align 16, size = 2 * roundUp(16, 12) = 2*16 = 32
+        assert_eq!(<[wgsl_rs::std::Vec3f; 2]>::SIZE, 32);
+        assert_eq!(<[wgsl_rs::std::Vec3f; 2]>::ALIGN, 16);
+    }
+
+    #[test]
+    fn runtime_array_layout() {
+        assert_eq!(<wgsl_rs::std::RuntimeArray<f32>>::SIZE, 0);
+        assert_eq!(<wgsl_rs::std::RuntimeArray<f32>>::ALIGN, 4);
+    }
+
+    // ===== Atomic tests =====
+
+    #[test]
+    fn atomic_layouts() {
+        assert_eq!(<wgsl_rs::std::Atomic<u32>>::SIZE, 4);
+        assert_eq!(<wgsl_rs::std::Atomic<u32>>::ALIGN, 4);
+        assert_eq!(<wgsl_rs::std::Atomic<i32>>::SIZE, 4);
+        assert_eq!(<wgsl_rs::std::Atomic<i32>>::ALIGN, 4);
+    }
+
+    // ===== round_up tests =====
+
+    #[test]
+    fn round_up_valid() {
+        assert_eq!(round_up(0, 4), 0);
+        assert_eq!(round_up(1, 4), 4);
+        assert_eq!(round_up(4, 4), 4);
+        assert_eq!(round_up(5, 4), 8);
+        assert_eq!(round_up(12, 16), 16);
+        assert_eq!(round_up(16, 16), 16);
+        assert_eq!(round_up(17, 16), 32);
+        assert_eq!(round_up(80, 4), 80);
+        assert_eq!(round_up(84, 16), 96);
+    }
+
+    // ===== Derived Layout tests =====
+
+    #[derive(Layout)]
+    struct Empty {}
+
+    #[test]
+    fn empty_struct() {
+        assert_eq!(<Empty>::SIZE, 0);
+        assert_eq!(<Empty>::ALIGN, 1);
+        assert_eq!(<Empty>::FIELDS.len(), 0);
+    }
+
+    #[derive(Layout)]
+    struct SingleScalar {
+        value: f32,
+    }
+
+    #[test]
+    fn single_scalar_struct() {
+        assert_eq!(<SingleScalar>::SIZE, 4);
+        assert_eq!(<SingleScalar>::ALIGN, 4);
+        assert_eq!(<SingleScalar>::FIELDS.len(), 1);
+        assert_eq!(<SingleScalar>::FIELDS[0].name, "value");
+        assert_eq!(<SingleScalar>::FIELDS[0].offset, 0);
+        assert_eq!(<SingleScalar>::FIELDS[0].size, 4);
+        assert_eq!(<SingleScalar>::FIELDS[0].alignment, 4);
+        assert_eq!(<SingleScalar>::FIELDS[0].pad_before, 0);
+    }
+
+    #[derive(Layout)]
+    struct TightLayout {
+        velocity: wgsl_rs::std::Vec3f,
+        acceleration: wgsl_rs::std::Vec3f,
+        frame_count: u32,
+    }
+
+    #[test]
+    fn tight_layout_offsets() {
+        // velocity: offset 0, size 12, align 16
+        assert_eq!(<TightLayout>::FIELDS[0].name, "velocity");
+        assert_eq!(<TightLayout>::FIELDS[0].offset, 0);
+        assert_eq!(<TightLayout>::FIELDS[0].size, 12);
+        assert_eq!(<TightLayout>::FIELDS[0].alignment, 16);
+        assert_eq!(<TightLayout>::FIELDS[0].pad_before, 0);
+
+        // acceleration: roundUp(0+12, 16) = 16, size 12
+        assert_eq!(<TightLayout>::FIELDS[1].name, "acceleration");
+        assert_eq!(<TightLayout>::FIELDS[1].offset, 16);
+        assert_eq!(<TightLayout>::FIELDS[1].size, 12);
+        assert_eq!(<TightLayout>::FIELDS[1].alignment, 16);
+        assert_eq!(<TightLayout>::FIELDS[1].pad_before, 4);
+
+        // frame_count: roundUp(16+12, 4) = 28, u32=4
+        assert_eq!(<TightLayout>::FIELDS[2].name, "frame_count");
+        assert_eq!(<TightLayout>::FIELDS[2].offset, 28);
+        assert_eq!(<TightLayout>::FIELDS[2].size, 4);
+        assert_eq!(<TightLayout>::FIELDS[2].alignment, 4);
+        assert_eq!(<TightLayout>::FIELDS[2].pad_before, 0);
+
+        // struct size = roundUp(max(16,16,4)=16, 28+4=32) = 32
+        assert_eq!(<TightLayout>::SIZE, 32);
+        assert_eq!(<TightLayout>::ALIGN, 16);
+    }
+
+    #[derive(Layout)]
+    struct ComplexEx4 {
+        velocity: wgsl_rs::std::Vec3f,
+        size: f32,
+        direction: [wgsl_rs::std::Vec3f; 1],
+        scale: f32,
+        friction: f32,
+    }
+
+    #[test]
+    fn complex_ex4() {
+        // velocity: offset 0,  size 12, align 16
+        // size:     roundUp(12, 4) = 12, size 4, align 4, pad_before 0
+        // direction: roundUp(16, 16) = 16, [Vec3f;1] = 1*roundUp(16,12)=16, align 16
+        // scale:    roundUp(32, 4) = 32, size 4, align 4, pad_before 0
+        // friction: roundUp(36, 4) = 36, size 4, align 4, pad_before 0
+        // SIZE = roundUp(16, 36+4=40) = 48
+        assert_eq!(<ComplexEx4>::SIZE, 48);
+        assert_eq!(<ComplexEx4>::ALIGN, 16);
+
+        assert_eq!(<ComplexEx4>::FIELDS[0].name, "velocity");
+        assert_eq!(<ComplexEx4>::FIELDS[0].offset, 0);
+        assert_eq!(<ComplexEx4>::FIELDS[0].size, 12);
+        assert_eq!(<ComplexEx4>::FIELDS[0].alignment, 16);
+        assert_eq!(<ComplexEx4>::FIELDS[0].pad_before, 0);
+
+        assert_eq!(<ComplexEx4>::FIELDS[1].name, "size");
+        assert_eq!(<ComplexEx4>::FIELDS[1].offset, 12);
+        assert_eq!(<ComplexEx4>::FIELDS[1].size, 4);
+        assert_eq!(<ComplexEx4>::FIELDS[1].alignment, 4);
+        assert_eq!(<ComplexEx4>::FIELDS[1].pad_before, 0);
+
+        // direction: [Vec3f;1] → align 16, size 16. roundUp(12+4=16, 16) = 16
+        assert_eq!(<ComplexEx4>::FIELDS[2].name, "direction");
+        assert_eq!(<ComplexEx4>::FIELDS[2].offset, 16);
+        assert_eq!(<ComplexEx4>::FIELDS[2].size, 16);
+        assert_eq!(<ComplexEx4>::FIELDS[2].alignment, 16);
+        assert_eq!(<ComplexEx4>::FIELDS[2].pad_before, 0);
+
+        assert_eq!(<ComplexEx4>::FIELDS[3].name, "scale");
+        assert_eq!(<ComplexEx4>::FIELDS[3].offset, 32);
+        assert_eq!(<ComplexEx4>::FIELDS[3].size, 4);
+        assert_eq!(<ComplexEx4>::FIELDS[3].alignment, 4);
+        assert_eq!(<ComplexEx4>::FIELDS[3].pad_before, 0);
+
+        assert_eq!(<ComplexEx4>::FIELDS[4].name, "friction");
+        assert_eq!(<ComplexEx4>::FIELDS[4].offset, 36);
+        assert_eq!(<ComplexEx4>::FIELDS[4].size, 4);
+        assert_eq!(<ComplexEx4>::FIELDS[4].alignment, 4);
+        assert_eq!(<ComplexEx4>::FIELDS[4].pad_before, 0);
+    }
+
+    #[derive(Layout)]
+    struct NestedPadded {
+        orientation: wgsl_rs::std::Vec3f,
+        size: f32,
+        direction: [wgsl_rs::std::Vec3f; 1],
+        scale: f32,
+        info: Vec3Struct,
+        friction: f32,
+    }
+
+    #[derive(Layout)]
+    struct Vec3Struct {
+        velocity: wgsl_rs::std::Vec3f,
+    }
+
+    #[test]
+    fn nested_struct_with_align_gaps() {
+        // Vec3Struct: ALIGN = 16, SIZE = roundUp(16, 0+12) = 16
+        assert_eq!(<Vec3Struct>::SIZE, 16);
+        assert_eq!(<Vec3Struct>::ALIGN, 16);
+
+        // orientation: offset 0, size 12, align 16
+        // size:        roundUp(12, 4) = 12, size 4, align 4
+        // direction:   roundUp(16, 16) = 16, [Vec3f;1]=16, align 16
+        // scale:       roundUp(32, 4) = 32, size 4, align 4
+        // info:        roundUp(36, 16) = 48, size 16, align 16 → pad_before = 12
+        // friction:    roundUp(64, 4) = 64, size 4, align 4
+        // SIZE = roundUp(16, 64+4=68) = 80
+
+        assert_eq!(<NestedPadded>::SIZE, 80);
+        assert_eq!(<NestedPadded>::ALIGN, 16);
+
+        assert_eq!(<NestedPadded>::FIELDS[0].name, "orientation");
+        assert_eq!(<NestedPadded>::FIELDS[0].offset, 0);
+        assert_eq!(<NestedPadded>::FIELDS[0].size, 12);
+        assert_eq!(<NestedPadded>::FIELDS[0].alignment, 16);
+        assert_eq!(<NestedPadded>::FIELDS[0].pad_before, 0);
+
+        assert_eq!(<NestedPadded>::FIELDS[1].name, "size");
+        assert_eq!(<NestedPadded>::FIELDS[1].offset, 12);
+        assert_eq!(<NestedPadded>::FIELDS[1].size, 4);
+        assert_eq!(<NestedPadded>::FIELDS[1].alignment, 4);
+        assert_eq!(<NestedPadded>::FIELDS[1].pad_before, 0);
+
+        assert_eq!(<NestedPadded>::FIELDS[2].name, "direction");
+        assert_eq!(<NestedPadded>::FIELDS[2].offset, 16);
+        assert_eq!(<NestedPadded>::FIELDS[2].size, 16);
+        assert_eq!(<NestedPadded>::FIELDS[2].alignment, 16);
+        assert_eq!(<NestedPadded>::FIELDS[2].pad_before, 0);
+
+        assert_eq!(<NestedPadded>::FIELDS[3].name, "scale");
+        assert_eq!(<NestedPadded>::FIELDS[3].offset, 32);
+        assert_eq!(<NestedPadded>::FIELDS[3].size, 4);
+        assert_eq!(<NestedPadded>::FIELDS[3].alignment, 4);
+        assert_eq!(<NestedPadded>::FIELDS[3].pad_before, 0);
+
+        // info: roundUp(32+4=36, 16) = 48, size 16, pad_before = 48 - 36 = 12
+        assert_eq!(<NestedPadded>::FIELDS[4].name, "info");
+        assert_eq!(<NestedPadded>::FIELDS[4].offset, 48);
+        assert_eq!(<NestedPadded>::FIELDS[4].size, 16);
+        assert_eq!(<NestedPadded>::FIELDS[4].alignment, 16);
+        assert_eq!(<NestedPadded>::FIELDS[4].pad_before, 12);
+
+        assert_eq!(<NestedPadded>::FIELDS[5].name, "friction");
+        assert_eq!(<NestedPadded>::FIELDS[5].offset, 64);
+        assert_eq!(<NestedPadded>::FIELDS[5].size, 4);
+        assert_eq!(<NestedPadded>::FIELDS[5].alignment, 4);
+        assert_eq!(<NestedPadded>::FIELDS[5].pad_before, 0);
+    }
+
+    #[derive(Layout)]
+    struct GenericPair<T> {
+        a: T,
+        b: T,
+    }
+
+    #[test]
+    fn generic_struct() {
+        let layout_pair_f32 = GenericPair::<f32>::FIELDS;
+        assert_eq!(GenericPair::<f32>::SIZE, 8);
+        assert_eq!(GenericPair::<f32>::ALIGN, 4);
+
+        assert_eq!(layout_pair_f32[0].name, "a");
+        assert_eq!(layout_pair_f32[0].offset, 0);
+        assert_eq!(layout_pair_f32[0].size, 4);
+        assert_eq!(layout_pair_f32[0].alignment, 4);
+        assert_eq!(layout_pair_f32[0].pad_before, 0);
+
+        assert_eq!(layout_pair_f32[1].name, "b");
+        assert_eq!(layout_pair_f32[1].offset, 4);
+        assert_eq!(layout_pair_f32[1].size, 4);
+        assert_eq!(layout_pair_f32[1].alignment, 4);
+        assert_eq!(layout_pair_f32[1].pad_before, 0);
+
+        // Generic with Vec3f (align 16, size 12)
+        let layout_pair_vec3 = GenericPair::<wgsl_rs::std::Vec3f>::FIELDS;
+        assert_eq!(GenericPair::<wgsl_rs::std::Vec3f>::SIZE, 32);
+        assert_eq!(GenericPair::<wgsl_rs::std::Vec3f>::ALIGN, 16);
+
+        assert_eq!(layout_pair_vec3[0].offset, 0);
+        assert_eq!(layout_pair_vec3[0].size, 12);
+        assert_eq!(layout_pair_vec3[0].pad_before, 0);
+
+        // b: roundUp(12, 16) = 16
+        assert_eq!(layout_pair_vec3[1].offset, 16);
+        assert_eq!(layout_pair_vec3[1].size, 12);
+        assert_eq!(layout_pair_vec3[1].pad_before, 4);
+    }
+
+    // Verify pad_before with mixed alignments
+    #[derive(Layout)]
+    struct MixedAlign {
+        a: f32,
+        b: wgsl_rs::std::Mat4x4f,
+        c: f32,
+    }
+
+    #[test]
+    fn mixed_align_pad_before() {
+        // a: offset 0, size 4, align 4
+        // b: roundUp(4, 16) = 16, size 64, align 16, pad_before = 12
+        // c: roundUp(80, 4) = 80, size 4, align 4, pad_before = 0
+        // SIZE = roundUp(16, 84) = 96
+        assert_eq!(<MixedAlign>::SIZE, 96);
+        assert_eq!(<MixedAlign>::ALIGN, 16);
+
+        assert_eq!(<MixedAlign>::FIELDS[0].pad_before, 0);
+        assert_eq!(<MixedAlign>::FIELDS[1].offset, 16);
+        assert_eq!(<MixedAlign>::FIELDS[1].pad_before, 12);
+        assert_eq!(<MixedAlign>::FIELDS[2].pad_before, 0);
+    }
+}

--- a/crates/wgsl-rs-layout/src/lib.rs
+++ b/crates/wgsl-rs-layout/src/lib.rs
@@ -48,7 +48,7 @@ mod types;
 
 pub use field::FieldLayout;
 
-/// Error returned by [`WgslLayout::write_layout_bytes`] when the destination
+/// Error returned by [`WgslLayout::layout_write_bytes`] when the destination
 /// buffer is too small.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
@@ -83,7 +83,7 @@ pub trait WgslLayout: Sized {
     /// # Errors
     ///
     /// Returns [`Error::BufferTooSmall`] if `buf.len() < Self::SIZE`.
-    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error>;
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error>;
 
     /// Read a value of this type from `buf` at offset 0, using WGSL layout
     /// rules (little-endian scalars, alignment-padded fields).
@@ -91,7 +91,7 @@ pub trait WgslLayout: Sized {
     /// # Errors
     ///
     /// Returns [`Error::BufferTooSmall`] if `buf.len() < Self::SIZE`.
-    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error>;
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error>;
 }
 
 /// A struct whose field layout has been computed per WGSL rules.
@@ -105,24 +105,24 @@ pub trait Layout: WgslLayout {
 
 /// Write `t`'s bytes into `bytes` at offset 0 per WGSL layout rules.
 ///
-/// Convenience wrapper around [`WgslLayout::write_layout_bytes`].
+/// Convenience wrapper around [`WgslLayout::layout_write_bytes`].
 ///
 /// # Errors
 ///
 /// Returns [`Error::BufferTooSmall`] if `bytes.len() < T::SIZE`.
-pub fn write_layout_bytes<T: WgslLayout>(bytes: &mut [u8], t: &T) -> Result<(), Error> {
-    t.write_layout_bytes(bytes)
+pub fn layout_write_bytes<T: WgslLayout>(bytes: &mut [u8], t: &T) -> Result<(), Error> {
+    t.layout_write_bytes(bytes)
 }
 
 /// Read a value of type `T` from `bytes` at offset 0 per WGSL layout rules.
 ///
-/// Convenience wrapper around [`WgslLayout::read_layout_bytes`].
+/// Convenience wrapper around [`WgslLayout::layout_read_bytes`].
 ///
 /// # Errors
 ///
 /// Returns [`Error::BufferTooSmall`] if `bytes.len() < T::SIZE`.
-pub fn read_layout_bytes<T: WgslLayout>(bytes: &[u8]) -> Result<T, Error> {
-    T::read_layout_bytes(bytes)
+pub fn layout_read_bytes<T: WgslLayout>(bytes: &[u8]) -> Result<T, Error> {
+    T::layout_read_bytes(bytes)
 }
 
 /// Round `val` up to the next multiple of `align`.
@@ -145,7 +145,7 @@ pub fn zero_buffer(buf: &mut [u8], len: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{read_layout_bytes, write_layout_bytes};
+    use crate::{layout_read_bytes, layout_write_bytes};
 
     // ===== Scalar tests =====
 
@@ -487,7 +487,7 @@ mod tests {
         assert_eq!(<MixedAlign>::FIELDS[2].pad_before, 0);
     }
 
-    // ===== write_layout_bytes tests =====
+    // ===== layout_write_bytes tests =====
 
     fn read_f32_le(buf: &[u8]) -> f32 {
         f32::from_le_bytes(buf[..4].try_into().unwrap())
@@ -501,26 +501,26 @@ mod tests {
     fn write_scalars() {
         let mut buf = [0u8; 4];
         let v = 1.25f32;
-        write_layout_bytes(&mut buf, &v).unwrap();
+        layout_write_bytes(&mut buf, &v).unwrap();
         assert_eq!(read_f32_le(&buf), 1.25);
 
         let v = -42i32;
-        write_layout_bytes(&mut buf, &v).unwrap();
+        layout_write_bytes(&mut buf, &v).unwrap();
         assert_eq!(i32::from_le_bytes(buf[..4].try_into().unwrap()), -42);
 
         let v = true;
-        write_layout_bytes(&mut buf, &v).unwrap();
+        layout_write_bytes(&mut buf, &v).unwrap();
         assert_eq!(read_u32_le(&buf), 1);
 
         let v = false;
-        write_layout_bytes(&mut buf, &v).unwrap();
+        layout_write_bytes(&mut buf, &v).unwrap();
         assert_eq!(read_u32_le(&buf), 0);
     }
 
     #[test]
     fn write_buffer_too_small() {
         let mut buf = [0u8; 3];
-        let err = write_layout_bytes(&mut buf, &42.0f32).unwrap_err();
+        let err = layout_write_bytes(&mut buf, &42.0f32).unwrap_err();
         assert_eq!(
             err,
             Error::BufferTooSmall {
@@ -534,7 +534,7 @@ mod tests {
     fn write_vec3f() {
         let v = wgsl_rs::std::vec3f(1.0, 2.0, 3.0);
         let mut buf = vec![0u8; 12];
-        write_layout_bytes(&mut buf, &v).unwrap();
+        layout_write_bytes(&mut buf, &v).unwrap();
         assert_eq!(read_f32_le(&buf[0..4]), 1.0);
         assert_eq!(read_f32_le(&buf[4..8]), 2.0);
         assert_eq!(read_f32_le(&buf[8..12]), 3.0);
@@ -544,7 +544,7 @@ mod tests {
     fn write_single_scalar_struct() {
         let s = SingleScalar { value: 3.5 };
         let mut buf = vec![0u8; <SingleScalar>::SIZE];
-        write_layout_bytes(&mut buf, &s).unwrap();
+        layout_write_bytes(&mut buf, &s).unwrap();
         assert_eq!(read_f32_le(&buf), 3.5);
     }
 
@@ -557,7 +557,7 @@ mod tests {
         };
         // SIZE = 32, with padding at bytes 12-15 and 28-31
         let mut buf = vec![0u8; 32];
-        write_layout_bytes(&mut buf, &s).unwrap();
+        layout_write_bytes(&mut buf, &s).unwrap();
 
         // velocity at offset 0-11
         assert_eq!(read_f32_le(&buf[0..4]), 1.0);
@@ -587,7 +587,7 @@ mod tests {
             friction: 0.05,
         };
         let mut buf = vec![0u8; <NestedPadded>::SIZE];
-        write_layout_bytes(&mut buf, &s).unwrap();
+        layout_write_bytes(&mut buf, &s).unwrap();
 
         // orientation at 0-11
         assert_eq!(read_f32_le(&buf[0..4]), 0.0);
@@ -619,7 +619,7 @@ mod tests {
     fn write_generic_struct() {
         let p = GenericPair::<f32> { a: 1.0, b: 2.0 };
         let mut buf = vec![0u8; 8];
-        write_layout_bytes(&mut buf, &p).unwrap();
+        layout_write_bytes(&mut buf, &p).unwrap();
         assert_eq!(read_f32_le(&buf[0..4]), 1.0);
         assert_eq!(read_f32_le(&buf[4..8]), 2.0);
     }
@@ -628,7 +628,7 @@ mod tests {
     fn write_zero_size_empty_struct() {
         let s = Empty {};
         let mut buf = [];
-        write_layout_bytes(&mut buf, &s).unwrap();
+        layout_write_bytes(&mut buf, &s).unwrap();
     }
 
     #[test]
@@ -639,7 +639,7 @@ mod tests {
             c: 2.0,
         };
         let mut buf = vec![0xAAu8; 96]; // fill with non-zero to verify zeroing
-        write_layout_bytes(&mut buf, &s).unwrap();
+        layout_write_bytes(&mut buf, &s).unwrap();
 
         // a at 0-3
         assert_eq!(read_f32_le(&buf[0..4]), 1.0);
@@ -653,35 +653,35 @@ mod tests {
         assert_eq!(&buf[84..96], &[0u8; 12]);
     }
 
-    // ===== read_layout_bytes tests =====
+    // ===== layout_read_bytes tests =====
 
     #[test]
     fn read_scalars() {
         let buf = 1.25f32.to_le_bytes();
-        let v: f32 = read_layout_bytes(&buf).unwrap();
+        let v: f32 = layout_read_bytes(&buf).unwrap();
         assert_eq!(v, 1.25);
 
         let buf = (-42i32).to_le_bytes();
-        let v: i32 = read_layout_bytes(&buf).unwrap();
+        let v: i32 = layout_read_bytes(&buf).unwrap();
         assert_eq!(v, -42);
 
         let buf = 42u32.to_le_bytes();
-        let v: u32 = read_layout_bytes(&buf).unwrap();
+        let v: u32 = layout_read_bytes(&buf).unwrap();
         assert_eq!(v, 42);
 
         let buf = 0u32.to_le_bytes();
-        let v: bool = read_layout_bytes(&buf).unwrap();
+        let v: bool = layout_read_bytes(&buf).unwrap();
         assert!(!v);
 
         let buf = 1u32.to_le_bytes();
-        let v: bool = read_layout_bytes(&buf).unwrap();
+        let v: bool = layout_read_bytes(&buf).unwrap();
         assert!(v);
     }
 
     #[test]
     fn read_buffer_too_small() {
         let buf = [0u8; 3];
-        let err = read_layout_bytes::<f32>(&buf).unwrap_err();
+        let err = layout_read_bytes::<f32>(&buf).unwrap_err();
         assert_eq!(
             err,
             Error::BufferTooSmall {
@@ -695,8 +695,8 @@ mod tests {
     fn read_vec3f() {
         let original = wgsl_rs::std::vec3f(1.0, 2.0, 3.0);
         let mut buf = vec![0u8; 12];
-        write_layout_bytes(&mut buf, &original).unwrap();
-        let restored: wgsl_rs::std::Vec3f = read_layout_bytes(&buf).unwrap();
+        layout_write_bytes(&mut buf, &original).unwrap();
+        let restored: wgsl_rs::std::Vec3f = layout_read_bytes(&buf).unwrap();
         assert_eq!(restored, original);
     }
 
@@ -708,8 +708,8 @@ mod tests {
             frame_count: 42,
         };
         let mut buf = vec![0u8; <TightLayout>::SIZE];
-        write_layout_bytes(&mut buf, &s).unwrap();
-        let restored: TightLayout = read_layout_bytes(&buf).unwrap();
+        layout_write_bytes(&mut buf, &s).unwrap();
+        let restored: TightLayout = layout_read_bytes(&buf).unwrap();
         assert_eq!(restored, s);
     }
 
@@ -727,8 +727,8 @@ mod tests {
             friction: 0.05,
         };
         let mut buf = vec![0u8; <NestedPadded>::SIZE];
-        write_layout_bytes(&mut buf, &s).unwrap();
-        let restored: NestedPadded = read_layout_bytes(&buf).unwrap();
+        layout_write_bytes(&mut buf, &s).unwrap();
+        let restored: NestedPadded = layout_read_bytes(&buf).unwrap();
         assert_eq!(restored, s);
     }
 
@@ -736,15 +736,15 @@ mod tests {
     fn read_write_roundtrip_generic() {
         let p = GenericPair::<f32> { a: 1.0, b: 2.0 };
         let mut buf = vec![0u8; <GenericPair<f32>>::SIZE];
-        write_layout_bytes(&mut buf, &p).unwrap();
-        let restored: GenericPair<f32> = read_layout_bytes(&buf).unwrap();
+        layout_write_bytes(&mut buf, &p).unwrap();
+        let restored: GenericPair<f32> = layout_read_bytes(&buf).unwrap();
         assert_eq!(restored.a, p.a);
         assert_eq!(restored.b, p.b);
     }
 
     #[test]
     fn read_zero_size_empty_struct() {
-        let s: Empty = read_layout_bytes(&[]).unwrap();
+        let s: Empty = layout_read_bytes(&[]).unwrap();
         // An empty struct has no fields to compare, so we just verify it returns Ok.
         let _ = s;
     }
@@ -757,8 +757,8 @@ mod tests {
             c: 2.0,
         };
         let mut buf = vec![0u8; <MixedAlign>::SIZE];
-        write_layout_bytes(&mut buf, &s).unwrap();
-        let restored: MixedAlign = read_layout_bytes(&buf).unwrap();
+        layout_write_bytes(&mut buf, &s).unwrap();
+        let restored: MixedAlign = layout_read_bytes(&buf).unwrap();
         assert_eq!(restored.a, s.a);
         // Mat4x4f only implements Default (not Debug/PartialEq easily), so check
         // columns

--- a/crates/wgsl-rs-layout/src/lib.rs
+++ b/crates/wgsl-rs-layout/src/lib.rs
@@ -7,9 +7,9 @@
 //!
 //! # Quick Start
 //!
-//! ```ignore
-//! use wgsl_rs_layout::{Layout, WgslLayout, FieldLayout};
-//! use wgsl_rs::{Mat4x4f, Vec4f};
+//! ```rust
+//! use wgsl_rs::std::*;
+//! use wgsl_rs_layout::{FieldLayout, Layout, WgslLayout};
 //!
 //! #[derive(Layout)]
 //! struct Uniforms {

--- a/crates/wgsl-rs-layout/src/lib.rs
+++ b/crates/wgsl-rs-layout/src/lib.rs
@@ -48,6 +48,19 @@ mod types;
 
 pub use field::FieldLayout;
 
+/// Error returned by [`WgslLayout::write_layout_bytes`] when the destination
+/// buffer is too small.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Error {
+    /// The buffer is too small for the type's size.
+    BufferTooSmall {
+        /// The number of bytes needed.
+        needed: usize,
+        /// The number of bytes available.
+        actual: usize,
+    },
+}
+
 /// A type with a known WGSL memory layout.
 ///
 /// Each type that can appear as a field in a host-shareable WGSL struct
@@ -63,6 +76,14 @@ pub trait WgslLayout {
     /// The alignment in bytes of this type per WGSL layout rules.
     /// Must be a power of two.
     const ALIGN: usize;
+
+    /// Write this value's bytes into `buf` at offset 0, using WGSL layout
+    /// rules (little-endian scalars, alignment-padded fields).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::BufferTooSmall`] if `buf.len() < Self::SIZE`.
+    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error>;
 }
 
 /// A struct whose field layout has been computed per WGSL rules.
@@ -74,6 +95,17 @@ pub trait Layout: WgslLayout {
     const FIELDS: &'static [FieldLayout];
 }
 
+/// Write `t`'s bytes into `bytes` at offset 0 per WGSL layout rules.
+///
+/// Convenience wrapper around [`WgslLayout::write_layout_bytes`].
+///
+/// # Errors
+///
+/// Returns [`Error::BufferTooSmall`] if `bytes.len() < T::SIZE`.
+pub fn write_layout_bytes<T: WgslLayout>(bytes: &mut [u8], t: &T) -> Result<(), Error> {
+    t.write_layout_bytes(bytes)
+}
+
 /// Round `val` up to the next multiple of `align`.
 ///
 /// `align` must be a power of two.
@@ -82,9 +114,19 @@ pub const fn round_up(val: usize, align: usize) -> usize {
     (val + (align - 1)) & !(align - 1)
 }
 
+/// Zero the first `len` bytes of `buf`.
+///
+/// Internal helper used by `#[derive(Layout)]` to zero padding bytes before
+/// writing field data.
+#[doc(hidden)]
+pub fn zero_buffer(buf: &mut [u8], len: usize) {
+    buf[..len].fill(0);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::write_layout_bytes;
 
     // ===== Scalar tests =====
 
@@ -424,5 +466,171 @@ mod tests {
         assert_eq!(<MixedAlign>::FIELDS[1].offset, 16);
         assert_eq!(<MixedAlign>::FIELDS[1].pad_before, 12);
         assert_eq!(<MixedAlign>::FIELDS[2].pad_before, 0);
+    }
+
+    // ===== write_layout_bytes tests =====
+
+    fn read_f32_le(buf: &[u8]) -> f32 {
+        f32::from_le_bytes(buf[..4].try_into().unwrap())
+    }
+
+    fn read_u32_le(buf: &[u8]) -> u32 {
+        u32::from_le_bytes(buf[..4].try_into().unwrap())
+    }
+
+    #[test]
+    fn write_scalars() {
+        let mut buf = [0u8; 4];
+        let v = 1.25f32;
+        write_layout_bytes(&mut buf, &v).unwrap();
+        assert_eq!(read_f32_le(&buf), 1.25);
+
+        let v = -42i32;
+        write_layout_bytes(&mut buf, &v).unwrap();
+        assert_eq!(i32::from_le_bytes(buf[..4].try_into().unwrap()), -42);
+
+        let v = true;
+        write_layout_bytes(&mut buf, &v).unwrap();
+        assert_eq!(read_u32_le(&buf), 1);
+
+        let v = false;
+        write_layout_bytes(&mut buf, &v).unwrap();
+        assert_eq!(read_u32_le(&buf), 0);
+    }
+
+    #[test]
+    fn write_buffer_too_small() {
+        let mut buf = [0u8; 3];
+        let err = write_layout_bytes(&mut buf, &42.0f32).unwrap_err();
+        assert_eq!(
+            err,
+            Error::BufferTooSmall {
+                needed: 4,
+                actual: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn write_vec3f() {
+        let v = wgsl_rs::std::vec3f(1.0, 2.0, 3.0);
+        let mut buf = vec![0u8; 12];
+        write_layout_bytes(&mut buf, &v).unwrap();
+        assert_eq!(read_f32_le(&buf[0..4]), 1.0);
+        assert_eq!(read_f32_le(&buf[4..8]), 2.0);
+        assert_eq!(read_f32_le(&buf[8..12]), 3.0);
+    }
+
+    #[test]
+    fn write_single_scalar_struct() {
+        let s = SingleScalar { value: 3.5 };
+        let mut buf = vec![0u8; <SingleScalar>::SIZE];
+        write_layout_bytes(&mut buf, &s).unwrap();
+        assert_eq!(read_f32_le(&buf), 3.5);
+    }
+
+    #[test]
+    fn write_tight_layout_padding() {
+        let s = TightLayout {
+            velocity: wgsl_rs::std::vec3f(1.0, 0.0, -1.0),
+            acceleration: wgsl_rs::std::vec3f(0.0, -9.8, 0.0),
+            frame_count: 42,
+        };
+        // SIZE = 32, with padding at bytes 12-15 and 28-31
+        let mut buf = vec![0u8; 32];
+        write_layout_bytes(&mut buf, &s).unwrap();
+
+        // velocity at offset 0-11
+        assert_eq!(read_f32_le(&buf[0..4]), 1.0);
+        assert_eq!(read_f32_le(&buf[4..8]), 0.0);
+        assert_eq!(read_f32_le(&buf[8..12]), -1.0);
+        // padding at 12-15 should be zero
+        assert_eq!(&buf[12..16], &[0u8; 4]);
+        // acceleration at offset 16-27
+        assert_eq!(read_f32_le(&buf[16..20]), 0.0);
+        assert_eq!(read_f32_le(&buf[20..24]), -9.8);
+        assert_eq!(read_f32_le(&buf[24..28]), 0.0);
+        // frame_count at offset 28-31 (offset 28 is NOT padding — it's field data)
+        assert_eq!(read_u32_le(&buf[28..32]), 42);
+    }
+
+    #[test]
+    fn write_nested_struct() {
+        let info = Vec3Struct {
+            velocity: wgsl_rs::std::vec3f(1.0, 2.0, 3.0),
+        };
+        let s = NestedPadded {
+            orientation: wgsl_rs::std::vec3f(0.0, 1.0, 0.0),
+            size: 2.5,
+            direction: [wgsl_rs::std::vec3f(4.0, 5.0, 6.0)],
+            scale: 0.1,
+            info,
+            friction: 0.05,
+        };
+        let mut buf = vec![0u8; <NestedPadded>::SIZE];
+        write_layout_bytes(&mut buf, &s).unwrap();
+
+        // orientation at 0-11
+        assert_eq!(read_f32_le(&buf[0..4]), 0.0);
+        assert_eq!(read_f32_le(&buf[4..8]), 1.0);
+        assert_eq!(read_f32_le(&buf[8..12]), 0.0);
+        // size at 12-15
+        assert_eq!(read_f32_le(&buf[12..16]), 2.5);
+        // direction at 16-31
+        assert_eq!(read_f32_le(&buf[16..20]), 4.0);
+        assert_eq!(read_f32_le(&buf[20..24]), 5.0);
+        assert_eq!(read_f32_le(&buf[24..28]), 6.0);
+        // padding at 28-31 zero
+        assert_eq!(&buf[28..32], &[0u8; 4]);
+        // scale at 32-35
+        assert_eq!(read_f32_le(&buf[32..36]), 0.1);
+        // padding at 36-47 zero (12 bytes before info)
+        assert_eq!(&buf[36..48], &[0u8; 12]);
+        // info at 48-63
+        assert_eq!(read_f32_le(&buf[48..52]), 1.0);
+        assert_eq!(read_f32_le(&buf[52..56]), 2.0);
+        assert_eq!(read_f32_le(&buf[56..60]), 3.0);
+        // padding at 60-63 zero
+        assert_eq!(&buf[60..64], &[0u8; 4]);
+        // friction at 64-67
+        assert_eq!(read_f32_le(&buf[64..68]), 0.05);
+    }
+
+    #[test]
+    fn write_generic_struct() {
+        let p = GenericPair::<f32> { a: 1.0, b: 2.0 };
+        let mut buf = vec![0u8; 8];
+        write_layout_bytes(&mut buf, &p).unwrap();
+        assert_eq!(read_f32_le(&buf[0..4]), 1.0);
+        assert_eq!(read_f32_le(&buf[4..8]), 2.0);
+    }
+
+    #[test]
+    fn write_zero_size_empty_struct() {
+        let s = Empty {};
+        let mut buf = [];
+        write_layout_bytes(&mut buf, &s).unwrap();
+    }
+
+    #[test]
+    fn write_mixed_align_padding() {
+        let s = MixedAlign {
+            a: 1.0,
+            b: wgsl_rs::std::Mat4x4f::default(),
+            c: 2.0,
+        };
+        let mut buf = vec![0xAAu8; 96]; // fill with non-zero to verify zeroing
+        write_layout_bytes(&mut buf, &s).unwrap();
+
+        // a at 0-3
+        assert_eq!(read_f32_le(&buf[0..4]), 1.0);
+        // padding at 4-15 should be zero
+        assert_eq!(&buf[4..16], &[0u8; 12]);
+        // b at 16-79 (mat4x4f)
+        assert_eq!(read_f32_le(&buf[16..20]), 0.0); // default Mat4x4f is identity
+        // c at 80-83
+        assert_eq!(read_f32_le(&buf[80..84]), 2.0);
+        // trailing padding at 84-95 zero
+        assert_eq!(&buf[84..96], &[0u8; 12]);
     }
 }

--- a/crates/wgsl-rs-layout/src/types.rs
+++ b/crates/wgsl-rs-layout/src/types.rs
@@ -6,6 +6,16 @@ impl WgslLayout for f32 {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
 
+    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        Ok(f32::from_le_bytes(buf[..4].try_into().unwrap()))
+    }
+
     fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
@@ -21,6 +31,16 @@ impl WgslLayout for f32 {
 impl WgslLayout for i32 {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
+
+    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        Ok(i32::from_le_bytes(buf[..4].try_into().unwrap()))
+    }
 
     fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
@@ -38,6 +58,16 @@ impl WgslLayout for u32 {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
 
+    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        Ok(u32::from_le_bytes(buf[..4].try_into().unwrap()))
+    }
+
     fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
@@ -53,6 +83,17 @@ impl WgslLayout for u32 {
 impl WgslLayout for bool {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
+
+    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        let val = u32::from_le_bytes(buf[..4].try_into().unwrap());
+        Ok(val != 0)
+    }
 
     fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
@@ -73,6 +114,19 @@ impl WgslLayout for wgsl_rs::std::Atomic<u32> {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
 
+    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        let val = u32::from_le_bytes(buf[..4].try_into().unwrap());
+        let a = wgsl_rs::std::Atomic::default();
+        wgsl_rs::std::atomic_store(&a, val);
+        Ok(a)
+    }
+
     fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
@@ -89,6 +143,19 @@ impl WgslLayout for wgsl_rs::std::Atomic<u32> {
 impl WgslLayout for wgsl_rs::std::Atomic<i32> {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
+
+    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        let val = i32::from_le_bytes(buf[..4].try_into().unwrap());
+        let a = wgsl_rs::std::Atomic::default();
+        wgsl_rs::std::atomic_store_i32(&a, val);
+        Ok(a)
+    }
 
     fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
@@ -109,6 +176,19 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec2
     const SIZE: usize = 8;
     const ALIGN: usize = 8;
 
+    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+        if buf.len() < 8 {
+            return Err(Error::BufferTooSmall {
+                needed: 8,
+                actual: buf.len(),
+            });
+        }
+        let stride = T::SIZE;
+        let x = T::read_layout_bytes(&buf[0..stride])?;
+        let y = T::read_layout_bytes(&buf[stride..stride * 2])?;
+        Ok(wgsl_rs::std::Vec2 { x, y })
+    }
+
     fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 8 {
             return Err(Error::BufferTooSmall {
@@ -126,6 +206,20 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec2
 impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec3<T> {
     const SIZE: usize = 12;
     const ALIGN: usize = 16;
+
+    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+        if buf.len() < 12 {
+            return Err(Error::BufferTooSmall {
+                needed: 12,
+                actual: buf.len(),
+            });
+        }
+        let stride = T::SIZE;
+        let x = T::read_layout_bytes(&buf[0..stride])?;
+        let y = T::read_layout_bytes(&buf[stride..stride * 2])?;
+        let z = T::read_layout_bytes(&buf[stride * 2..stride * 3])?;
+        Ok(wgsl_rs::std::Vec3 { x, y, z })
+    }
 
     fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 12 {
@@ -145,6 +239,21 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec3
 impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec4<T> {
     const SIZE: usize = 16;
     const ALIGN: usize = 16;
+
+    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+        if buf.len() < 16 {
+            return Err(Error::BufferTooSmall {
+                needed: 16,
+                actual: buf.len(),
+            });
+        }
+        let stride = T::SIZE;
+        let x = T::read_layout_bytes(&buf[0..stride])?;
+        let y = T::read_layout_bytes(&buf[stride..stride * 2])?;
+        let z = T::read_layout_bytes(&buf[stride * 2..stride * 3])?;
+        let w = T::read_layout_bytes(&buf[stride * 3..stride * 4])?;
+        Ok(wgsl_rs::std::Vec4 { x, y, z, w })
+    }
 
     fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 16 {
@@ -169,6 +278,21 @@ macro_rules! impl_mat_layout {
         impl WgslLayout for $ty {
             const SIZE: usize = $size;
             const ALIGN: usize = $align;
+
+            fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+                if buf.len() < $size {
+                    return Err(Error::BufferTooSmall {
+                        needed: $size,
+                        actual: buf.len(),
+                    });
+                }
+                let mut mat = Self::default();
+                for i in 0..$cols {
+                    let col_offset = i * $stride;
+                    mat[i] = <$row_vec>::read_layout_bytes(&buf[col_offset..])?;
+                }
+                Ok(mat)
+            }
 
             fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
                 if buf.len() < $size {
@@ -204,6 +328,23 @@ impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
     const SIZE: usize = N * crate::round_up(T::ALIGN, T::SIZE);
     const ALIGN: usize = T::ALIGN;
 
+    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+        let stride = crate::round_up(T::ALIGN, T::SIZE);
+        if buf.len() < N * stride {
+            return Err(Error::BufferTooSmall {
+                needed: N * stride,
+                actual: buf.len(),
+            });
+        }
+        // Initialize with default values then overwrite
+        let mut arr: [T; N] = unsafe { std::mem::zeroed() };
+        for (i, slot) in arr.iter_mut().enumerate() {
+            let elem = T::read_layout_bytes(&buf[i * stride..])?;
+            *slot = elem;
+        }
+        Ok(arr)
+    }
+
     fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         let stride = crate::round_up(T::ALIGN, T::SIZE);
         if buf.len() < N * stride {
@@ -224,6 +365,10 @@ impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
 impl<T: WgslLayout> WgslLayout for wgsl_rs::std::RuntimeArray<T> {
     const SIZE: usize = 0;
     const ALIGN: usize = T::ALIGN;
+
+    fn read_layout_bytes(_buf: &[u8]) -> Result<Self, Error> {
+        Ok(wgsl_rs::std::RuntimeArray::new())
+    }
 
     fn write_layout_bytes(&self, _buf: &mut [u8]) -> Result<(), Error> {
         Ok(())

--- a/crates/wgsl-rs-layout/src/types.rs
+++ b/crates/wgsl-rs-layout/src/types.rs
@@ -1,25 +1,70 @@
-use crate::WgslLayout;
+use crate::{Error, WgslLayout};
 
 // ===== Scalars =====
 
 impl WgslLayout for f32 {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
+
+    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        buf[..4].copy_from_slice(&self.to_le_bytes());
+        Ok(())
+    }
 }
 
 impl WgslLayout for i32 {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
+
+    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        buf[..4].copy_from_slice(&self.to_le_bytes());
+        Ok(())
+    }
 }
 
 impl WgslLayout for u32 {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
+
+    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        buf[..4].copy_from_slice(&self.to_le_bytes());
+        Ok(())
+    }
 }
 
 impl WgslLayout for bool {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
+
+    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        let val: u32 = if *self { 1 } else { 0 };
+        buf[..4].copy_from_slice(&val.to_le_bytes());
+        Ok(())
+    }
 }
 
 // ===== Atomically accessible types =====
@@ -27,56 +72,151 @@ impl WgslLayout for bool {
 impl WgslLayout for wgsl_rs::std::Atomic<u32> {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
+
+    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        let val = wgsl_rs::std::atomic_load(self);
+        buf[..4].copy_from_slice(&val.to_le_bytes());
+        Ok(())
+    }
 }
 
 impl WgslLayout for wgsl_rs::std::Atomic<i32> {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
+
+    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < 4 {
+            return Err(Error::BufferTooSmall {
+                needed: 4,
+                actual: buf.len(),
+            });
+        }
+        let val = wgsl_rs::std::atomic_load_i32(self);
+        buf[..4].copy_from_slice(&val.to_le_bytes());
+        Ok(())
+    }
 }
 
 // ===== Vectors (32-bit scalar elements) =====
 
-impl<T: wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec2<T> {
+impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec2<T> {
     const SIZE: usize = 8;
     const ALIGN: usize = 8;
+
+    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < 8 {
+            return Err(Error::BufferTooSmall {
+                needed: 8,
+                actual: buf.len(),
+            });
+        }
+        let stride = T::SIZE;
+        T::write_layout_bytes(&self.x, &mut buf[0..stride])?;
+        T::write_layout_bytes(&self.y, &mut buf[stride..stride * 2])?;
+        Ok(())
+    }
 }
 
-impl<T: wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec3<T> {
+impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec3<T> {
     const SIZE: usize = 12;
     const ALIGN: usize = 16;
+
+    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < 12 {
+            return Err(Error::BufferTooSmall {
+                needed: 12,
+                actual: buf.len(),
+            });
+        }
+        let stride = T::SIZE;
+        T::write_layout_bytes(&self.x, &mut buf[0..stride])?;
+        T::write_layout_bytes(&self.y, &mut buf[stride..stride * 2])?;
+        T::write_layout_bytes(&self.z, &mut buf[stride * 2..stride * 3])?;
+        Ok(())
+    }
 }
 
-impl<T: wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec4<T> {
+impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec4<T> {
     const SIZE: usize = 16;
     const ALIGN: usize = 16;
+
+    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < 16 {
+            return Err(Error::BufferTooSmall {
+                needed: 16,
+                actual: buf.len(),
+            });
+        }
+        let stride = T::SIZE;
+        T::write_layout_bytes(&self.x, &mut buf[0..stride])?;
+        T::write_layout_bytes(&self.y, &mut buf[stride..stride * 2])?;
+        T::write_layout_bytes(&self.z, &mut buf[stride * 2..stride * 3])?;
+        T::write_layout_bytes(&self.w, &mut buf[stride * 3..stride * 4])?;
+        Ok(())
+    }
 }
 
 // ===== Matrices =====
 
 macro_rules! impl_mat_layout {
-    ($ty:ty, $align:expr, $size:expr) => {
+    ($ty:ty, $row_vec:ty, $cols:literal, $stride:expr, $align:expr, $size:expr) => {
         impl WgslLayout for $ty {
             const SIZE: usize = $size;
             const ALIGN: usize = $align;
+
+            fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+                if buf.len() < $size {
+                    return Err(Error::BufferTooSmall {
+                        needed: $size,
+                        actual: buf.len(),
+                    });
+                }
+                for i in 0..$cols {
+                    let col_offset = i * $stride;
+                    let col: &$row_vec = &self[i];
+                    col.write_layout_bytes(&mut buf[col_offset..])?;
+                }
+                Ok(())
+            }
         }
     };
 }
 
-impl_mat_layout!(wgsl_rs::std::Mat2x2f, 8, 16);
-impl_mat_layout!(wgsl_rs::std::Mat2x3f, 16, 32);
-impl_mat_layout!(wgsl_rs::std::Mat2x4f, 16, 32);
-impl_mat_layout!(wgsl_rs::std::Mat3x2f, 8, 24);
-impl_mat_layout!(wgsl_rs::std::Mat3x3f, 16, 48);
-impl_mat_layout!(wgsl_rs::std::Mat3x4f, 16, 48);
-impl_mat_layout!(wgsl_rs::std::Mat4x2f, 8, 32);
-impl_mat_layout!(wgsl_rs::std::Mat4x3f, 16, 64);
-impl_mat_layout!(wgsl_rs::std::Mat4x4f, 16, 64);
+impl_mat_layout!(wgsl_rs::std::Mat2x2f, wgsl_rs::std::Vec2f, 2, 8, 8, 16);
+impl_mat_layout!(wgsl_rs::std::Mat2x3f, wgsl_rs::std::Vec3f, 2, 16, 16, 32);
+impl_mat_layout!(wgsl_rs::std::Mat2x4f, wgsl_rs::std::Vec4f, 2, 16, 16, 32);
+impl_mat_layout!(wgsl_rs::std::Mat3x2f, wgsl_rs::std::Vec2f, 3, 8, 8, 24);
+impl_mat_layout!(wgsl_rs::std::Mat3x3f, wgsl_rs::std::Vec3f, 3, 16, 16, 48);
+impl_mat_layout!(wgsl_rs::std::Mat3x4f, wgsl_rs::std::Vec4f, 3, 16, 16, 48);
+impl_mat_layout!(wgsl_rs::std::Mat4x2f, wgsl_rs::std::Vec2f, 4, 8, 8, 32);
+impl_mat_layout!(wgsl_rs::std::Mat4x3f, wgsl_rs::std::Vec3f, 4, 16, 16, 64);
+impl_mat_layout!(wgsl_rs::std::Mat4x4f, wgsl_rs::std::Vec4f, 4, 16, 16, 64);
 
 // ===== Fixed-size arrays =====
 
 impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
     const SIZE: usize = N * crate::round_up(T::ALIGN, T::SIZE);
     const ALIGN: usize = T::ALIGN;
+
+    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+        let stride = crate::round_up(T::ALIGN, T::SIZE);
+        if buf.len() < N * stride {
+            return Err(Error::BufferTooSmall {
+                needed: N * stride,
+                actual: buf.len(),
+            });
+        }
+        for (i, elem) in self.iter().enumerate() {
+            elem.write_layout_bytes(&mut buf[i * stride..])?;
+        }
+        Ok(())
+    }
 }
 
 // ===== Runtime-sized arrays =====
@@ -84,4 +224,8 @@ impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
 impl<T: WgslLayout> WgslLayout for wgsl_rs::std::RuntimeArray<T> {
     const SIZE: usize = 0;
     const ALIGN: usize = T::ALIGN;
+
+    fn write_layout_bytes(&self, _buf: &mut [u8]) -> Result<(), Error> {
+        Ok(())
+    }
 }

--- a/crates/wgsl-rs-layout/src/types.rs
+++ b/crates/wgsl-rs-layout/src/types.rs
@@ -6,7 +6,7 @@ impl WgslLayout for f32 {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
 
-    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -16,7 +16,7 @@ impl WgslLayout for f32 {
         Ok(f32::from_le_bytes(buf[..4].try_into().unwrap()))
     }
 
-    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -32,7 +32,7 @@ impl WgslLayout for i32 {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
 
-    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -42,7 +42,7 @@ impl WgslLayout for i32 {
         Ok(i32::from_le_bytes(buf[..4].try_into().unwrap()))
     }
 
-    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -58,7 +58,7 @@ impl WgslLayout for u32 {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
 
-    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -68,7 +68,7 @@ impl WgslLayout for u32 {
         Ok(u32::from_le_bytes(buf[..4].try_into().unwrap()))
     }
 
-    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -84,7 +84,7 @@ impl WgslLayout for bool {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
 
-    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -95,7 +95,7 @@ impl WgslLayout for bool {
         Ok(val != 0)
     }
 
-    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -114,7 +114,7 @@ impl WgslLayout for wgsl_rs::std::Atomic<u32> {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
 
-    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -127,7 +127,7 @@ impl WgslLayout for wgsl_rs::std::Atomic<u32> {
         Ok(a)
     }
 
-    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -144,7 +144,7 @@ impl WgslLayout for wgsl_rs::std::Atomic<i32> {
     const SIZE: usize = 4;
     const ALIGN: usize = 4;
 
-    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -157,7 +157,7 @@ impl WgslLayout for wgsl_rs::std::Atomic<i32> {
         Ok(a)
     }
 
-    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 4 {
             return Err(Error::BufferTooSmall {
                 needed: 4,
@@ -176,7 +176,7 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec2
     const SIZE: usize = 8;
     const ALIGN: usize = 8;
 
-    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
         if buf.len() < 8 {
             return Err(Error::BufferTooSmall {
                 needed: 8,
@@ -184,12 +184,12 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec2
             });
         }
         let stride = T::SIZE;
-        let x = T::read_layout_bytes(&buf[0..stride])?;
-        let y = T::read_layout_bytes(&buf[stride..stride * 2])?;
+        let x = T::layout_read_bytes(&buf[0..stride])?;
+        let y = T::layout_read_bytes(&buf[stride..stride * 2])?;
         Ok(wgsl_rs::std::Vec2 { x, y })
     }
 
-    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 8 {
             return Err(Error::BufferTooSmall {
                 needed: 8,
@@ -197,8 +197,8 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec2
             });
         }
         let stride = T::SIZE;
-        T::write_layout_bytes(&self.x, &mut buf[0..stride])?;
-        T::write_layout_bytes(&self.y, &mut buf[stride..stride * 2])?;
+        T::layout_write_bytes(&self.x, &mut buf[0..stride])?;
+        T::layout_write_bytes(&self.y, &mut buf[stride..stride * 2])?;
         Ok(())
     }
 }
@@ -207,7 +207,7 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec3
     const SIZE: usize = 12;
     const ALIGN: usize = 16;
 
-    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
         if buf.len() < 12 {
             return Err(Error::BufferTooSmall {
                 needed: 12,
@@ -215,13 +215,13 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec3
             });
         }
         let stride = T::SIZE;
-        let x = T::read_layout_bytes(&buf[0..stride])?;
-        let y = T::read_layout_bytes(&buf[stride..stride * 2])?;
-        let z = T::read_layout_bytes(&buf[stride * 2..stride * 3])?;
+        let x = T::layout_read_bytes(&buf[0..stride])?;
+        let y = T::layout_read_bytes(&buf[stride..stride * 2])?;
+        let z = T::layout_read_bytes(&buf[stride * 2..stride * 3])?;
         Ok(wgsl_rs::std::Vec3 { x, y, z })
     }
 
-    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 12 {
             return Err(Error::BufferTooSmall {
                 needed: 12,
@@ -229,9 +229,9 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec3
             });
         }
         let stride = T::SIZE;
-        T::write_layout_bytes(&self.x, &mut buf[0..stride])?;
-        T::write_layout_bytes(&self.y, &mut buf[stride..stride * 2])?;
-        T::write_layout_bytes(&self.z, &mut buf[stride * 2..stride * 3])?;
+        T::layout_write_bytes(&self.x, &mut buf[0..stride])?;
+        T::layout_write_bytes(&self.y, &mut buf[stride..stride * 2])?;
+        T::layout_write_bytes(&self.z, &mut buf[stride * 2..stride * 3])?;
         Ok(())
     }
 }
@@ -240,7 +240,7 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec4
     const SIZE: usize = 16;
     const ALIGN: usize = 16;
 
-    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
         if buf.len() < 16 {
             return Err(Error::BufferTooSmall {
                 needed: 16,
@@ -248,14 +248,14 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec4
             });
         }
         let stride = T::SIZE;
-        let x = T::read_layout_bytes(&buf[0..stride])?;
-        let y = T::read_layout_bytes(&buf[stride..stride * 2])?;
-        let z = T::read_layout_bytes(&buf[stride * 2..stride * 3])?;
-        let w = T::read_layout_bytes(&buf[stride * 3..stride * 4])?;
+        let x = T::layout_read_bytes(&buf[0..stride])?;
+        let y = T::layout_read_bytes(&buf[stride..stride * 2])?;
+        let z = T::layout_read_bytes(&buf[stride * 2..stride * 3])?;
+        let w = T::layout_read_bytes(&buf[stride * 3..stride * 4])?;
         Ok(wgsl_rs::std::Vec4 { x, y, z, w })
     }
 
-    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         if buf.len() < 16 {
             return Err(Error::BufferTooSmall {
                 needed: 16,
@@ -263,10 +263,10 @@ impl<T: WgslLayout + wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec4
             });
         }
         let stride = T::SIZE;
-        T::write_layout_bytes(&self.x, &mut buf[0..stride])?;
-        T::write_layout_bytes(&self.y, &mut buf[stride..stride * 2])?;
-        T::write_layout_bytes(&self.z, &mut buf[stride * 2..stride * 3])?;
-        T::write_layout_bytes(&self.w, &mut buf[stride * 3..stride * 4])?;
+        T::layout_write_bytes(&self.x, &mut buf[0..stride])?;
+        T::layout_write_bytes(&self.y, &mut buf[stride..stride * 2])?;
+        T::layout_write_bytes(&self.z, &mut buf[stride * 2..stride * 3])?;
+        T::layout_write_bytes(&self.w, &mut buf[stride * 3..stride * 4])?;
         Ok(())
     }
 }
@@ -279,7 +279,7 @@ macro_rules! impl_mat_layout {
             const SIZE: usize = $size;
             const ALIGN: usize = $align;
 
-            fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+            fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
                 if buf.len() < $size {
                     return Err(Error::BufferTooSmall {
                         needed: $size,
@@ -289,12 +289,12 @@ macro_rules! impl_mat_layout {
                 let mut mat = Self::default();
                 for i in 0..$cols {
                     let col_offset = i * $stride;
-                    mat[i] = <$row_vec>::read_layout_bytes(&buf[col_offset..])?;
+                    mat[i] = <$row_vec>::layout_read_bytes(&buf[col_offset..])?;
                 }
                 Ok(mat)
             }
 
-            fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+            fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
                 if buf.len() < $size {
                     return Err(Error::BufferTooSmall {
                         needed: $size,
@@ -304,7 +304,7 @@ macro_rules! impl_mat_layout {
                 for i in 0..$cols {
                     let col_offset = i * $stride;
                     let col: &$row_vec = &self[i];
-                    col.write_layout_bytes(&mut buf[col_offset..])?;
+                    col.layout_write_bytes(&mut buf[col_offset..])?;
                 }
                 Ok(())
             }
@@ -328,7 +328,7 @@ impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
     const SIZE: usize = N * crate::round_up(T::ALIGN, T::SIZE);
     const ALIGN: usize = T::ALIGN;
 
-    fn read_layout_bytes(buf: &[u8]) -> Result<Self, Error> {
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
         let stride = crate::round_up(T::ALIGN, T::SIZE);
         if buf.len() < N * stride {
             return Err(Error::BufferTooSmall {
@@ -339,13 +339,13 @@ impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
         // Initialize with default values then overwrite
         let mut arr: [T; N] = unsafe { std::mem::zeroed() };
         for (i, slot) in arr.iter_mut().enumerate() {
-            let elem = T::read_layout_bytes(&buf[i * stride..])?;
+            let elem = T::layout_read_bytes(&buf[i * stride..])?;
             *slot = elem;
         }
         Ok(arr)
     }
 
-    fn write_layout_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
         let stride = crate::round_up(T::ALIGN, T::SIZE);
         if buf.len() < N * stride {
             return Err(Error::BufferTooSmall {
@@ -354,7 +354,7 @@ impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
             });
         }
         for (i, elem) in self.iter().enumerate() {
-            elem.write_layout_bytes(&mut buf[i * stride..])?;
+            elem.layout_write_bytes(&mut buf[i * stride..])?;
         }
         Ok(())
     }
@@ -366,11 +366,11 @@ impl<T: WgslLayout> WgslLayout for wgsl_rs::std::RuntimeArray<T> {
     const SIZE: usize = 0;
     const ALIGN: usize = T::ALIGN;
 
-    fn read_layout_bytes(_buf: &[u8]) -> Result<Self, Error> {
+    fn layout_read_bytes(_buf: &[u8]) -> Result<Self, Error> {
         Ok(wgsl_rs::std::RuntimeArray::new())
     }
 
-    fn write_layout_bytes(&self, _buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, _buf: &mut [u8]) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/crates/wgsl-rs-layout/src/types.rs
+++ b/crates/wgsl-rs-layout/src/types.rs
@@ -1,0 +1,87 @@
+use crate::WgslLayout;
+
+// ===== Scalars =====
+
+impl WgslLayout for f32 {
+    const SIZE: usize = 4;
+    const ALIGN: usize = 4;
+}
+
+impl WgslLayout for i32 {
+    const SIZE: usize = 4;
+    const ALIGN: usize = 4;
+}
+
+impl WgslLayout for u32 {
+    const SIZE: usize = 4;
+    const ALIGN: usize = 4;
+}
+
+impl WgslLayout for bool {
+    const SIZE: usize = 4;
+    const ALIGN: usize = 4;
+}
+
+// ===== Atomically accessible types =====
+
+impl WgslLayout for wgsl_rs::std::Atomic<u32> {
+    const SIZE: usize = 4;
+    const ALIGN: usize = 4;
+}
+
+impl WgslLayout for wgsl_rs::std::Atomic<i32> {
+    const SIZE: usize = 4;
+    const ALIGN: usize = 4;
+}
+
+// ===== Vectors (32-bit scalar elements) =====
+
+impl<T: wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec2<T> {
+    const SIZE: usize = 8;
+    const ALIGN: usize = 8;
+}
+
+impl<T: wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec3<T> {
+    const SIZE: usize = 12;
+    const ALIGN: usize = 16;
+}
+
+impl<T: wgsl_rs::std::WgslScalar> WgslLayout for wgsl_rs::std::Vec4<T> {
+    const SIZE: usize = 16;
+    const ALIGN: usize = 16;
+}
+
+// ===== Matrices =====
+
+macro_rules! impl_mat_layout {
+    ($ty:ty, $align:expr, $size:expr) => {
+        impl WgslLayout for $ty {
+            const SIZE: usize = $size;
+            const ALIGN: usize = $align;
+        }
+    };
+}
+
+impl_mat_layout!(wgsl_rs::std::Mat2x2f, 8, 16);
+impl_mat_layout!(wgsl_rs::std::Mat2x3f, 16, 32);
+impl_mat_layout!(wgsl_rs::std::Mat2x4f, 16, 32);
+impl_mat_layout!(wgsl_rs::std::Mat3x2f, 8, 24);
+impl_mat_layout!(wgsl_rs::std::Mat3x3f, 16, 48);
+impl_mat_layout!(wgsl_rs::std::Mat3x4f, 16, 48);
+impl_mat_layout!(wgsl_rs::std::Mat4x2f, 8, 32);
+impl_mat_layout!(wgsl_rs::std::Mat4x3f, 16, 64);
+impl_mat_layout!(wgsl_rs::std::Mat4x4f, 16, 64);
+
+// ===== Fixed-size arrays =====
+
+impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
+    const SIZE: usize = N * crate::round_up(T::ALIGN, T::SIZE);
+    const ALIGN: usize = T::ALIGN;
+}
+
+// ===== Runtime-sized arrays =====
+
+impl<T: WgslLayout> WgslLayout for wgsl_rs::std::RuntimeArray<T> {
+    const SIZE: usize = 0;
+    const ALIGN: usize = T::ALIGN;
+}

--- a/crates/wgsl-rs-layout/src/types.rs
+++ b/crates/wgsl-rs-layout/src/types.rs
@@ -326,28 +326,30 @@ impl_mat_layout!(wgsl_rs::std::Mat4x4f, wgsl_rs::std::Vec4f, 4, 16, 16, 64);
 // ===== Fixed-size arrays =====
 
 impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
-    const SIZE: usize = N * crate::round_up(T::ALIGN, T::SIZE);
+    const SIZE: usize = N * crate::round_up(T::SIZE, T::ALIGN);
     const ALIGN: usize = T::ALIGN;
 
     fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
-        let stride = crate::round_up(T::ALIGN, T::SIZE);
+        let stride = crate::round_up(T::SIZE, T::ALIGN);
         if buf.len() < N * stride {
             return Err(Error::BufferTooSmall {
                 needed: N * stride,
                 actual: buf.len(),
             });
         }
-        // Initialize with default values then overwrite
-        let mut arr: [T; N] = unsafe { std::mem::zeroed() };
-        for (i, slot) in arr.iter_mut().enumerate() {
+        let mut arr = std::mem::MaybeUninit::<[T; N]>::uninit();
+        let arr_ptr = arr.as_mut_ptr() as *mut T;
+        for i in 0..N {
             let elem = T::layout_read_bytes(&buf[i * stride..])?;
-            *slot = elem;
+            unsafe {
+                arr_ptr.add(i).write(elem);
+            }
         }
-        Ok(arr)
+        Ok(unsafe { arr.assume_init() })
     }
 
     fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
-        let stride = crate::round_up(T::ALIGN, T::SIZE);
+        let stride = crate::round_up(T::SIZE, T::ALIGN);
         if buf.len() < N * stride {
             return Err(Error::BufferTooSmall {
                 needed: N * stride,

--- a/crates/wgsl-rs-layout/src/types.rs
+++ b/crates/wgsl-rs-layout/src/types.rs
@@ -303,6 +303,7 @@ macro_rules! impl_mat_layout {
                 }
                 for i in 0..$cols {
                     let col_offset = i * $stride;
+                    buf[col_offset..][..$stride].fill(0);
                     let col: &$row_vec = &self[i];
                     col.layout_write_bytes(&mut buf[col_offset..])?;
                 }
@@ -354,7 +355,9 @@ impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
             });
         }
         for (i, elem) in self.iter().enumerate() {
-            elem.layout_write_bytes(&mut buf[i * stride..])?;
+            let start = i * stride;
+            buf[start..][..stride].fill(0);
+            elem.layout_write_bytes(&mut buf[start..])?;
         }
         Ok(())
     }

--- a/crates/wgsl-rs-layout/src/types.rs
+++ b/crates/wgsl-rs-layout/src/types.rs
@@ -325,7 +325,7 @@ impl_mat_layout!(wgsl_rs::std::Mat4x4f, wgsl_rs::std::Vec4f, 4, 16, 16, 64);
 
 // ===== Fixed-size arrays =====
 
-impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
+impl<T: WgslLayout + Default, const N: usize> WgslLayout for [T; N] {
     const SIZE: usize = N * crate::round_up(T::SIZE, T::ALIGN);
     const ALIGN: usize = T::ALIGN;
 
@@ -337,15 +337,10 @@ impl<T: WgslLayout, const N: usize> WgslLayout for [T; N] {
                 actual: buf.len(),
             });
         }
-        let mut arr = std::mem::MaybeUninit::<[T; N]>::uninit();
-        let arr_ptr = arr.as_mut_ptr() as *mut T;
-        for i in 0..N {
-            let elem = T::layout_read_bytes(&buf[i * stride..])?;
-            unsafe {
-                arr_ptr.add(i).write(elem);
-            }
-        }
-        Ok(unsafe { arr.assume_init() })
+        let arr = std::array::from_fn(|i| {
+            T::layout_read_bytes(&buf[i * stride..]).expect("already checked the size")
+        });
+        Ok(arr)
     }
 
     fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
@@ -371,11 +366,38 @@ impl<T: WgslLayout> WgslLayout for wgsl_rs::std::RuntimeArray<T> {
     const SIZE: usize = 0;
     const ALIGN: usize = T::ALIGN;
 
-    fn layout_read_bytes(_buf: &[u8]) -> Result<Self, Error> {
-        Ok(wgsl_rs::std::RuntimeArray::new())
+    fn layout_read_bytes(buf: &[u8]) -> Result<Self, Error> {
+        let stride = crate::round_up(T::SIZE, T::ALIGN);
+        let len = buf.len() / stride;
+
+        if buf.len() < len * stride {
+            return Err(Error::BufferTooSmall {
+                needed: len * stride,
+                actual: buf.len(),
+            });
+        }
+        let mut arr = wgsl_rs::std::RuntimeArray::with_capacity(len);
+        for i in 0..len {
+            let elem = T::layout_read_bytes(&buf[i * stride..])?;
+            arr.push(elem);
+        }
+        Ok(arr)
     }
 
-    fn layout_write_bytes(&self, _buf: &mut [u8]) -> Result<(), Error> {
+    fn layout_write_bytes(&self, buf: &mut [u8]) -> Result<(), Error> {
+        let stride = crate::round_up(T::SIZE, T::ALIGN);
+        let len = buf.len() / stride;
+        if buf.len() < len * stride {
+            return Err(Error::BufferTooSmall {
+                needed: len * stride,
+                actual: buf.len(),
+            });
+        }
+        for (i, elem) in self.data.iter().enumerate() {
+            let start = i * stride;
+            buf[start..][..stride].fill(0);
+            elem.layout_write_bytes(&mut buf[start..])?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
These changes provide a trait to aid in determining struct memory layout in WGSL and marshaling data to and from the GPU.

Fixes #121 