### PR TITLE
feat: wgsl-rs-layout diagrams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,6 +3765,7 @@ version = "0.1.0"
 name = "wgsl-rs-layout"
 version = "0.1.0"
 dependencies = [
+ "snafu",
  "wgsl-rs",
  "wgsl-rs-layout-macros",
 ]

--- a/crates/wgsl-rs-layout-macros/src/lib.rs
+++ b/crates/wgsl-rs-layout-macros/src/lib.rs
@@ -100,10 +100,44 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         quote! { <#ty as #layout_trait_path>::ALIGN }
     };
 
-    // Build inherent consts to hold offset/size/align for each field.
-    // These are accessible from both trait impls via Self::.
+    // Detect runtime array fields. Per the WGSL spec §6.2.10, a
+    // runtime-sized array may only appear as the last member of a
+    // struct. We detect by inspecting the type's last path segment
+    // and a single generic argument.
+    //
+    // The heuristic is: the type is a path that ends in
+    // `RuntimeArray` and has exactly one generic type argument.
+    let runtime_array_indices: Vec<usize> = field_types
+        .iter()
+        .enumerate()
+        .filter_map(|(i, ty)| if is_runtime_array(ty) { Some(i) } else { None })
+        .collect();
+
+    // Reject any runtime array that isn't the last field.
+    for &i in &runtime_array_indices {
+        if i != field_count - 1 {
+            return Err(syn::Error::new_spanned(
+                &named_fields.named[i],
+                "runtime-sized array must be the last member of the struct (WGSL spec §6.2.10)",
+            ));
+        }
+    }
+
+    let has_runtime_array = !runtime_array_indices.is_empty();
+    // If the last field is a runtime array, we exclude it from the
+    // per-field FIELDS array and treat the remaining fields as the
+    // struct's "prefix".
+    let prefix_count = if has_runtime_array {
+        field_count - 1
+    } else {
+        field_count
+    };
+
+    // Build inherent consts to hold offset/size/align for each
+    // *prefix* field. The runtime array (if any) is handled
+    // separately.
     let mut inherent_consts = Vec::new();
-    for (i, ty) in field_types.iter().enumerate() {
+    for (i, ty) in field_types.iter().enumerate().take(prefix_count) {
         let offset_name =
             syn::Ident::new(&format!("__OFFSET_{}", i), proc_macro2::Span::call_site());
         let size_name = syn::Ident::new(&format!("__SIZE_{}", i), proc_macro2::Span::call_site());
@@ -137,10 +171,63 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         }
     }
 
-    // Build ALIGN: max of all field alignments
-    let self_align = build_max_align_from_consts(field_count);
+    // If there's a runtime array, emit its offset and stride consts.
+    if has_runtime_array {
+        let rt_i = field_count - 1;
+        let rt_offset_name = syn::Ident::new(
+            &format!("__OFFSET_{}", rt_i),
+            proc_macro2::Span::call_site(),
+        );
+        let rt_size_name =
+            syn::Ident::new(&format!("__SIZE_{}", rt_i), proc_macro2::Span::call_site());
+        let rt_align_name =
+            syn::Ident::new(&format!("__ALIGN_{}", rt_i), proc_macro2::Span::call_site());
+        let rt_type = field_types[rt_i];
+        let elem_type = runtime_array_elem(rt_type)
+            .expect("detected as runtime array but couldn't extract element type");
 
-    // SIZE = roundUp(AlignOf(S), lastOffset + lastSize)
+        // The runtime array sits at the next aligned offset after the
+        // last prefix field.
+        let prev_offset = if prefix_count > 0 {
+            let name = syn::Ident::new(
+                &format!("__OFFSET_{}", prefix_count - 1),
+                proc_macro2::Span::call_site(),
+            );
+            quote! { Self::#name }
+        } else {
+            quote! { 0 }
+        };
+        let prev_size = if prefix_count > 0 {
+            size_of(field_types[prefix_count - 1])
+        } else {
+            quote! { 0 }
+        };
+        let cur_align = align_of(rt_type);
+
+        inherent_consts.push(quote! {
+            const #rt_size_name: usize = 0;
+            const #rt_align_name: usize = #cur_align;
+            const #rt_offset_name: usize = #round_up_path(
+                #prev_offset + #prev_size,
+                #cur_align,
+            );
+            const __RUNTIME_ARRAY_STRIDE: usize = #round_up_path(
+                <#elem_type as #layout_trait_path>::SIZE,
+                <#elem_type as #layout_trait_path>::ALIGN,
+            );
+        });
+    }
+
+    // Build ALIGN: max of all *prefix* field alignments. If there's a
+    // runtime array, its alignment is already included since the
+    // prefix's `__ALIGN_N-1` is the last prefix field and the runtime
+    // array's `__ALIGN_N` is in inherent_consts above.
+    let self_align = build_max_align_from_consts(field_count, has_runtime_array);
+
+    // SIZE = roundUp(AlignOf(S), lastOffset + lastSize). For a struct
+    // with a runtime array, `lastSize` is 0 (the array's SIZE), so
+    // SIZE = roundUp(AlignOf(S), runtime_array_offset) — i.e. the
+    // size with N=0 elements.
     let last_i = field_count - 1;
     let last_offset = syn::Ident::new(
         &format!("__OFFSET_{}", last_i),
@@ -155,12 +242,13 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         #round_up_path(Self::#last_offset + Self::#last_size, Self::ALIGN)
     };
 
-    // Build FIELDS array entries
+    // Build FIELDS array entries. Skip the runtime array field (if
+    // any) so it's not represented as a 0-byte data field.
     let mut field_entry_tokens = Vec::new();
     let mut field_write_tokens = Vec::new();
     let mut field_read_tokens = Vec::new();
     let mut field_init_tokens = Vec::new();
-    for (i, name) in field_names.iter().enumerate() {
+    for (i, name) in field_names.iter().enumerate().take(prefix_count) {
         let offset_name =
             syn::Ident::new(&format!("__OFFSET_{}", i), proc_macro2::Span::call_site());
         let size_name = syn::Ident::new(&format!("__SIZE_{}", i), proc_macro2::Span::call_site());
@@ -168,6 +256,8 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         let field_ident = syn::Ident::new(name, proc_macro2::Span::call_site());
 
         let pad_after = if i == field_count - 1 {
+            // For a non-runtime-array struct, pad_after for the last
+            // field is the trailing struct padding.
             quote! { Self::SIZE - (Self::#offset_name + Self::#size_name) }
         } else {
             let next_offset_name = syn::Ident::new(
@@ -204,6 +294,45 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                     &buf[Self::#offset_name..],
                 )?;
             }
+        });
+
+        field_init_tokens.push(field_ident);
+    }
+
+    // If there's a runtime array, also emit a read/write/init for it
+    // using the existing `WgslLayout` impl on `RuntimeArray<T>`. The
+    // buffer for read/write must be sized appropriately by the
+    // caller, so this is best-effort: the read/write paths use the
+    // struct's `SIZE` (which is the prefix size with N=0) for the
+    // check, and skip the runtime-array portion.
+    if has_runtime_array {
+        let rt_i = field_count - 1;
+        let field_ident = syn::Ident::new(&field_names[rt_i], proc_macro2::Span::call_site());
+        let rt_offset = syn::Ident::new(
+            &format!("__OFFSET_{}", rt_i),
+            proc_macro2::Span::call_site(),
+        );
+        let rt_type = field_types[rt_i];
+
+        // The runtime array's `layout_read_bytes` reads as many
+        // elements as fit in the remaining buffer; we don't need to
+        // verify that the buffer extends beyond `SIZE` (which is the
+        // prefix size).
+        field_read_tokens.push(quote! {
+            let #field_ident = <#rt_type as ::wgsl_rs_layout::WgslLayout>::layout_read_bytes(
+                &buf[Self::#rt_offset..],
+            )?;
+        });
+
+        // Writing the runtime array uses the buffer beyond `SIZE`.
+        // The array's `layout_write_bytes` iterates the elements and
+        // writes each element's bytes. The caller is responsible for
+        // sizing `buf` to hold the prefix + the array's element bytes.
+        field_write_tokens.push(quote! {
+            ::wgsl_rs_layout::WgslLayout::layout_write_bytes(
+                &self.#field_ident,
+                &mut buf[Self::#rt_offset..],
+            )?;
         });
 
         field_init_tokens.push(field_ident);
@@ -248,11 +377,40 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         }
     };
 
+    let runtime_array_impls = if has_runtime_array {
+        let rt_i = field_count - 1;
+        let rt_field_name = &field_names[rt_i];
+        let rt_offset_name = syn::Ident::new(
+            &format!("__OFFSET_{}", rt_i),
+            proc_macro2::Span::call_site(),
+        );
+        let rt_align_name =
+            syn::Ident::new(&format!("__ALIGN_{}", rt_i), proc_macro2::Span::call_site());
+        quote! {
+            const RUNTIME_ARRAY_STRIDE: Option<usize> = Some(Self::__RUNTIME_ARRAY_STRIDE);
+            const RUNTIME_ARRAY_FIELD: ::std::option::Option<::wgsl_rs_layout::FieldLayout> =
+                ::std::option::Option::Some(::wgsl_rs_layout::FieldLayout {
+                    name: #rt_field_name,
+                    offset: Self::#rt_offset_name,
+                    size: 0,
+                    alignment: Self::#rt_align_name,
+                    pad_after: Self::__RUNTIME_ARRAY_STRIDE,
+                });
+        }
+    } else {
+        quote! {
+            const RUNTIME_ARRAY_STRIDE: Option<usize> = ::std::option::Option::None;
+            const RUNTIME_ARRAY_FIELD: ::std::option::Option<::wgsl_rs_layout::FieldLayout> =
+                ::std::option::Option::None;
+        }
+    };
+
     let layout_impl = quote! {
         impl #impl_generics ::wgsl_rs_layout::Layout for #struct_name #ty_generics #where_clause {
             const FIELDS: &'static [::wgsl_rs_layout::FieldLayout] = &[
                 #(#field_entry_tokens),*
             ];
+            #runtime_array_impls
         }
     };
 
@@ -263,9 +421,44 @@ fn derive_layout(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     })
 }
 
+/// Heuristic check for "this type is `RuntimeArray<...>`". Matches
+/// any path whose last segment is `RuntimeArray` and has exactly one
+/// generic type argument.
+fn is_runtime_array(ty: &Type) -> bool {
+    runtime_array_elem(ty).is_some()
+}
+
+/// If `ty` looks like a runtime array (`Path` ending in
+/// `RuntimeArray<...>` with one type arg), return the inner element
+/// type.
+fn runtime_array_elem(ty: &Type) -> Option<&Type> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let last_seg = type_path.path.segments.last()?;
+    if last_seg.ident != "RuntimeArray" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &last_seg.arguments else {
+        return None;
+    };
+    if args.args.len() != 1 {
+        return None;
+    }
+    let arg = args.args.first()?;
+    if let syn::GenericArgument::Type(elem_ty) = arg {
+        Some(elem_ty)
+    } else {
+        None
+    }
+}
+
 /// Build a const expression computing max of all field alignments,
 /// referencing inherent consts __ALIGN_0..__ALIGN_N.
-fn build_max_align_from_consts(field_count: usize) -> proc_macro2::TokenStream {
+fn build_max_align_from_consts(
+    field_count: usize,
+    _has_runtime_array: bool,
+) -> proc_macro2::TokenStream {
     if field_count == 0 {
         return quote! { 1usize };
     }

--- a/crates/wgsl-rs-layout/Cargo.toml
+++ b/crates/wgsl-rs-layout/Cargo.toml
@@ -3,6 +3,11 @@ name = "wgsl-rs-layout"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = []
+doc-diagrams = ["dep:snafu"]
+
 [dependencies]
 wgsl-rs = { path = "../wgsl-rs" }
 wgsl-rs-layout-macros = { path = "../wgsl-rs-layout-macros" }
+snafu = { workspace = true, optional = true }

--- a/crates/wgsl-rs-layout/examples/doc_diagrams.rs
+++ b/crates/wgsl-rs-layout/examples/doc_diagrams.rs
@@ -1,0 +1,117 @@
+//! End-to-end demo: generate SVG diagrams for a few fixture types
+//! and write them to a directory `rustdoc` can pick up via
+//! `--resource-files`.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run -p wgsl-rs-layout --features doc-diagrams --example doc_diagrams -- \
+//!     path/to/output_dir
+//! ```
+//!
+//! Then `cargo doc` with
+//! `RUSTDOCFLAGS="--resource-files path/to/output_dir"`.
+
+#[cfg(feature = "doc-diagrams")]
+use std::path::PathBuf;
+
+#[cfg(feature = "doc-diagrams")]
+use wgsl_rs::std::{Mat4x4f, RuntimeArray, Vec3f, Vec3u, Vec4f};
+#[cfg(feature = "doc-diagrams")]
+use wgsl_rs_layout::diagrams::{DiagramConfig, generate_svg};
+#[cfg(feature = "doc-diagrams")]
+use wgsl_rs_layout::{Layout, WgslLayout};
+
+/// A typical uniform buffer.
+#[cfg(feature = "doc-diagrams")]
+#[derive(Layout)]
+struct Uniforms {
+    view: Mat4x4f,
+    color: Vec4f,
+    time: f32,
+}
+
+/// A tight struct where field alignment drives the layout.
+#[cfg(feature = "doc-diagrams")]
+#[derive(Layout)]
+struct Tight {
+    velocity: Vec3f,
+    frame_count: u32,
+    acceleration: Vec3f,
+    delta: f32,
+}
+
+
+#[cfg(feature = "doc-diagrams")]
+#[derive(Layout)]
+/// An example from
+/// <https://webgpufundamentals.org/webgpu/lessons/webgpu-memory-layout.html>.
+struct Ex4a {
+    velocity: Vec3f,
+}
+
+#[cfg(feature = "doc-diagrams")]
+#[derive(Layout)]
+/// An example from
+/// <https://webgpufundamentals.org/webgpu/lessons/webgpu-memory-layout.html>.
+struct Ex4 {
+    orientation: Vec3f,
+    size: f32,
+    direction: [Vec3u; 1],
+    scale: f32,
+    info: Ex4a,
+    friction: f32,
+}
+
+/// A small struct for showcasing per-byte offset labels.
+#[cfg(feature = "doc-diagrams")]
+#[derive(Layout)]
+struct Small {
+    a: f32,
+    b: u32,
+    c: f32,
+}
+
+/// A struct ending in a runtime array.
+#[cfg(feature = "doc-diagrams")]
+#[derive(Layout)]
+#[allow(dead_code)]
+struct MyStorageType {
+    descriptor: Vec4f,
+    count: u32,
+    data: RuntimeArray<Ex4>,
+}
+
+#[cfg(feature = "doc-diagrams")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir: PathBuf = std::env::args()
+        .nth(1)
+        .ok_or("missing output directory argument")?
+        .parse()?;
+    let svg_dir = out_dir.join("wgsldiagrams");
+    std::fs::create_dir_all(&svg_dir)?;
+
+    let cfg = DiagramConfig::default();
+
+    for (name, svg) in [
+        ("Uniforms", generate_svg::<Uniforms>(&cfg)?),
+        ("Tight", generate_svg::<Tight>(&cfg)?),
+        ("Ex4", generate_svg::<Ex4>(&cfg)?),
+        ("Small", generate_svg::<Small>(&cfg)?),
+        ("MyStorageType", generate_svg::<MyStorageType>(&cfg)?),
+    ] {
+        let dest = svg_dir.join(format!("{name}.svg"));
+        std::fs::write(&dest, svg)?;
+        eprintln!("wrote {}", dest.display());
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "doc-diagrams"))]
+fn main() {
+    eprintln!(
+        "this example requires the `doc-diagrams` feature:\n  cargo run -p wgsl-rs-layout \
+         --features doc-diagrams --example doc_diagrams -- \\\n  <output_dir>"
+    );
+    std::process::exit(1);
+}

--- a/crates/wgsl-rs-layout/src/diagrams/mod.rs
+++ b/crates/wgsl-rs-layout/src/diagrams/mod.rs
@@ -1,0 +1,267 @@
+//! Byte-layout diagram generation for `cargo doc`.
+//!
+//! Enable with the `doc-diagrams` cargo feature to use this module.
+//!
+//! # Overview
+//!
+//! Given any type `T` that implements both [`Layout`](crate::Layout)
+//! and [`WgslLayout`](crate::WgslLayout) (i.e. any type annotated
+//! with `#[derive(Layout)]` and every built-in WGSL type),
+//! [`generate_svg`] produces a self-contained SVG byte-layout
+//! diagram. The visual style mirrors
+//! <https://webgpufundamentals.org/webgpu/lessons/webgpu-memory-layout.html>:
+//! one label band + one byte band, repeated for every row, with
+//! per-field HSL coloring.
+//!
+//! The row width is derived from the type: each row spans
+//! `T::ALIGN` bytes. A struct with `align = 4` renders in 4-byte
+//! rows, a struct with `align = 16` renders in 16-byte rows,
+//! matching the WGSL layout's natural word size.
+//!
+//! All layout information is sourced directly from the trait
+//! constants — `<T as WgslLayout>::SIZE` / `::ALIGN` and
+//! `<T as Layout>::FIELDS` — so the rendered diagram is always
+//! consistent with what the `#[derive(Layout)]` macro emits.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use wgsl_rs_layout::{
+//!     Layout,
+//!     diagrams::{DiagramConfig, generate_svg},
+//! };
+//!
+//! #[derive(Layout)]
+//! struct Uniforms {/* ... */}
+//!
+//! fn generate_one() -> Result<(), Box<dyn std::error::Error>> {
+//!     let svg = generate_svg::<Uniforms>(&DiagramConfig::default())?;
+//!     std::fs::write("target/doc-resources/wgsldiagrams/Uniforms.svg", svg)?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # Wiring into `cargo doc`
+//!
+//! 1. In your crate, add the `doc-diagrams` feature to `wgsl-rs-layout`.
+//!
+//! 2. Write a small driver (a binary, a `build.rs`, an `xtask` step, or just a
+//!    hand-run command) that calls [`generate_svg::<MyType>()`](generate_svg)
+//!    for every type you want to diagram and writes the SVGs into a directory
+//!    `rustdoc` can find via `--resource-files`.
+//!
+//! 3. In `.cargo/config.toml`:
+//!
+//!    ```toml
+//!    [build]
+//!    rustdocflags = ["--resource-files", "target/doc-resources/"]
+//!    ```
+//!
+//! 4. In your doc comments, reference the generated SVG by relative path:
+//!
+//!    ```ignore
+//!    /// Camera state.
+//!    ///
+//!    /// ![byte layout](wgsldiagrams/Uniforms.svg)
+//!    pub struct Uniforms { ... }
+//!    ```
+
+mod svg;
+
+use snafu::prelude::*;
+
+use crate::{Layout, WgslLayout};
+
+/// Tuning knobs for [`generate_svg`].
+///
+/// Build a config via [`DiagramConfig::builder`] so values are
+/// validated up front. The [`DiagramConfig::default`] constructor
+/// returns a known-good config.
+#[derive(Debug, Clone)]
+pub struct DiagramConfig {
+    /// Width and height of a single byte cell, in pixels.
+    cell_size: f32,
+}
+
+impl Default for DiagramConfig {
+    fn default() -> Self {
+        Self::builder()
+            .cell_size(22.0)
+            .build()
+            .expect("default DiagramConfig is valid")
+    }
+}
+
+/// Builder for [`DiagramConfig`].
+///
+/// Validates inputs on [`DiagramConfigBuilder::build`]: `cell_size`
+/// must be positive and finite.
+#[derive(Debug, Clone)]
+pub struct DiagramConfigBuilder {
+    cell_size: Option<f32>,
+}
+
+impl DiagramConfigBuilder {
+    /// Set the cell size, in pixels. Must be a positive, finite
+    /// `f32` (e.g. `22.0`). Returns the builder for chaining.
+    pub fn cell_size(mut self, value: f32) -> Self {
+        self.cell_size = Some(value);
+        self
+    }
+
+    /// Build a [`DiagramConfig`], validating all inputs.
+    pub fn build(self) -> Result<DiagramConfig, DiagramError> {
+        let cell_size = self.cell_size.unwrap_or(22.0);
+        if !cell_size.is_finite() || cell_size <= 0.0 {
+            return InvalidConfigSnafu {
+                reason: format!("cell_size must be a positive finite f32, got {cell_size}"),
+            }
+            .fail();
+        }
+        Ok(DiagramConfig { cell_size })
+    }
+}
+
+impl DiagramConfig {
+    /// Start a new builder with no fields set; defaults are applied
+    /// on build.
+    pub fn builder() -> DiagramConfigBuilder {
+        DiagramConfigBuilder { cell_size: None }
+    }
+
+    /// Width and height of a single byte cell, in pixels.
+    pub fn cell_size(&self) -> f32 {
+        self.cell_size
+    }
+}
+
+/// Errors that abort diagram generation.
+#[derive(Debug, Snafu)]
+pub enum DiagramError {
+    /// The diagram exceeds the renderer's maximum supported size.
+    #[snafu(display("layout size {size} bytes exceeds the renderer max ({max} bytes)"))]
+    SizeTooLarge {
+        /// The size in bytes of the type being diagrammed.
+        size: usize,
+        /// The renderer maximum.
+        max: usize,
+    },
+    /// A [`DiagramConfig`] value was invalid.
+    #[snafu(display("invalid DiagramConfig: {reason}"))]
+    InvalidConfig {
+        /// Human-readable description of the validation failure.
+        reason: String,
+    },
+}
+
+/// Maximum byte size the renderer supports. Above this, diagrams
+/// become unreadable, so [`generate_svg`] returns
+/// [`DiagramError::SizeTooLarge`].
+const MAX_BYTES: usize = 16 * 1024;
+
+/// Number of example array elements rendered for a runtime array.
+/// Chosen as 1 to keep the diagram compact: the meta line already
+/// conveys that the actual size depends on `LEN`.
+const RUNTIME_ARRAY_PREVIEW_COUNT: usize = 1;
+
+/// Number of bytes per row in the rendered diagram. Equal to
+/// `T::ALIGN`, so the diagram's natural word size scales with
+/// the type's alignment.
+const ROW_BYTES_PER_TYPE_ALIGN: usize = 1;
+
+/// One field's layout, internally borrowed by the renderer.
+struct RenderField {
+    /// Field name as written in the source struct.
+    name: String,
+    /// Byte offset from the start of the struct.
+    offset: usize,
+    /// Byte size of the field's data.
+    size: usize,
+    /// Bytes of padding after this field. Currently unused by the
+    /// renderer (padding is recomputed from offsets), but kept for
+    /// future use and to mirror [`crate::FieldLayout`].
+    #[allow(dead_code)]
+    pad_after: usize,
+}
+
+/// Generate an SVG byte-layout diagram for `T`.
+///
+/// Reads `<T as WgslLayout>::SIZE` / `::ALIGN` and
+/// `<T as Layout>::FIELDS` to build the diagram; no source parsing.
+///
+/// The row width is `T::ALIGN` bytes, so a 4-byte-aligned struct
+/// renders in 4-byte rows and a 16-byte-aligned struct renders in
+/// 16-byte rows.
+///
+/// If `T` has a runtime array field, the diagram shows the prefix
+/// fields normally followed by a single example element of the array
+/// (labeled `<name>[0]`). The actual total size is reported in the
+/// meta line as `<prefix_offset> + LEN × <stride> bytes`.
+///
+/// # Errors
+///
+/// Returns [`DiagramError::SizeTooLarge`] if the rendered diagram's
+/// total byte count (including the runtime-array preview element)
+/// would exceed [`MAX_BYTES`].
+pub fn generate_svg<T: WgslLayout + Layout>(
+    config: &DiagramConfig,
+) -> Result<String, DiagramError> {
+    let prefix_fields: Vec<RenderField> = T::FIELDS
+        .iter()
+        .map(|f| RenderField {
+            name: f.name.to_string(),
+            offset: f.offset,
+            size: f.size,
+            pad_after: f.pad_after,
+        })
+        .collect();
+
+    let mut fields = prefix_fields;
+    let mut display_size = T::SIZE;
+    let bytes_per_row = T::ALIGN * ROW_BYTES_PER_TYPE_ALIGN;
+    let meta = if let Some(ra) = T::RUNTIME_ARRAY_FIELD {
+        let stride =
+            T::RUNTIME_ARRAY_STRIDE.expect("RUNTIME_ARRAY_FIELD implies RUNTIME_ARRAY_STRIDE");
+        let name = ra.name;
+        let start = ra.offset;
+        for i in 0..RUNTIME_ARRAY_PREVIEW_COUNT {
+            fields.push(RenderField {
+                name: format!("{name}[{i}]"),
+                offset: start + i * stride,
+                size: stride,
+                pad_after: 0,
+            });
+        }
+        display_size = start + RUNTIME_ARRAY_PREVIEW_COUNT * stride;
+        format!(
+            "size: {prefix} + LEN \u{00d7} {stride} bytes \u{00b7} align: {align} bytes",
+            prefix = start,
+            stride = stride,
+            align = T::ALIGN
+        )
+    } else {
+        format!(
+            "size: {size} bytes \u{00b7} align: {align} bytes",
+            size = T::SIZE,
+            align = T::ALIGN
+        )
+    };
+
+    snafu::ensure!(
+        display_size <= MAX_BYTES,
+        SizeTooLargeSnafu {
+            size: display_size,
+            max: MAX_BYTES,
+        }
+    );
+
+    Ok(svg::render(
+        &fields,
+        display_size,
+        bytes_per_row,
+        T::ALIGN,
+        std::any::type_name::<T>(),
+        &meta,
+        config,
+    ))
+}

--- a/crates/wgsl-rs-layout/src/diagrams/svg.rs
+++ b/crates/wgsl-rs-layout/src/diagrams/svg.rs
@@ -1,0 +1,637 @@
+//! SVG byte-diagram renderer.
+//!
+//! Output structure:
+//!
+//! - A header strip with the struct name and a `size: N bytes · align: N bytes`
+//!   meta line (or `size: <offset> + LEN × <stride> bytes` for runtime-array
+//!   structs).
+//! - One `<bytes_per_row>`-byte "row" per chunk of struct size. The row width
+//!   is supplied by the caller (the orchestrator derives it from `T::ALIGN`).
+//! - Each row has a label band and a byte band.
+//! - The label band shows the field name in a wide colored rect; padding is
+//!   shown as `-pad-` on a light-grey background.
+//! - The byte band shows colored cells with the absolute byte offset rendered
+//!   inside each one. Word boundaries (every 4 bytes) are signalled by an
+//!   alternating background tint overlay on every other word in the byte band
+//!   only.
+
+use super::{DiagramConfig, RenderField};
+use std::fmt::Write;
+
+/// Width of a word in bytes. Used to compute the alternating
+/// background tint on every other word.
+const WORD_BYTES: usize = 4;
+
+/// Heuristic average glyph width, in pixels, for the 16px-bold
+/// struct-name text. Used to estimate header width.
+const TITLE_CHAR_PX: f32 = 9.0;
+/// Heuristic average glyph width, in pixels, for the 11px meta
+/// line. Used to estimate header width.
+const META_CHAR_PX: f32 = 6.0;
+/// Horizontal gap between the struct name and the meta text when
+/// inline.
+const INLINE_GAP_PX: f32 = 8.4; // 0.6em at 14px monospace
+
+/// Render a diagram for the given fields and total size.
+///
+/// `bytes_per_row` is the row width in bytes; the diagram wraps
+/// after every `bytes_per_row` bytes.
+///
+/// The header (struct name + meta line) is rendered inline on a
+/// single line when it fits within the diagram's body width, and
+/// wraps to two lines otherwise. The diagram's viewBox always
+/// accommodates the header so the meta line is fully visible.
+pub(super) fn render(
+    fields: &[RenderField],
+    size: usize,
+    bytes_per_row: usize,
+    _align: usize,
+    type_name: &str,
+    meta: &str,
+    config: &DiagramConfig,
+) -> String {
+    let cell = config.cell_size;
+    let label_height = cell;
+    let byte_height = cell;
+    let row_gap = cell / 4.0;
+    let pad_left = 0.0;
+    let pad_right = cell / 3.0;
+
+    // Estimate the inline header width: name + gap + meta.
+    let short_name = short_type_name(type_name);
+    let inline_header_estimate =
+        short_name.len() as f32 * TITLE_CHAR_PX + INLINE_GAP_PX + meta.len() as f32 * META_CHAR_PX;
+
+    // Body width is the dominant width when the header fits
+    // inline; otherwise the header estimate is the dominant
+    // constraint and the diagram widens to fit it.
+    let body_width = (bytes_per_row as f32) * cell + pad_left + pad_right;
+    let total_width = body_width.max(inline_header_estimate + pad_right);
+
+    // Title (struct name) and meta line. If they fit on one line,
+    // share a single <text> element via <tspan> children. Otherwise
+    // the title sits on line 1 and the meta on line 2.
+    let wrap_header = inline_header_estimate + pad_right > body_width;
+    let title_line_height = if wrap_header { cell * 0.95 } else { cell * 1.1 };
+    let meta_line_height = if wrap_header { cell * 0.7 } else { 0.0 };
+    let header_height = title_line_height + meta_line_height;
+
+    let n_rows = size.div_ceil(bytes_per_row).max(1);
+    let body_height = (label_height + byte_height + row_gap) * n_rows as f32 + row_gap;
+    let total_height = header_height + body_height;
+
+    let mut out = String::new();
+    write!(
+        &mut out,
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w:.0} {h:.0}" class="wgsl-rs-byte-diagram" data-struct="{name}">"#,
+        w = total_width,
+        h = total_height,
+        name = escape_attr(type_name),
+    )
+    .unwrap();
+
+    // Inline style scoped to this class. Light-mode only.
+    write!(
+        &mut out,
+        r#"<style>
+.wgsl-rs-byte-diagram {{ font-family: monospace; }}
+.wgsl-rs-byte-diagram text {{ dominant-baseline: middle; }}
+.wgsl-rs-byte-diagram .struct-name {{ font-weight: 700; font-size: 16px; fill: #111; }}
+.wgsl-rs-byte-diagram .meta {{ font-size: 11px; fill: #666; }}
+.wgsl-rs-byte-diagram .field-name {{ font-size: 11px; fill: #111; }}
+.wgsl-rs-byte-diagram .pad-text {{ font-size: 11px; fill: #888; }}
+.wgsl-rs-byte-diagram .byte-index {{ font-size: 9px; fill: rgba(0,0,0,0.55); }}
+.wgsl-rs-byte-diagram .byte-cell {{ stroke: rgba(0,0,0,0.2); stroke-width: 1; }}
+.wgsl-rs-byte-diagram .label-cell {{ stroke: rgba(0,0,0,0.2); stroke-width: 1; }}
+.wgsl-rs-byte-diagram .pad-cell {{ stroke: rgba(0,0,0,0.1); stroke-width: 1; fill: #f7f7f7; }}
+.wgsl-rs-byte-diagram .pad-label-cell {{ stroke: rgba(0,0,0,0.1); stroke-width: 1; fill: #f7f7f7; }}
+/* Alternating background tint for every other 4-byte word, applied
+   only to the byte band. The tint is a translucent overlay so it
+   darkens the underlying field/pad color without overriding it. */
+.wgsl-rs-byte-diagram .word-tint {{ fill: rgba(0, 0, 0, 0.08); stroke: none; pointer-events: none; }}
+</style>"#
+    )
+    .unwrap();
+
+    // Header. Inline when the estimate fits, wrapped to two lines
+    // otherwise.
+    if wrap_header {
+        let title_y = title_line_height * 0.7;
+        let meta_y = title_line_height + meta_line_height * 0.7;
+        write!(
+            &mut out,
+            r#"<text class="struct-name" x="0" y="{y:.1}">{name}</text>"#,
+            y = title_y,
+            name = escape_text(short_name),
+        )
+        .unwrap();
+        write!(
+            &mut out,
+            r#"<text class="meta" x="0" y="{y:.1}">{meta}</text>"#,
+            y = meta_y,
+            meta = escape_text(meta),
+        )
+        .unwrap();
+    } else {
+        write!(
+            &mut out,
+            r#"<text class="struct-name" x="0" y="{y:.1}"><tspan class="struct-name">{name}</tspan><tspan class="meta" dx="0.6em">{meta}</tspan></text>"#,
+            y = title_line_height * 0.7,
+            name = escape_text(short_name),
+            meta = escape_text(meta),
+        )
+        .unwrap();
+    }
+
+    // Build a byte map: index -> (kind, owner_field_idx).
+    let mut byte_map: Vec<(ByteKind, usize)> = vec![(ByteKind::Pad, 0); size];
+    for (i, f) in fields.iter().enumerate() {
+        for b in f.offset..(f.offset + f.size) {
+            if b < byte_map.len() {
+                byte_map[b] = (ByteKind::Data, i);
+            }
+        }
+    }
+
+    let bytes_x = pad_left;
+    let body_top = header_height + row_gap;
+
+    for row in 0..n_rows {
+        let row_offset = row * bytes_per_row;
+        let row_y = body_top + row as f32 * (label_height + byte_height + row_gap);
+        let label_y = row_y;
+        let byte_y = label_y + label_height;
+
+        // Label band: one rect per run of consecutive same-field bytes.
+        let runs = build_runs(&byte_map, row_offset, bytes_per_row, size);
+        for run in &runs {
+            let x = bytes_x + run.start as f32 * cell;
+            let w = run.len as f32 * cell;
+            match run.kind {
+                ByteKind::Data => {
+                    let field = &fields[run.owner];
+                    let hue = hue_for(&field.name);
+                    let label_color = lch_to_hex(hue, 90, 60);
+                    write!(
+                        &mut out,
+                        r#"<rect class="label-cell" x="{x:.1}" y="{y:.1}" width="{w:.1}" height="{h:.1}" fill="{fill}"/>"#,
+                        x = x,
+                        y = label_y,
+                        w = w,
+                        h = label_height,
+                        fill = label_color,
+                    )
+                    .unwrap();
+                    write!(
+                        &mut out,
+                        r#"<text class="field-name" x="{tx:.1}" y="{ty:.1}" text-anchor="start">.{name}</text>"#,
+                        tx = x,
+                        ty = label_y + label_height / 2.0,
+                        name = escape_text(&field.name),
+                    )
+                    .unwrap();
+                }
+                ByteKind::Pad => {
+                    if w > 0.0 {
+                        write!(
+                            &mut out,
+                            r#"<rect class="pad-label-cell" x="{x:.1}" y="{y:.1}" width="{w:.1}" height="{h:.1}"/>"#,
+                            x = x,
+                            y = label_y,
+                            w = w,
+                            h = label_height,
+                        )
+                        .unwrap();
+                        if w >= 36.0 {
+                            write!(
+                                &mut out,
+                                r#"<text class="pad-text" x="{tx:.1}" y="{ty:.1}" text-anchor="start">-pad-</text>"#,
+                                tx = x,
+                                ty = label_y + label_height / 2.0,
+                            )
+                            .unwrap();
+                        }
+                    }
+                }
+            }
+        }
+
+        // Pre-compute per-field byte colors so we don't re-hash and
+        // re-convert every cell. The cached `String` is cheap to
+        // clone; for very large layouts this turns an O(cells) cost
+        // into O(fields).
+        let mut field_byte_colors: Vec<Option<String>> = vec![None; fields.len()];
+        for (i, f) in fields.iter().enumerate() {
+            let hue = hue_for(&f.name);
+            field_byte_colors[i] = Some(lch_to_hex(hue, 65, 50));
+        }
+
+        // Byte band: unlabelled colored squares with the absolute
+        // byte offset rendered inside each cell.
+        for b in 0..bytes_per_row {
+            let abs = row_offset + b;
+            if abs >= size {
+                break;
+            }
+            let x = bytes_x + b as f32 * cell;
+            let (kind, owner) = byte_map[abs];
+            match kind {
+                ByteKind::Data => {
+                    let field = &fields[owner];
+                    let byte_color = field_byte_colors[owner]
+                        .as_deref()
+                        .expect("color pre-computed for every field");
+                    let is_first_in_field = abs == field.offset;
+                    let is_last_in_field = abs == field.offset + field.size - 1;
+                    let class = byte_cell_class(is_first_in_field, is_last_in_field);
+                    write!(
+                        &mut out,
+                        r#"<rect class="{class}" x="{x:.1}" y="{y:.1}" width="{w:.1}" height="{h:.1}" fill="{fill}"/>"#,
+                        x = x,
+                        y = byte_y,
+                        w = cell,
+                        h = byte_height,
+                        class = class,
+                        fill = byte_color,
+                    )
+                    .unwrap();
+                }
+                ByteKind::Pad => {
+                    write!(
+                        &mut out,
+                        r#"<rect class="pad-cell" x="{x:.1}" y="{y:.1}" width="{w:.1}" height="{h:.1}"/>"#,
+                        x = x,
+                        y = byte_y,
+                        w = cell,
+                        h = byte_height,
+                    )
+                    .unwrap();
+                }
+            }
+        }
+
+        // Word-end tint overlay: paint a translucent dark rect over
+        // every other 4-byte word in the byte band. Emitted AFTER
+        // the byte-band cells so the tint sits on top of the opaque
+        // field colors and is visible to the user.
+        for w in 0..bytes_per_row / WORD_BYTES {
+            let word_start = w * WORD_BYTES;
+            if row_offset + word_start >= size {
+                break;
+            }
+            if !w.is_multiple_of(2) {
+                continue;
+            }
+            let x = bytes_x + word_start as f32 * cell;
+            let last_in_row =
+                ((row_offset + word_start + WORD_BYTES).min(size)) - (row_offset + word_start);
+            let w_px = last_in_row as f32 * cell;
+            write!(
+                &mut out,
+                r#"<rect class="word-tint" x="{x:.1}" y="{y:.1}" width="{w:.1}" height="{h:.1}"/>"#,
+                x = x,
+                y = byte_y,
+                w = w_px,
+                h = byte_height,
+            )
+            .unwrap();
+        }
+
+        // Byte-index text labels: emitted last so they sit on top of
+        // both the byte cells and the word-tint overlay.
+        for b in 0..bytes_per_row {
+            let abs = row_offset + b;
+            if abs >= size {
+                break;
+            }
+            let x = bytes_x + b as f32 * cell;
+            let tx = x + cell / 2.0;
+            let ty = byte_y + byte_height / 2.0;
+            write!(
+                &mut out,
+                r#"<text class="byte-index" x="{tx:.1}" y="{ty:.1}" text-anchor="middle">{n}</text>"#,
+                tx = tx,
+                ty = ty,
+                n = abs,
+            )
+            .unwrap();
+        }
+    }
+
+    write!(&mut out, "</svg>").unwrap();
+    out
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ByteKind {
+    Data,
+    Pad,
+}
+
+#[derive(Debug)]
+struct Run {
+    start: usize,
+    len: usize,
+    kind: ByteKind,
+    owner: usize,
+}
+
+/// Group consecutive bytes of the same kind into runs.
+fn build_runs(
+    byte_map: &[(ByteKind, usize)],
+    row_start: usize,
+    row_len: usize,
+    size: usize,
+) -> Vec<Run> {
+    let mut runs = Vec::new();
+    let row_end = (row_start + row_len).min(size);
+    let mut i = row_start;
+    while i < row_end {
+        let (kind, owner) = byte_map[i];
+        let mut j = i + 1;
+        while j < row_end && byte_map[j].0 == kind && byte_map[j].1 == owner {
+            j += 1;
+        }
+        runs.push(Run {
+            start: i - row_start,
+            len: j - i,
+            kind,
+            owner,
+        });
+        i = j;
+    }
+    runs
+}
+
+/// Build a class string for a byte-band cell. Word boundaries are
+/// signalled by an overlay rect, so the cell itself carries no
+/// `word-end` class.
+fn byte_cell_class(is_first: bool, is_last: bool) -> &'static str {
+    match (is_first, is_last) {
+        (true, true) => "byte-cell elem-start elem-end",
+        (true, false) => "byte-cell elem-start",
+        (false, true) => "byte-cell elem-end",
+        (false, false) => "byte-cell",
+    }
+}
+
+/// Take the last `::`-separated segment of a fully-qualified type
+/// name so the header shows `Uniforms` rather than
+/// `my_crate::foo::Uniforms`.
+fn short_type_name(name: &str) -> &str {
+    name.rsplit("::").next().unwrap_or(name)
+}
+
+/// Stable hash of a string mapped to a hue in `[0, 360)`. Uses FNV-1a.
+fn hue_for(name: &str) -> u32 {
+    let mut hash: u32 = 0x811c_9dc5;
+    for b in name.bytes() {
+        hash ^= b as u32;
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    hash % 360
+}
+
+/// Convert a hue + a (lightness, chroma) pair to an `#rrggbb` hex
+/// string. Approximates the LCH color we'd get from `lch(L C H)` in
+/// CSS but emits a format that all SVG renderers understand.
+fn lch_to_hex(hue: u32, lightness: u32, chroma: u32) -> String {
+    let l = lightness.min(100) as f32 / 100.0;
+    let s = (chroma.min(150) as f32 * 0.6).min(100.0) / 100.0;
+    let h = hue as f32;
+    hsl_to_hex(h, s, l)
+}
+
+fn hsl_to_hex(h: f32, s: f32, l: f32) -> String {
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let h_prime = h / 60.0;
+    let x = c * (1.0 - (h_prime % 2.0 - 1.0).abs());
+    let (r1, g1, b1) = if h_prime < 1.0 {
+        (c, x, 0.0)
+    } else if h_prime < 2.0 {
+        (x, c, 0.0)
+    } else if h_prime < 3.0 {
+        (0.0, c, x)
+    } else if h_prime < 4.0 {
+        (0.0, x, c)
+    } else if h_prime < 5.0 {
+        (x, 0.0, c)
+    } else {
+        (c, 0.0, x)
+    };
+    let m = l - c / 2.0;
+    let r = ((r1 + m).clamp(0.0, 1.0) * 255.0).round() as u8;
+    let g = ((g1 + m).clamp(0.0, 1.0) * 255.0).round() as u8;
+    let b = ((b1 + m).clamp(0.0, 1.0) * 255.0).round() as u8;
+    format!("#{r:02x}{g:02x}{b:02x}")
+}
+
+fn escape_text(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn escape_attr(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+#[cfg(all(test, feature = "doc-diagrams"))]
+mod tests {
+    use super::*;
+
+    fn meta_for(size: usize, align: usize) -> String {
+        format!("size: {size} bytes \u{00b7} align: {align} bytes")
+    }
+
+    fn fields_one_scalar() -> Vec<RenderField> {
+        vec![RenderField {
+            name: "value".into(),
+            offset: 0,
+            size: 4,
+            pad_after: 0,
+        }]
+    }
+
+    fn fields_three() -> Vec<RenderField> {
+        vec![
+            RenderField {
+                name: "a".into(),
+                offset: 0,
+                size: 4,
+                pad_after: 12,
+            },
+            RenderField {
+                name: "b".into(),
+                offset: 16,
+                size: 64,
+                pad_after: 0,
+            },
+            RenderField {
+                name: "c".into(),
+                offset: 80,
+                size: 4,
+                pad_after: 12,
+            },
+        ]
+    }
+
+    #[test]
+    fn renders_simple_struct() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_one_scalar(), 4, 4, 4, "S", &meta_for(4, 4), &cfg);
+        assert!(svg.contains("<svg"));
+        assert!(svg.contains("</svg>"));
+        assert!(svg.contains("wgsl-rs-byte-diagram"));
+        assert!(svg.contains("data-struct=\"S\""));
+        assert!(svg.contains(".value"));
+    }
+
+    #[test]
+    fn renders_three_field_struct() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        assert!(svg.contains(".a"));
+        assert!(svg.contains(".b"));
+        assert!(svg.contains(".c"));
+        assert!(svg.contains("-pad-"));
+    }
+
+    #[test]
+    fn header_shows_struct_name() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        assert!(svg.contains("class=\"struct-name\""));
+        assert!(svg.contains(">S<"));
+    }
+
+    #[test]
+    fn header_shows_size_and_align() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        assert!(svg.contains("size: 96 bytes"));
+        assert!(svg.contains("align: 16 bytes"));
+    }
+
+    #[test]
+    fn name_and_meta_on_same_line() {
+        // The header is a single <text class="struct-name"> element
+        // containing two <tspan> children. The name and the meta
+        // share the same baseline.
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        // Exactly one <text> opens with the struct-name class.
+        let open = svg.matches(r#"<text class="struct-name""#).count();
+        assert_eq!(
+            open, 1,
+            "expected one <text class=\"struct-name\">, got {open}"
+        );
+        // The header text element contains both the name and the meta.
+        let header_start = svg.find(r#"<text class="struct-name""#).unwrap();
+        let header_end = svg[header_start..].find("</text>").unwrap() + header_start;
+        let header = &svg[header_start..=header_end];
+        assert!(header.contains("S"), "name missing from header text");
+        assert!(
+            header.contains("size: 96 bytes"),
+            "meta missing from header text"
+        );
+        assert!(
+            header.contains(r#"<tspan class="meta""#),
+            "meta should be a tspan"
+        );
+        // No separate <text class="meta"> element.
+        let meta_text_count = svg.matches(r#"<text class="meta""#).count();
+        assert_eq!(meta_text_count, 0, "meta should not be a separate <text>");
+    }
+
+    #[test]
+    fn no_column_header_strip() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        // The "offset" / "layout" column-header strip is removed; the
+        // per-cell byte indices make the row offset redundant.
+        assert!(!svg.contains("col-header"));
+        assert!(!svg.contains(">offset<"));
+        assert!(!svg.contains(">layout<"));
+    }
+
+    #[test]
+    fn no_offset_column() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        // The leftmost column of large offset numbers is gone.
+        assert!(!svg.contains(r#"class="offset""#));
+    }
+
+    #[test]
+    fn word_tint_overlay_appears() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        assert!(
+            svg.contains("word-tint"),
+            "expected word-tint overlay class for word boundaries: {svg}"
+        );
+    }
+
+    #[test]
+    fn word_tint_only_on_byte_band() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        // 6 rows × 4 words/row = 24 words; half get tinted = 12.
+        let count = svg.matches(r#"class="word-tint""#).count();
+        assert_eq!(count, 12, "expected 12 word-tint overlays, got {count}");
+    }
+
+    #[test]
+    fn byte_indices_rendered_in_every_cell() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        // 96 bytes -> 96 byte-index text elements, one per cell.
+        let count = svg.matches(r#"class="byte-index""#).count();
+        assert_eq!(count, 96, "expected 96 byte-index labels, got {count}");
+    }
+
+    #[test]
+    fn byte_indices_are_absolute() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        assert!(svg.contains(">16<"), "expected absolute offset 16 in svg");
+        assert!(svg.contains(">80<"), "expected absolute offset 80 in svg");
+        assert!(svg.contains(">95<"), "expected absolute offset 95 in svg");
+    }
+
+    #[test]
+    fn pad_label_cell_uses_light_grey_fill() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        assert!(
+            svg.contains("class=\"pad-label-cell\""),
+            "expected pad-label-cell rects in label band: {svg}"
+        );
+    }
+
+    #[test]
+    fn no_per_byte_scalar_label() {
+        let cfg = DiagramConfig::default();
+        let svg = render(&fields_three(), 96, 16, 16, "S", &meta_for(96, 16), &cfg);
+        assert!(!svg.contains("f32-"));
+        assert!(!svg.contains("f16-"));
+        assert!(!svg.contains("i32-"));
+        assert!(!svg.contains("u32-"));
+    }
+
+    #[test]
+    fn short_type_name_strips_module_path() {
+        assert_eq!(short_type_name("my_crate::foo::Uniforms"), "Uniforms");
+        assert_eq!(short_type_name("Uniforms"), "Uniforms");
+        assert_eq!(short_type_name(""), "");
+    }
+
+    #[test]
+    fn hue_is_stable() {
+        assert_eq!(hue_for("view"), hue_for("view"));
+    }
+}

--- a/crates/wgsl-rs-layout/src/lib.rs
+++ b/crates/wgsl-rs-layout/src/lib.rs
@@ -36,6 +36,16 @@
 //! for the last field). When writing data into a GPU buffer, you write
 //! this field's bytes followed by `pad_after` zero bytes to fill any
 //! alignment gaps.
+//!
+//! # SVG diagrams for `cargo doc` (optional)
+//!
+//! Enable the `doc-diagrams` feature to generate per-byte SVG diagrams
+//! from any `T: WgslLayout + Layout` (i.e. any type annotated with
+//! `#[derive(Layout)]` or any of the built-in WGSL types). The
+//! diagrams are sourced directly from the trait constants — no source
+//! parsing, no separate layout table. See the `diagrams` module for
+//! the API and an end-to-end workflow that hooks the output into
+//! `cargo doc` via `rustdoc`'s `--resource-files` flag.
 
 pub use wgsl_rs_layout_macros::Layout;
 
@@ -101,6 +111,28 @@ pub trait WgslLayout: Sized {
 pub trait Layout: WgslLayout {
     /// Per-field layout information in declaration order.
     const FIELDS: &'static [FieldLayout];
+
+    /// If the struct's last field is a runtime array, the byte stride
+    /// of one element: `roundUp(AlignOf(E), SizeOf(E))` where `E` is
+    /// the array's element type.
+    ///
+    /// When `Some(_)`, the struct's `WgslLayout::SIZE` reports the
+    /// size with **zero** elements; the actual runtime size is
+    /// `offset_of_runtime_array + N * stride`, rounded up to
+    /// `ALIGN`, for any runtime-determined `N`.
+    ///
+    /// Per the WGSL spec §6.2.10, a runtime-sized array may only
+    /// appear as the last member of a struct. `#[derive(Layout)]`
+    /// rejects a runtime array field that is not in the last
+    /// position.
+    const RUNTIME_ARRAY_STRIDE: Option<usize> = None;
+
+    /// If the struct's last field is a runtime array, the layout of
+    /// that field. Contains the field's name, offset, alignment, and
+    /// the element type's stride (in `pad_after`, repurposed as
+    /// stride to avoid adding another associated constant).
+    /// `None` if there is no runtime-array field.
+    const RUNTIME_ARRAY_FIELD: Option<FieldLayout> = None;
 }
 
 /// Write `t`'s bytes into `bytes` at offset 0 per WGSL layout rules.
@@ -141,6 +173,9 @@ pub const fn round_up(val: usize, align: usize) -> usize {
 pub fn zero_buffer(buf: &mut [u8], len: usize) {
     buf[..len].fill(0);
 }
+
+#[cfg(feature = "doc-diagrams")]
+pub mod diagrams;
 
 #[cfg(test)]
 mod tests {
@@ -780,5 +815,101 @@ mod tests {
             u: u32,
             mat: Mat4f,
         }
+    }
+
+    // ===== Runtime-array tests =====
+
+    use wgsl_rs::std::RuntimeArray;
+
+    #[derive(Layout, Debug, PartialEq)]
+    struct Ex4ForRuntime {
+        velocity: wgsl_rs::std::Vec3f,
+    }
+
+    #[derive(Layout)]
+    #[allow(dead_code)]
+    struct WithRuntimeArray {
+        descriptor: wgsl_rs::std::Vec4f,
+        count: u32,
+        data: RuntimeArray<Ex4ForRuntime>,
+    }
+
+    #[test]
+    fn runtime_array_size_is_prefix() {
+        // MyStorageType prefix: descriptor (16B) + count (4B) + 12B pad
+        // to align runtime array to 16. With zero array elements, the
+        // struct's SIZE is just the prefix size: 32.
+        assert_eq!(<WithRuntimeArray as WgslLayout>::SIZE, 32);
+        assert_eq!(<WithRuntimeArray as WgslLayout>::ALIGN, 16);
+    }
+
+    #[test]
+    fn runtime_array_stride_is_element_stride() {
+        // Ex4ForRuntime: size = roundUp(AlignOf(Vec3f), SizeOf(Vec3f)) = 16.
+        assert_eq!(<WithRuntimeArray as Layout>::RUNTIME_ARRAY_STRIDE, Some(16));
+    }
+
+    #[test]
+    fn runtime_array_field_layout() {
+        // The RUNTIME_ARRAY_FIELD carries the field name, offset,
+        // alignment, and stride.
+        let f = <WithRuntimeArray as Layout>::RUNTIME_ARRAY_FIELD.unwrap();
+        assert_eq!(f.name, "data");
+        assert_eq!(f.offset, 32);
+        assert_eq!(f.alignment, 16);
+        assert_eq!(f.pad_after, 16);
+    }
+
+    #[test]
+    fn runtime_array_excluded_from_fields() {
+        // The runtime array field is NOT in FIELDS — it's reported
+        // separately via RUNTIME_ARRAY_FIELD.
+        assert_eq!(<WithRuntimeArray as Layout>::FIELDS.len(), 2);
+        assert_eq!(<WithRuntimeArray as Layout>::FIELDS[0].name, "descriptor");
+        assert_eq!(<WithRuntimeArray as Layout>::FIELDS[1].name, "count");
+    }
+
+    #[test]
+    fn runtime_array_write_read_roundtrip() {
+        // Verify the macro emits a layout_write_bytes for the trailing
+        // RuntimeArray so that write/read are symmetric: a value
+        // written with layout_write_bytes can be read back with
+        // layout_read_bytes, including the array's element bytes.
+        use crate::layout_write_bytes;
+
+        let prefix_size = <WithRuntimeArray as WgslLayout>::SIZE;
+        let stride = <WithRuntimeArray as Layout>::RUNTIME_ARRAY_STRIDE.unwrap();
+        // Two array elements: descriptor (16B) + count (4B) + 12B pad +
+        // 2 * 16B array = 64B total.
+        let total_size = prefix_size + 2 * stride;
+        let mut buf = vec![0u8; total_size];
+
+        let mut data = wgsl_rs::std::RuntimeArray::new();
+        data.push(Ex4ForRuntime {
+            velocity: wgsl_rs::std::vec3f(1.0, 0.0, 0.0),
+        });
+        data.push(Ex4ForRuntime {
+            velocity: wgsl_rs::std::vec3f(0.0, 1.0, 0.0),
+        });
+        let original = WithRuntimeArray {
+            descriptor: wgsl_rs::std::vec4f(1.0, 2.0, 3.0, 4.0),
+            count: 42,
+            data,
+        };
+
+        layout_write_bytes(&mut buf, &original).unwrap();
+        // The prefix bytes were written.
+        assert_ne!(&buf[0..16], &vec![0u8; 16][..]);
+        // The array's element bytes were written (zeroed padding
+        // around each element per the WgslLayout impl).
+        assert_ne!(
+            &buf[prefix_size..prefix_size + stride],
+            &vec![0u8; stride][..]
+        );
+
+        let restored: WithRuntimeArray = layout_read_bytes(&buf).unwrap();
+        assert_eq!(restored.descriptor, original.descriptor);
+        assert_eq!(restored.count, original.count);
+        assert_eq!(restored.data.len(), original.data.len());
     }
 }

--- a/crates/wgsl-rs-layout/tests/diagrams.rs
+++ b/crates/wgsl-rs-layout/tests/diagrams.rs
@@ -1,0 +1,347 @@
+//! End-to-end tests for the `doc-diagrams` feature.
+
+#![cfg(feature = "doc-diagrams")]
+
+use wgsl_rs::std::{Mat4x4f, Vec3f, Vec4f};
+use wgsl_rs_layout::{
+    Layout, WgslLayout,
+    diagrams::{DiagramConfig, DiagramError, generate_svg},
+};
+
+#[derive(Layout)]
+struct Uniforms {
+    view: Mat4x4f,
+    color: Vec4f,
+    time: f32,
+}
+
+#[derive(Layout)]
+struct Tight {
+    velocity: Vec3f,
+    acceleration: Vec3f,
+    frame_count: u32,
+}
+
+#[test]
+fn generates_diagram_for_concrete_struct() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+
+    assert!(svg.contains("wgsl-rs-byte-diagram"));
+    assert!(svg.contains(".view"));
+    assert!(svg.contains(".color"));
+    assert!(svg.contains(".time"));
+    assert!(svg.contains("-pad-"));
+    // 96 bytes total; one byte-index label per cell.
+    let count = svg.matches(r#"class="byte-index""#).count();
+    assert_eq!(count, 96);
+}
+
+#[test]
+fn custom_cell_size_changes_layout() {
+    // Verifies that the cell_size knob still affects the rendered
+    // SVG (it was the only user-configurable knob in
+    // `DiagramConfig`).
+    let cfg_small = DiagramConfig::builder().cell_size(10.0).build().unwrap();
+    let cfg_big = DiagramConfig::builder().cell_size(40.0).build().unwrap();
+    let small = generate_svg::<Tight>(&cfg_small).unwrap();
+    let big = generate_svg::<Tight>(&cfg_big).unwrap();
+    assert_ne!(small, big);
+    assert!(small.contains("width=\"10"));
+    assert!(big.contains("width=\"40"));
+}
+
+#[test]
+fn respects_config_cell_size() {
+    let cfg_a = DiagramConfig::builder().cell_size(20.0).build().unwrap();
+    let cfg_b = DiagramConfig::builder().cell_size(40.0).build().unwrap();
+    let a = generate_svg::<Uniforms>(&cfg_a).unwrap();
+    let b = generate_svg::<Uniforms>(&cfg_b).unwrap();
+    assert_ne!(a, b);
+    assert!(a.contains("width=\"20"));
+    assert!(b.contains("width=\"40"));
+}
+
+#[test]
+fn diagram_config_builder_rejects_invalid_cell_size() {
+    // Zero.
+    let err = DiagramConfig::builder().cell_size(0.0).build().unwrap_err();
+    assert!(matches!(err, DiagramError::InvalidConfig { .. }));
+    // Negative.
+    let err = DiagramConfig::builder()
+        .cell_size(-1.0)
+        .build()
+        .unwrap_err();
+    assert!(matches!(err, DiagramError::InvalidConfig { .. }));
+    // NaN.
+    let err = DiagramConfig::builder()
+        .cell_size(f32::NAN)
+        .build()
+        .unwrap_err();
+    assert!(matches!(err, DiagramError::InvalidConfig { .. }));
+    // Infinity.
+    let err = DiagramConfig::builder()
+        .cell_size(f32::INFINITY)
+        .build()
+        .unwrap_err();
+    assert!(matches!(err, DiagramError::InvalidConfig { .. }));
+    // Valid default still works.
+    let _cfg = DiagramConfig::builder().cell_size(22.0).build().unwrap();
+}
+
+#[test]
+fn row_width_scales_with_alignment() {
+    // Render an align=4-only struct and an align=16 struct. The
+    // align=16 diagram should be wider than the align=4 diagram
+    // because each row holds more bytes. Both diagrams may widen
+    // beyond the body width to fit the header text; we just check
+    // that the align=16 case is wider.
+    #[derive(Layout)]
+    #[allow(dead_code)]
+    struct Align4 {
+        a: f32,
+        b: f32,
+        c: f32,
+        d: f32,
+    }
+
+    let cfg = DiagramConfig::default();
+    let svg4 = generate_svg::<Align4>(&cfg).unwrap();
+    let svg16 = generate_svg::<Uniforms>(&cfg).unwrap();
+
+    // Both diagrams should render without error and have a viewBox.
+    assert!(svg4.contains("viewBox="));
+    assert!(svg16.contains("viewBox="));
+
+    // The align=16 diagram is wider than align=4 because each row
+    // holds more bytes.
+    let vb4 = viewbox_width(&svg4);
+    let vb16 = viewbox_width(&svg16);
+    assert!(
+        vb16 > vb4,
+        "align=16 diagram ({vb16}px) should be wider than align=4 ({vb4}px)"
+    );
+}
+
+fn viewbox_width(svg: &str) -> f32 {
+    let start = svg.find("viewBox=\"").unwrap() + "viewBox=\"".len();
+    let end = svg[start..].find('"').unwrap() + start;
+    let parts: Vec<&str> = svg[start..end].split_whitespace().collect();
+    let w: f32 = parts[2].parse().unwrap();
+    w
+}
+
+#[test]
+fn fields_appear_in_declaration_order() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    let view_pos = svg.find(".view").expect(".view in svg");
+    let color_pos = svg.find(".color").expect(".color in svg");
+    let time_pos = svg.find(".time").expect(".time in svg");
+    assert!(view_pos < color_pos);
+    assert!(color_pos < time_pos);
+}
+
+#[test]
+fn diagram_data_struct_attribute_contains_type_name() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    let attr_start = svg.find("data-struct=\"").unwrap() + "data-struct=\"".len();
+    let attr_end = svg[attr_start..].find('"').unwrap() + attr_start;
+    let attr = &svg[attr_start..attr_end];
+    assert!(attr.contains("Uniforms"), "data-struct value was {attr:?}");
+}
+
+#[test]
+fn header_renders_struct_name() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    assert!(svg.contains("class=\"struct-name\""));
+    let name_start = svg.find("class=\"struct-name\"").unwrap();
+    let after = &svg[name_start..];
+    let close = after.find("</text>").unwrap();
+    assert!(after[..close].contains("Uniforms"));
+}
+
+#[test]
+fn header_renders_size_and_align() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    assert!(svg.contains("size: 96 bytes"));
+    assert!(svg.contains("align: 16 bytes"));
+}
+
+#[test]
+fn header_name_and_meta_on_same_line() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    // Exactly one <text class="struct-name"> element.
+    let open_count = svg.matches(r#"<text class="struct-name""#).count();
+    assert_eq!(
+        open_count, 1,
+        "expected one <text class=\"struct-name\">, got {open_count}"
+    );
+    // Both name and meta live inside that single <text> element.
+    let header_start = svg.find(r#"<text class="struct-name""#).unwrap();
+    let header_end = svg[header_start..].find("</text>").unwrap() + header_start;
+    let header = &svg[header_start..=header_end];
+    assert!(header.contains("Uniforms"));
+    assert!(header.contains("size: 96 bytes"));
+    assert!(header.contains(r#"<tspan class="meta""#));
+    // No separate <text class="meta"> element.
+    let meta_text_count = svg.matches(r#"<text class="meta""#).count();
+    assert_eq!(meta_text_count, 0);
+}
+
+#[test]
+fn narrow_row_wraps_header_to_two_lines() {
+    // For an align=4 struct (4-byte rows), the body is only 88px
+    // wide but the header text is ~250px. The header should wrap
+    // to two lines: one <text class="struct-name"> for the title
+    // and one <text class="meta"> for the meta line.
+    #[derive(Layout)]
+    #[allow(dead_code)]
+    struct SmallAlign4 {
+        a: f32,
+        b: f32,
+        c: f32,
+    }
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<SmallAlign4>(&cfg).unwrap();
+
+    // Two separate <text> elements: the title and the meta.
+    let title_count = svg.matches(r#"<text class="struct-name""#).count();
+    let meta_count = svg.matches(r#"<text class="meta""#).count();
+    assert_eq!(title_count, 1, "expected one <text class=\"struct-name\">");
+    assert_eq!(meta_count, 1, "expected one <text class=\"meta\">");
+
+    // The header is wider than the body would be alone.
+    let vb = viewbox_width(&svg) as f32;
+    let body_only = 4.0 * 22.0 + 0.0 + 22.0 / 3.0; // 4-byte row + padding
+    assert!(
+        vb > body_only,
+        "viewBox {vb} should be wider than body {body_only} after header wrap"
+    );
+
+    // Both texts contain the expected text.
+    assert!(svg.contains(">SmallAlign4<"));
+    assert!(svg.contains("size: 12 bytes"));
+    assert!(svg.contains("align: 4 bytes"));
+}
+
+#[test]
+fn no_column_header_strip() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    // The "offset" / "layout" column-header strip is removed; the
+    // per-cell byte indices make the row offset redundant.
+    assert!(!svg.contains("col-header"));
+    assert!(!svg.contains(">offset<"));
+    assert!(!svg.contains(">layout<"));
+}
+
+#[test]
+fn no_offset_column() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    // The leftmost column of large offset numbers is gone.
+    assert!(!svg.contains(r#"class="offset""#));
+}
+
+#[test]
+fn word_tint_overlay_present() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    let count = svg.matches(r#"class="word-tint""#).count();
+    assert!(count > 0, "expected at least one word-tint overlay: {svg}");
+}
+
+#[test]
+fn word_tint_only_on_byte_band() {
+    // 6 rows × 4 words/row = 24 words; half get tinted = 12.
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    let count = svg.matches(r#"class="word-tint""#).count();
+    assert_eq!(count, 12, "expected 12 word-tint overlays, got {count}");
+}
+
+#[test]
+fn byte_indices_are_absolute() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    // Row 1 starts at absolute offset 16, row 5 at 80.
+    assert!(svg.contains(">16<"), "expected absolute offset 16 in svg");
+    assert!(svg.contains(">80<"), "expected absolute offset 80 in svg");
+    assert!(svg.contains(">95<"), "expected absolute offset 95 in svg");
+}
+
+#[test]
+fn pad_label_cell_uses_light_grey_fill() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    assert!(
+        svg.contains("class=\"pad-label-cell\""),
+        "expected pad-label-cell rects in label band: {svg}"
+    );
+}
+
+#[test]
+fn no_per_byte_scalar_label() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<Uniforms>(&cfg).unwrap();
+    assert!(!svg.contains("f32-"));
+    assert!(!svg.contains("f16-"));
+    assert!(!svg.contains("i32-"));
+    assert!(!svg.contains("u32-"));
+}
+
+// ===== Runtime-array tests =====
+
+use wgsl_rs::std::RuntimeArray;
+
+#[derive(Layout)]
+struct Ex4ForRuntime {
+    velocity: wgsl_rs::std::Vec3f,
+}
+
+#[derive(Layout)]
+#[allow(dead_code)]
+struct WithRuntimeArray {
+    descriptor: wgsl_rs::std::Vec4f,
+    count: u32,
+    data: RuntimeArray<Ex4ForRuntime>,
+}
+
+#[test]
+fn runtime_array_meta_uses_len_placeholder() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<WithRuntimeArray>(&cfg).unwrap();
+    // The meta line should indicate that the size depends on LEN.
+    assert!(
+        svg.contains("LEN"),
+        "expected LEN placeholder in meta line: {svg}"
+    );
+    assert!(
+        svg.contains("align: 16 bytes"),
+        "expected align in meta line: {svg}"
+    );
+}
+
+#[test]
+fn runtime_array_shows_one_example() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<WithRuntimeArray>(&cfg).unwrap();
+    // Exactly one example element is rendered, labeled `data[0]`.
+    assert!(svg.contains("data[0]"), "missing data[0] in svg");
+    assert!(!svg.contains("data[1]"), "data[1] should not be rendered");
+    assert!(!svg.contains("data[2]"), "data[2] should not be rendered");
+    assert!(!svg.contains("..."), "ellipsis should not be rendered");
+}
+
+#[test]
+fn runtime_array_prefix_fields_appear() {
+    let cfg = DiagramConfig::default();
+    let svg = generate_svg::<WithRuntimeArray>(&cfg).unwrap();
+    assert!(svg.contains(".descriptor"));
+    assert!(svg.contains(".count"));
+}


### PR DESCRIPTION
These changes provide a function that will generate a data memory layout SVG diagram for WGSL structs that derive `Layout`. 

These diagrams look like the ones shown in <https://webgpufundamentals.org/webgpu/lessons/webgpu-memory-layout.html>.

## Examples

These structs:

```rust
/// A typical uniform buffer.
#[derive(Layout)]
struct Uniforms {
    view: Mat4x4f,
    color: Vec4f,
    time: f32,
}

/// A tight struct where field alignment drives the layout.
#[derive(Layout)]
struct Tight {
    velocity: Vec3f,
    frame_count: u32,
    acceleration: Vec3f,
    delta: f32,
}

#[derive(Layout)]
/// An example from <https://webgpufundamentals.org/webgpu/lessons/webgpu-memory-layout.html>.
struct Ex4a {
    velocity: Vec3f,
}

#[derive(Layout)]
/// An example from <https://webgpufundamentals.org/webgpu/lessons/webgpu-memory-layout.html>.
struct Ex4 {
    orientation: Vec3f,
    size: f32,
    direction: [Vec3u; 1],
    scale: f32,
    info: Ex4a,
    friction: f32,
}

/// A small struct for showcasing per-byte offset labels.
#[derive(Layout)]
struct Small {
    a: f32,
    b: u32,
    c: f32,
}

/// A struct ending in a runtime array.
#[cfg(feature = "doc-diagrams")]
#[derive(Layout)]
#[allow(dead_code)]
struct MyStorageType {
    descriptor: Vec4f,
    count: u32,
    data: RuntimeArray<Ex4>,
}
```

...will produce these layout diagrams:

<img width="300" height="231" alt="Ex4" src="https://github.com/user-attachments/assets/21d93714-72ee-4e7d-99eb-2eb214a4dfb5" />
<img width="300" height="289" alt="MyStorageType" src="https://github.com/user-attachments/assets/faa5115e-71fd-4ad7-b0b4-84cd5a0f899a" />
<img width="300" height="225" alt="Small" src="https://github.com/user-attachments/assets/5511fb18-1fce-4b14-956a-ae0e224ba8f2" />
<img width="300" height="108" alt="Tight" src="https://github.com/user-attachments/assets/f5cc3190-f7ae-42bc-9972-0ca707673d56" />
<img width="300" height="273" alt="Uniforms" src="https://github.com/user-attachments/assets/c1a0c7a6-321b-4736-9696-cc3147a7d78d" />


