### PR TITLE
Reject multi-segment type paths in Type::parse

### DIFF
--- a/crates/wgsl-rs-macros/src/parse.rs
+++ b/crates/wgsl-rs-macros/src/parse.rs
@@ -857,6 +857,18 @@ impl Type {
                 type_path.qself.as_ref(),
                 "QSelf not allowed in scalar type",
             )?;
+            // Reject multi-segment paths in type position. WGSL struct
+            // names must be simple identifiers; a Rust path like
+            // `std::marker::PhantomData` has no WGSL equivalent. Bring
+            // the type into scope with a `use` import first.
+            snafu::ensure!(
+                type_path.path.segments.len() == 1,
+                UnsupportedSnafu {
+                    span: type_path.path.segments.span(),
+                    note: "fully qualified type paths like `std::marker::PhantomData` are not \
+                           supported; use a `use` import to bring the type into scope",
+                }
+            );
             let segment = type_path.path.segments.first().context(UnsupportedSnafu {
                 span: type_path.path.segments.span(),
                 note: "Unexpected type path",

--- a/crates/wgsl-rs/tests/trybuild.rs
+++ b/crates/wgsl-rs/tests/trybuild.rs
@@ -21,3 +21,9 @@ fn linkage_access_in_const_is_rejected() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/fail/linkage_access_in_const.rs");
 }
+
+#[test]
+fn multi_segment_type_path_in_struct_is_rejected() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/fail/path_in_struct.rs");
+}

--- a/crates/wgsl-rs/tests/ui/fail/path_in_struct.rs
+++ b/crates/wgsl-rs/tests/ui/fail/path_in_struct.rs
@@ -1,0 +1,20 @@
+//! This test ensures that structs must be imported instead of being referenced
+//! by path name.
+use wgsl_rs::wgsl;
+
+#[wgsl]
+pub mod slab {
+    use wgsl_rs::std::*;
+
+    /// An identifier that can be used to read or write a type from/into the
+    /// slab.
+    #[repr(transparent)]
+    pub struct Id<T> {
+        pub index: u32,
+        // This should fail to parse because the struct `PhantomData` is
+        // a fully qualified path name.
+        pub phantom: std::marker::PhantomData<T>,
+    }
+}
+
+fn main() {}

--- a/crates/wgsl-rs/tests/ui/fail/path_in_struct.stderr
+++ b/crates/wgsl-rs/tests/ui/fail/path_in_struct.stderr
@@ -1,0 +1,6 @@
+error: Parsing error: 'Encountered unsupported Rust syntax:
+       fully qualified type paths like `std::marker::PhantomData` are not supported; use a `use` import to bring the type into scope.'
+  --> tests/ui/fail/path_in_struct.rs:16:22
+   |
+16 |         pub phantom: std::marker::PhantomData<T>,
+   |                      ^^^

--- a/crates/wgsl-rs/tests/ui/pass/generic_struct_instantiation.rs
+++ b/crates/wgsl-rs/tests/ui/pass/generic_struct_instantiation.rs
@@ -1,0 +1,15 @@
+//! This test shows that
+use wgsl_rs::wgsl;
+
+#[wgsl]
+pub mod slab {
+    use wgsl_rs::std::*;
+
+    /// An identifier that can be used to read or write a type from/into the
+    /// slab.
+    #[repr(transparent)]
+    pub struct Id<T> {
+        pub index: u32,
+        pub phantom: std::marker::PhantomData<T>,
+    }
+}


### PR DESCRIPTION
## Summary

`Type::parse` in `wgsl-rs-macros` silently dropped all but the first segment of a `syn::Type::Path`. For a field like `pub phantom: std::marker::PhantomData<T>`, this produced a malformed `Type::Struct` with `name='std'` and no type args instead of a parse error.

## Fix

Add a `snafu::ensure!` in the `syn::Type::Path` branch of `Type::parse` (crates/wgsl-rs-macros/src/parse.rs:860) that rejects paths with more than one segment. Error message points the user at the `use`-import workaround.

This brings the type-position path branch into line with checks that already exist in the struct-constructor branch (line 2174) and the impl self-ty branch (line 5781).

## Test

A `compile_fail` trybuild test at `crates/wgsl-rs/tests/ui/fail/path_in_struct.rs` exercises the new error, with the captured `.stderr` committed alongside.

## Verification

- `cargo test --workspace` — 0 failures.
- `cargo fmt` — no changes.
- `cargo clippy --all-features` — no new warnings on touched files.
- The 10 `useless_format` warnings in `crates/roundtrip-tests/src/shaders/{rounding,trig}.rs` are pre-existing on `main` and unrelated to this change.

## Disclosure

Authored with AI assistance per NLnet's policy.