### PR TITLE
fix: strip Rust float literal suffixes from generated WGSL (#85)

### DIFF
--- a/crates/example/src/examples.rs
+++ b/crates/example/src/examples.rs
@@ -48,7 +48,6 @@ pub fn get_module_by_name(name: &str) -> Option<&'static wgsl_rs::Source> {
         .map(|v| v as _)
 }
 
-
 #[wgsl]
 pub mod hello_triangle {
     //! This is a "hello world" shader that shows a triangle with changing

--- a/crates/roundtrip-tests/src/shaders/derivative_operations.rs
+++ b/crates/roundtrip-tests/src/shaders/derivative_operations.rs
@@ -77,7 +77,6 @@ pub mod derivative_variants {
     }
 }
 
-
 /// Renders the basic derivative shader to one target and returns pixels.
 fn render_basic(device: &wgpu::Device, queue: &wgpu::Queue) -> Vec<[f32; 4]> {
     let texture =

--- a/crates/roundtrip-tests/src/shaders/vector_arithmetic.rs
+++ b/crates/roundtrip-tests/src/shaders/vector_arithmetic.rs
@@ -678,7 +678,6 @@ impl RoundtripTest for VectorArithmeticTest {
             });
             let gpu_floats: &[f32] = bytemuck::cast_slice(&gpu_bytes);
 
-
             vec_binary_f32::INPUT.set(flattened);
             vec_binary_f32::OUTPUT.set([Vec4f::default(); 320]);
             dispatch_workgroups((1, 1, 1), (N as u32, 1, 1), |builtins| {
@@ -744,7 +743,6 @@ impl RoundtripTest for VectorArithmeticTest {
             });
             let gpu_i32s: &[i32] = bytemuck::cast_slice(&gpu_bytes);
 
-
             vec_binary_i32::INPUT.set(flattened);
             vec_binary_i32::OUTPUT.set([Vec4i::default(); 256]);
             dispatch_workgroups((1, 1, 1), (N as u32, 1, 1), |builtins| {
@@ -788,7 +786,6 @@ impl RoundtripTest for VectorArithmeticTest {
             });
             let gpu_u32s: &[u32] = bytemuck::cast_slice(&gpu_bytes);
 
-
             vec_binary_u32::INPUT.set(flattened);
             vec_binary_u32::OUTPUT.set([Vec4u::default(); 256]);
             dispatch_workgroups((1, 1, 1), (N as u32, 1, 1), |builtins| {
@@ -827,7 +824,6 @@ impl RoundtripTest for VectorArithmeticTest {
                 workgroup_count: (1, 1, 1),
             });
             let gpu_floats: &[f32] = bytemuck::cast_slice(&gpu_bytes);
-
 
             vec_scalar_f32::INPUT.set(flattened);
             vec_scalar_f32::OUTPUT.set([Vec4f::default(); 512]);
@@ -870,7 +866,6 @@ impl RoundtripTest for VectorArithmeticTest {
                 workgroup_count: (1, 1, 1),
             });
             let gpu_i32s: &[i32] = bytemuck::cast_slice(&gpu_bytes);
-
 
             vec_scalar_i32::INPUT.set(flattened);
             vec_scalar_i32::OUTPUT.set([Vec4i::default(); 512]);
@@ -915,7 +910,6 @@ impl RoundtripTest for VectorArithmeticTest {
                 workgroup_count: (1, 1, 1),
             });
             let gpu_u32s: &[u32] = bytemuck::cast_slice(&gpu_bytes);
-
 
             vec_scalar_u32::INPUT.set(flattened);
             vec_scalar_u32::OUTPUT.set([Vec4u::default(); 512]);
@@ -972,7 +966,6 @@ impl RoundtripTest for VectorArithmeticTest {
                 workgroup_count: (1, 1, 1),
             });
             let gpu_floats: &[f32] = bytemuck::cast_slice(&gpu_bytes);
-
 
             vec_unary::INPUT.set(flattened);
             vec_unary::OUTPUT.set([0.0f32; 512]);
@@ -1043,7 +1036,6 @@ impl RoundtripTest for VectorArithmeticTest {
             });
             let gpu_floats: &[f32] = bytemuck::cast_slice(&gpu_bytes);
 
-
             vec_mixed_dims::INPUT.set(flattened);
             vec_mixed_dims::OUTPUT.set([0.0f32; 384]);
             dispatch_workgroups((1, 1, 1), (N as u32, 1, 1), |builtins| {
@@ -1098,7 +1090,6 @@ impl RoundtripTest for VectorArithmeticTest {
                 workgroup_count: (1, 1, 1),
             });
             let gpu_u32s: &[u32] = bytemuck::cast_slice(&gpu_bytes);
-
 
             vec_overflow_u32::INPUT.set(flattened);
             vec_overflow_u32::OUTPUT.set([vec4u(0, 0, 0, 0); 384]);
@@ -1156,7 +1147,6 @@ impl RoundtripTest for VectorArithmeticTest {
                 workgroup_count: (1, 1, 1),
             });
             let gpu_i32s_raw: &[i32] = bytemuck::cast_slice(&gpu_bytes);
-
 
             vec_overflow_i32::INPUT.set(flattened);
             vec_overflow_i32::OUTPUT.set([vec4i(0, 0, 0, 0); 448]);

--- a/crates/wgsl-rs-layout/examples/doc_diagrams.rs
+++ b/crates/wgsl-rs-layout/examples/doc_diagrams.rs
@@ -41,7 +41,6 @@ struct Tight {
     delta: f32,
 }
 
-
 #[cfg(feature = "doc-diagrams")]
 #[derive(Layout)]
 /// An example from

--- a/crates/wgsl-rs-macros/src/ir_convert.rs
+++ b/crates/wgsl-rs-macros/src/ir_convert.rs
@@ -509,7 +509,7 @@ fn tex_depth_kind(k: parse::TextureDepthKind) -> ir::TextureDepthKind {
 /// Convert a parse expression to IR.
 pub fn expr_from_parse(e: &parse::Expr) -> Result<ir::Expr> {
     Ok(match e {
-        parse::Expr::Lit(l) => ir::Expr::Lit(lit(l)),
+        parse::Expr::Lit(l) => ir::Expr::Lit(lit(l)?),
         parse::Expr::Ident(i) => ir::Expr::Ident(i.to_string()),
         parse::Expr::Array { elems, .. } => ir::Expr::Array {
             elems: elems
@@ -614,17 +614,45 @@ fn fn_path(p: &parse::FnPath) -> ir::FnPath {
     }
 }
 
-fn lit(l: &parse::Lit) -> ir::Lit {
-    match l {
+fn lit(l: &parse::Lit) -> Result<ir::Lit> {
+    Ok(match l {
         parse::Lit::Bool(b) => ir::Lit::Bool(b.value()),
         parse::Lit::Int(i) => ir::Lit::Int {
             digits: i.base10_digits().to_string(),
             suffix: i.suffix().to_string(),
         },
-        parse::Lit::Float(f) => ir::Lit::Float {
-            text: f.to_string(),
-        },
-    }
+        parse::Lit::Float(f) => {
+            // Rust float literals may carry a type suffix like `_f32`, `_f64`,
+            // or `_f16` (e.g. `0.0_f32`). WGSL does not recognize these suffixes,
+            // so the suffix must be stripped before storing the text. WGSL only
+            // has `f32` (and `f16` behind an extension), so the plain mantissa
+            // (e.g. `0.0`) is valid WGSL. `f64` is unsupported and produces a
+            // compile error.
+            let raw = f.to_string();
+            let text = match f.suffix() {
+                // Common path: no suffix, the literal text is already valid WGSL.
+                "" => raw,
+                "f32" | "f16" => raw
+                    .strip_suffix(f.suffix())
+                    .map(|s| s.trim_end_matches('_').to_string())
+                    .unwrap_or(raw),
+                "f64" => {
+                    return Err(ConvertError::Unsupported {
+                        span: f.span(),
+                        note: "f64 float literals are not supported in WGSL (only f32/f16)"
+                            .to_string(),
+                    });
+                }
+                other => {
+                    return Err(ConvertError::Unsupported {
+                        span: f.span(),
+                        note: format!("unsupported float literal suffix `{other}` in WGSL"),
+                    });
+                }
+            };
+            ir::Lit::Float { text }
+        }
+    })
 }
 
 fn bin_op(op: &parse::BinOp) -> ir::BinOp {
@@ -798,7 +826,7 @@ fn stmt_if(i: &parse::StmtIf) -> Result<ir::StmtIf> {
 
 fn case_selector(s: &parse::CaseSelector) -> Result<ir::CaseSelector> {
     Ok(match s {
-        parse::CaseSelector::Literal(l) => ir::CaseSelector::Literal(lit(l)),
+        parse::CaseSelector::Literal(l) => ir::CaseSelector::Literal(lit(l)?),
         parse::CaseSelector::Expr(e) => ir::CaseSelector::Expr(expr_from_parse(e)?),
         parse::CaseSelector::Default(_) => ir::CaseSelector::Default,
     })

--- a/crates/wgsl-rs-macros/src/lib.rs
+++ b/crates/wgsl-rs-macros/src/lib.rs
@@ -227,7 +227,6 @@ impl From<parse::Error> for WgslGenError {
     }
 }
 
-
 /// Collect the encoded names of all module-level type parameters in the
 /// parsed module, in the order they should appear in the generated
 /// `WGSL_SOURCE.module_type_params` slice.
@@ -1365,7 +1364,6 @@ pub fn builtin(_attr: TokenStream, token_stream: TokenStream) -> TokenStream {
 pub fn wgsl_allow(_attr: TokenStream, token_stream: TokenStream) -> TokenStream {
     token_stream
 }
-
 
 /// Ignores any item following the attribute during parsing, skipping WGSL code
 /// generation.

--- a/crates/wgsl-rs-macros/src/monomorphize.rs
+++ b/crates/wgsl-rs-macros/src/monomorphize.rs
@@ -1007,7 +1007,6 @@ fn rewrite_names_in_item(
     let _ = v.visit_item(item);
 }
 
-
 // ===== Missing turbofish detection =====
 //
 // Errors if any call to a known generic template function lacks turbofish
@@ -1284,7 +1283,6 @@ impl ParseVisitorMut for CrossModuleVisitor<'_> {
     }
 }
 
-
 // ===== Template dependency scanning =====
 //
 // Scans a generic function's body for turbofish calls to other generic
@@ -1519,7 +1517,6 @@ fn mangle_type(ty: &Type) -> Result<String, crate::parse::Error> {
         }
     })
 }
-
 
 /// Convert an array length expression to a string for name mangling.
 fn len_to_string(expr: &Expr) -> String {

--- a/crates/wgsl-rs/src/std.rs
+++ b/crates/wgsl-rs/src/std.rs
@@ -160,7 +160,6 @@ impl<T: AnySendSync> DerefMut for ModuleVarWriteGuard<'_, T> {
     }
 }
 
-
 /// A `TypeMap` holds values of any WGSL type, but only one of that type.
 type TypeMap = HashMap<TypeId, Box<dyn std::any::Any + Send + Sync>>;
 

--- a/crates/wgsl-rs/tests/linkage_gating.rs
+++ b/crates/wgsl-rs/tests/linkage_gating.rs
@@ -1,0 +1,72 @@
+//! Regression test for wgsl-rs#72.
+//!
+//! Ensures that wgpu linkage is not produced when the `linkage-wgpu` feature
+//! is disabled. The macro should emit only the CPU-side runtime API
+//! (`Uniform::new`, `Storage::new`, `get!`, `get_mut!`) and no `wgpu::*`,
+//! `linkage::wgpu::*`, `WgpuLinkage`, or bind-group references should appear
+//! in the compiled output.
+//!
+//! This test is gated on `not(feature = "linkage-wgpu")` so it only runs in
+//! the default/no-feature build. The companion `linkage_wgpu.rs` integration
+//! test covers the feature-enabled path.
+
+#![cfg(not(feature = "linkage-wgpu"))]
+#![allow(dead_code)]
+
+use wgsl_rs::wgsl;
+
+// A module that exercises the `uniform!` and `storage!` macros — the paths
+// that previously emitted compile-time wgpu linkage before PR #124.
+#[wgsl]
+mod linkage_gating {
+    use wgsl_rs::std::*;
+
+    uniform!(group(0), binding(0), FRAME: u32);
+    storage!(group(0), binding(1), read_write, OUTPUT: [f32; 16]);
+
+    #[vertex]
+    pub fn vs_main(#[builtin(vertex_index)] _vertex_index: u32) -> Vec4f {
+        let pos = vec2f(0.0, 0.0);
+        vec4f(pos.x, pos.y, 0.0, 1.0)
+    }
+
+    #[fragment]
+    pub fn fs_main() -> Vec4f {
+        let frame = get!(FRAME);
+        let mut output = get_mut!(OUTPUT);
+        // Use both linkage variables to keep them live in both worlds.
+        // The arithmetic is valid in Rust and in WGSL.
+        output[0] = f32(frame) / 16.0;
+        vec4f(1.0, 0.0, 0.0, 1.0)
+    }
+}
+
+#[test]
+fn module_renders_without_linkage_wgpu_feature() {
+    // With `linkage-wgpu` off, the `#[wgsl]` module must still expand and
+    // render to valid WGSL — the CPU-side runtime API (`uniform!`/`storage!`/
+    // `get!`/`get_mut!`) is available without the feature, and no wgpu
+    // linkage codegen should be triggered. This is a smoke test that the
+    // module compiles and renders; the next test asserts the rendered
+    // source contains no wgpu/linkage artifacts.
+    let _ = linkage_gating::WGSL_SOURCE.wgsl_source().unwrap();
+}
+
+#[test]
+fn source_renders_without_wgpu_references() {
+    // The rendered WGSL must not contain any `wgpu` linkage artifacts —
+    // only the shader source itself.
+    let src = linkage_gating::WGSL_SOURCE.wgsl_source().unwrap();
+    assert!(
+        !src.contains("wgpu"),
+        "rendered WGSL should not mention wgpu, got: {src}"
+    );
+    assert!(
+        !src.contains("linkage"),
+        "rendered WGSL should not mention linkage, got: {src}"
+    );
+    assert!(
+        !src.contains("bind_group"),
+        "rendered WGSL should not mention bind_group, got: {src}"
+    );
+}

--- a/crates/wgsl-rs/tests/trybuild.rs
+++ b/crates/wgsl-rs/tests/trybuild.rs
@@ -27,3 +27,9 @@ fn multi_segment_type_path_in_struct_is_rejected() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/fail/path_in_struct.rs");
 }
+
+#[test]
+fn typed_literal_f64_suffix_is_rejected() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/fail/typed_literal_f64_suffix.rs");
+}

--- a/crates/wgsl-rs/tests/typed_literal_suffixes.rs
+++ b/crates/wgsl-rs/tests/typed_literal_suffixes.rs
@@ -1,0 +1,78 @@
+//! Regression test for wgsl-rs#85.
+//!
+//! Rust numeric literals with type suffixes like `0.0_f32`, `5_i32`, `10_u32`
+//! must not be emitted verbatim into the generated WGSL — WGSL does not
+//! recognize Rust-style suffixes. The IR conversion strips the suffix so the
+//! rendered WGSL contains only the plain mantissa (e.g. `0.0`), which is
+//! valid WGSL `f32`/`i32`/`u32` literal syntax.
+
+#![allow(dead_code)]
+
+use wgsl_rs::wgsl;
+
+#[wgsl]
+mod typed_suffixes {
+    pub fn suffixed_float() -> f32 {
+        let v = 0.0_f32;
+        let a = 0.5_f32;
+        v + a
+    }
+
+    pub fn suffixed_ints() -> u32 {
+        let i = 5_i32;
+        let u = 10_u32;
+        u + (i as u32)
+    }
+
+    pub fn plain_literals() -> f32 {
+        let v = 0.0;
+        let a = 0.5;
+        v + a
+    }
+}
+
+#[test]
+fn suffixed_floats_are_stripped_in_wgsl() {
+    let src = typed_suffixes::WGSL_SOURCE.wgsl_source().unwrap();
+    // The specific suffixed literals used in the test module must not appear
+    // verbatim — the suffix should be stripped, leaving only the mantissa.
+    assert!(
+        !src.contains("0.0_f32"),
+        "rendered WGSL should not contain 0.0_f32, got: {src}"
+    );
+    assert!(
+        !src.contains("0.5_f32"),
+        "rendered WGSL should not contain 0.5_f32, got: {src}"
+    );
+    assert!(
+        !src.contains("5_i32"),
+        "rendered WGSL should not contain 5_i32, got: {src}"
+    );
+    assert!(
+        !src.contains("10_u32"),
+        "rendered WGSL should not contain 10_u32, got: {src}"
+    );
+    // The stripped mantissas/digits should be present.
+    assert!(
+        src.contains("0.0"),
+        "expected stripped 0.0 in WGSL, got: {src}"
+    );
+    assert!(
+        src.contains("0.5"),
+        "expected stripped 0.5 in WGSL, got: {src}"
+    );
+}
+
+#[test]
+fn plain_literals_still_render_correctly() {
+    let src = typed_suffixes::WGSL_SOURCE.wgsl_source().unwrap();
+    // Plain literals should round-trip unchanged.
+    assert!(
+        src.contains("0.0"),
+        "expected plain 0.0 in WGSL, got: {src}"
+    );
+    assert!(
+        src.contains("0.5"),
+        "expected plain 0.5 in WGSL, got: {src}"
+    );
+}

--- a/crates/wgsl-rs/tests/ui/fail/typed_literal_f64_suffix.rs
+++ b/crates/wgsl-rs/tests/ui/fail/typed_literal_f64_suffix.rs
@@ -1,0 +1,11 @@
+use wgsl_rs::wgsl;
+
+#[wgsl]
+mod bad_float {
+    pub fn f() -> f64 {
+        let v = 0.0_f64;
+        v
+    }
+}
+
+fn main() {}

--- a/crates/wgsl-rs/tests/ui/fail/typed_literal_f64_suffix.stderr
+++ b/crates/wgsl-rs/tests/ui/fail/typed_literal_f64_suffix.stderr
@@ -1,0 +1,6 @@
+error: Parsing error: 'Encountered unsupported Rust syntax:
+       f64 float literals are not supported in WGSL (only f32/f16).'
+ --> tests/ui/fail/typed_literal_f64_suffix.rs:6:17
+  |
+6 |         let v = 0.0_f64;
+  |                 ^^^^^^^


### PR DESCRIPTION
Resolves #85.
Confirms #72 (already fixed by #124, now regression-tested).

## What changed

### `ir_convert.rs:lit()` (the fix for #85)

Rust float literals with type suffixes like `0.0_f32`, `5_i32`, `10_u32` were emitted verbatim into the generated WGSL, which does not recognize these suffixes. The error only surfaced as a misleading naga parse failure ("expected ;") pointing at the whole function body.

`lit()` now returns `Result<ir::Lit>` and strips the Rust float suffix during IR conversion, so the rendered WGSL contains only the plain mantissa (e.g. `0.0`), which is valid WGSL `f32`. `f64` suffixes produce a clear compile error:

```
error: f64 float literals are not supported in WGSL (only f32/f16)
```

The two existing infallible call sites (`expr_from_parse` and `case_selector`) propagate the new error via `?`.

### `tests/linkage_gating.rs` (regression test for #72)

#72 ("Ensure `wgpu` linkage is only included with `feature = linkage-wgpu`") was already resolved by #124 — the compile-time wgpu linkage codegen in the proc-macro was deleted entirely, and the runtime `wgsl_rs::linkage::wgpu` module is properly `#[cfg(feature = linkage-wgpu)]`-gated. This adds a regression test gated on `#![cfg(not(feature = linkage-wgpu))]` that expands a `#[wgsl]` module using `uniform!`/`storage!`/`get!`/`get_mut!` and asserts:

- the rendered WGSL contains no `wgpu`, `linkage`, or `bind_group` strings,
- the macro-generated `__validate_wgsl` test confirms the WGSL is valid.

With `--all-features` the file is cfg'd out (the companion `linkage_wgpu.rs` covers the feature-on path).

### `tests/typed_literal_suffixes.rs` + `tests/ui/fail/typed_literal_f64_suffix.rs`

Integration tests asserting no `_f32`/`_i32`/`_u32` suffixes leak into the rendered WGSL and plain literals still round-trip, plus a trybuild compile-fail test for the `f64` suffix.

## Verification

- `cargo test -p wgsl-rs`: all green (247 lib + linkage_wgpu + 5 trybuild + 3 typed_literal_suffixes + 3 linkage_gating + import resolution)
- `cargo xtask ci pr-check`: all green, roundtrip 106/106
- `cargo clippy --all-features --all-targets -- -D warnings`: clean

## AI disclosure

Per `AGENTS.md`, this change was produced in collaboration with an AI agent. Commit author: `Schell Carl Scivally with glm-5.2 <efsubenovex@gmail.com>`.