### PR TITLE
fix: strip #[builtin(...)] from #[fragment] function parameters (#84)

### DIFF
--- a/crates/wgsl-rs-macros/src/lib.rs
+++ b/crates/wgsl-rs-macros/src/lib.rs
@@ -1244,7 +1244,23 @@ pub fn vertex(_attr: TokenStream, token_stream: TokenStream) -> TokenStream {
 /// See [`wgsl`] for the full annotation reference.
 #[proc_macro_attribute]
 pub fn fragment(_attr: TokenStream, token_stream: TokenStream) -> TokenStream {
-    token_stream
+    // Strip #[builtin(...)] attributes from function arguments, mirroring
+    // `#[vertex]` and `#[compute]`. Without this, `#[builtin(position)]` on a
+    // fragment parameter is passed through to the Rust compiler, which rejects
+    // it as a non-macro attribute (wgsl-rs#84).
+    let mut item_fn: syn::ItemFn = syn::parse_macro_input!(token_stream);
+    for arg in item_fn.sig.inputs.iter_mut() {
+        if let syn::FnArg::Typed(pat_type) = arg {
+            pat_type.attrs.retain(|attr| {
+                if let Some(ident) = attr.path().get_ident() {
+                    !matches!(ident.to_string().as_str(), "builtin")
+                } else {
+                    true
+                }
+            });
+        }
+    }
+    item_fn.into_token_stream().into()
 }
 
 /// Marks a function as a compute shader entry point.

--- a/crates/wgsl-rs/tests/fragment_builtin.rs
+++ b/crates/wgsl-rs/tests/fragment_builtin.rs
@@ -1,0 +1,51 @@
+//! Regression test for wgsl-rs#84.
+//!
+//! `#[fragment]` previously did not strip `#[builtin(...)]` attributes from
+//! function parameters, causing a hard Rust compile error:
+//! "expected non-macro attribute, found attribute macro `builtin`" when
+//! using `#[builtin(position)]` directly on a fragment function parameter.
+//! The fix mirrors the stripping logic already present in `#[vertex]` and
+//! `#[compute]`.
+
+#![allow(dead_code)]
+
+use wgsl_rs::wgsl;
+
+#[wgsl]
+mod fragment_builtin {
+    use wgsl_rs::std::*;
+
+    // Direct `#[builtin(...)]` on a fragment parameter — the pattern that
+    // failed before the fix. `#[vertex]` and `#[compute]` already supported
+    // this; `#[fragment]` now does too.
+    #[fragment]
+    pub fn frag_main(#[builtin(position)] frag_coord: Vec4f) -> Vec4f {
+        vec4f(frag_coord.x, frag_coord.y, frag_coord.z, 1.0)
+    }
+
+    // A fragment entry point with no builtins should still work.
+    #[fragment]
+    pub fn frag_no_builtin() -> Vec4f {
+        vec4f(1.0, 0.0, 0.0, 1.0)
+    }
+}
+
+#[test]
+fn fragment_with_builtin_param_compiles_and_renders() {
+    let src = fragment_builtin::WGSL_SOURCE.wgsl_source().unwrap();
+    // The WGSL should contain the `@builtin(position)` decoration on the
+    // fragment input, and a valid `@fragment` entry point.
+    assert!(
+        src.contains("@builtin(position)"),
+        "expected @builtin(position) in WGSL, got: {src}"
+    );
+    assert!(
+        src.contains("@fragment"),
+        "expected @fragment in WGSL, got: {src}"
+    );
+    // The Rust-side `builtin` attribute macro must not leak into WGSL.
+    assert!(
+        !src.contains("#[builtin"),
+        "WGSL should not contain #[builtin], got: {src}"
+    );
+}


### PR DESCRIPTION
Resolves #84.

## What changed

`#[vertex]` and `#[compute]` strip `#[builtin(...)]` attributes from function parameters before emitting Rust output, but `#[fragment]` passed the token stream through unchanged. This caused a hard Rust compile error:

```
error: expected non-macro attribute, found attribute macro `builtin`
```

when using `#[builtin(position)]` directly on a fragment function parameter. The workaround was to use an `#[input]` struct.

### `crates/wgsl-rs-macros/src/lib.rs`

Mirrors the existing stripping logic from `#[vertex]` (lib.rs:1220) and `#[compute]` (lib.rs:1258) into `#[fragment]` (lib.rs:1246): parses the `ItemFn`, retains only non-`builtin` attributes on each `FnArg::Typed`'s `pat_type.attrs`, and re-emits the token stream.

### `crates/wgsl-rs/tests/fragment_builtin.rs` (new)

Integration test exercising the exact pattern from #84 — `#[fragment] pub fn frag_main(#[builtin(position)] frag_coord: Vec4f) -> Vec4f` — asserting it compiles, the WGSL contains `@builtin(position)` and `@fragment`, and no `#[builtin` leaks into the WGSL output. Plus a no-builtin fragment entry point as a regression guard.

## Verification

- `cargo test -p wgsl-rs --test fragment_builtin`: 2/2 pass (including the macro-generated `__validate_wgsl`)
- `cargo xtask ci pr-check`: all green, roundtrip 106/106
- `cargo clippy --all-features --all-targets -- -D warnings`: clean

## AI disclosure

Per `AGENTS.md`, this change was produced in collaboration with an AI agent. Commit author: `Schell Carl Scivally with glm-5.2 <efsubenovex@gmail.com>`.