### PR TITLE
fix: reject mixed default/literal selectors in match or-patterns (#57)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ cargo build                                 # Build all crates
 cargo test                                  # Run all tests
 cargo test -p wgsl-rs-macros                # Test specific crate (wgsl-rs-macros in this case)
 cargo test -- test_name                     # Run a single test by name
-cargo fmt && cargo clippy                   # Format and lint
+cargo fmt && cargo clippy                   # Format and lint (note: use `cargo +nightly fmt` — rustfmt.toml uses unstable features)
 cargo run -p roundtrip-tests                # Run the round-trip tests to ensure the "two worlds" agree
 cargo run -p example                        # Run the example, showing help text about subcommands
 cargo run -p example -- show                # Show the names of available example modules
@@ -42,7 +42,7 @@ cargo expand -p example -- examples::{name} # Expand the example which uses the 
 cargo clippy --all-features                 # Show all clippy lints
 ```
 
-Always remember to run `cargo fmt` after making changes.
+Always remember to run `cargo +nightly fmt` after making changes (the `rustfmt.toml` uses unstable features that require the nightly toolchain; stable `cargo fmt` silently skips them and may leave formatting diffs).
 
 ### xtask - development tools for agents
 

--- a/crates/wgsl-rs-macros/src/parse.rs
+++ b/crates/wgsl-rs-macros/src/parse.rs
@@ -3429,12 +3429,12 @@ fn parse_match_arm_pattern(pat: &syn::Pat) -> Result<(Vec<CaseSelector>, Vec<Spa
                 format!(
                     "WGSL requires 'default' to be its own switch arm — cannot mix '_' with \
                      literal selectors in an or-pattern. Split '{lits_joined} | _' into separate \
-                     arms: '{lits_joined} => ...' and '_ => ...'."
+                     arms: '{lits_joined} => ...' and '_ => ...'"
                 )
             }
             _ => "WGSL requires 'default' to be its own switch arm — cannot mix '_' with other \
-                 selectors in an or-pattern. Split this arm into a literal/expression arm and a \
-                 separate '_' arm."
+                  selectors in an or-pattern. Split this arm into a literal/expression arm and a \
+                  separate '_' arm"
                 .to_string(),
         };
 

--- a/crates/wgsl-rs-macros/src/parse.rs
+++ b/crates/wgsl-rs-macros/src/parse.rs
@@ -3391,6 +3391,56 @@ fn parse_match_arm_pattern(pat: &syn::Pat) -> Result<(Vec<CaseSelector>, Vec<Spa
         &mut has_default,
     )?;
 
+    // WGSL requires `default` to be its own switch arm — it cannot be
+    // combined with literal/expression selectors in a single arm (e.g.
+    // `0 | _` would render as the invalid `case 0, default: ...`). Reject
+    // mixed or-patterns at parse time with a clear error so the user
+    // knows to split the arm. See wgsl-rs#57.
+    let has_non_default = selectors
+        .iter()
+        .any(|s| !matches!(s, CaseSelector::Default(_)));
+    if has_default && has_non_default {
+        let default_span = selectors
+            .iter()
+            .rev()
+            .find_map(|s| match s {
+                CaseSelector::Default(span) => Some(*span),
+                _ => None,
+            })
+            .unwrap_or_else(proc_macro2::Span::call_site);
+
+        // Try to reconstruct the literal selectors for a suggested fix.
+        // Only Int/Float literals are cheap to render (via to_string());
+        // Bool and Expr selectors bail to the generic message to keep this
+        // simple. See wgsl-rs#57.
+        let literal_texts: Option<Vec<String>> = selectors
+            .iter()
+            .filter(|s| !matches!(s, CaseSelector::Default(_)))
+            .map(|s| match s {
+                CaseSelector::Literal(Lit::Int(i)) => Some(i.to_string()),
+                CaseSelector::Literal(Lit::Float(f)) => Some(f.to_string()),
+                _ => None,
+            })
+            .collect();
+
+        let note = match literal_texts {
+            Some(lits) if !lits.is_empty() => {
+                let lits_joined = lits.join(" | ");
+                format!(
+                    "WGSL requires 'default' to be its own switch arm — cannot mix '_' with \
+                     literal selectors in an or-pattern. Split '{lits_joined} | _' into separate \
+                     arms: '{lits_joined} => ...' and '_ => ...'."
+                )
+            }
+            _ => "WGSL requires 'default' to be its own switch arm — cannot mix '_' with other \
+                 selectors in an or-pattern. Split this arm into a literal/expression arm and a \
+                 separate '_' arm."
+                .to_string(),
+        };
+
+        return Err(Error::unsupported(default_span, note));
+    }
+
     Ok((selectors, non_literal_spans, has_default))
 }
 

--- a/crates/wgsl-rs/tests/match_switch.rs
+++ b/crates/wgsl-rs/tests/match_switch.rs
@@ -1,0 +1,64 @@
+//! Regression test for wgsl-rs#57.
+//!
+//! Valid `match` patterns that do NOT mix `default` with literals must still
+//! transpile correctly. This guards against over-rejection from the parse-time
+//! validation added for #57. The macro-generated `__validate_wgsl` test
+//! confirms the rendered WGSL is valid.
+
+#![allow(dead_code)]
+#![allow(clippy::manual_range_patterns)]
+#![allow(unused_assignments)]
+
+use wgsl_rs::wgsl;
+
+#[wgsl]
+mod valid_switches {
+    pub fn or_literals(x: u32) -> u32 {
+        let mut result: u32 = 0u32;
+        match x {
+            0 | 1 | 2 => {
+                result = 1u32;
+            }
+            _ => {
+                result = 0u32;
+            }
+        }
+        result
+    }
+
+    pub fn explicit_default(x: u32) -> u32 {
+        let mut result: u32 = 0u32;
+        match x {
+            0 => {
+                result = 1u32;
+            }
+            1 => {
+                result = 2u32;
+            }
+            _ => {
+                result = 9u32;
+            }
+        }
+        result
+    }
+}
+
+#[test]
+fn or_literals_render_correctly() {
+    let src = valid_switches::WGSL_SOURCE.wgsl_source().unwrap();
+    // The or-pattern `0 | 1 | 2` should render as `case 0, 1, 2:` (not mixed
+    // with default).
+    assert!(
+        src.contains("case 0, 1, 2"),
+        "expected 'case 0, 1, 2' in WGSL, got: {src}"
+    );
+    // `default` must NOT be combined with the case selectors.
+    assert!(
+        !src.contains("case 0, 1, 2, default"),
+        "default should not be mixed with case selectors, got: {src}"
+    );
+    assert!(
+        src.contains("default"),
+        "expected a default arm, got: {src}"
+    );
+}

--- a/crates/wgsl-rs/tests/trybuild.rs
+++ b/crates/wgsl-rs/tests/trybuild.rs
@@ -17,6 +17,12 @@ fn extensions_not_impl_is_rejected() {
 }
 
 #[test]
+fn match_mixed_default_selectors_is_rejected() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/fail/match_mixed_default_selectors.rs");
+}
+
+#[test]
 fn linkage_access_in_const_is_rejected() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/fail/linkage_access_in_const.rs");

--- a/crates/wgsl-rs/tests/ui/fail/match_mixed_default_selectors.rs
+++ b/crates/wgsl-rs/tests/ui/fail/match_mixed_default_selectors.rs
@@ -1,0 +1,12 @@
+use wgsl_rs::wgsl;
+
+#[wgsl]
+mod mixed_default {
+    pub fn f(x: u32) -> u32 {
+        match x {
+            0 | _ => 1u32,
+        }
+    }
+}
+
+fn main() {}

--- a/crates/wgsl-rs/tests/ui/fail/match_mixed_default_selectors.stderr
+++ b/crates/wgsl-rs/tests/ui/fail/match_mixed_default_selectors.stderr
@@ -1,0 +1,6 @@
+error: Parsing error: 'Encountered unsupported Rust syntax:
+       WGSL requires 'default' to be its own switch arm — cannot mix '_' with literal selectors in an or-pattern. Split '0 | _' into separate arms: '0 => ...' and '_ => ...'..'
+ --> tests/ui/fail/match_mixed_default_selectors.rs:7:17
+  |
+7 |             0 | _ => 1u32,
+  |                 ^

--- a/crates/wgsl-rs/tests/ui/fail/match_mixed_default_selectors.stderr
+++ b/crates/wgsl-rs/tests/ui/fail/match_mixed_default_selectors.stderr
@@ -1,5 +1,5 @@
 error: Parsing error: 'Encountered unsupported Rust syntax:
-       WGSL requires 'default' to be its own switch arm — cannot mix '_' with literal selectors in an or-pattern. Split '0 | _' into separate arms: '0 => ...' and '_ => ...'..'
+       WGSL requires 'default' to be its own switch arm — cannot mix '_' with literal selectors in an or-pattern. Split '0 | _' into separate arms: '0 => ...' and '_ => ...'.'
  --> tests/ui/fail/match_mixed_default_selectors.rs:7:17
   |
 7 |             0 | _ => 1u32,


### PR DESCRIPTION
Resolves #57.

## What changed

WGSL requires `default` to be its own switch arm — it cannot be combined with literal/expression selectors in a single arm. A Rust or-pattern like `0 | _` previously parsed successfully and rendered as the invalid WGSL `case 0, default: ...`, which naga rejected with a misleading `expected ;` error pointing at the whole switch block.

### `crates/wgsl-rs-macros/src/parse.rs` (the fix)

`parse_match_arm_pattern` now validates the collected selectors after `parse_pattern_recursive` returns. If an arm contains both a `CaseSelector::Default` (wildcard `_`) and any `Literal`/`Expr` selector, it returns a clear compile error pointing at the wildcard span:

```
error: WGSL requires 'default' to be its own switch arm — cannot mix '_' with
       literal selectors in an or-pattern. Split '0 | _' into separate arms:
       '0 => ...' and '_ => ...'.
```

When all non-Default selectors are `Int`/`Float` literals, the error includes a suggested split (reconstructing the literal text via `to_string()`). For `Bool`/`Expr` selectors, a generic message is used — rendering those cheaply is fiddly and the bail-on-difficulty rule applies.

### Tests

- `crates/wgsl-rs/tests/ui/fail/match_mixed_default_selectors.rs` + `.stderr` — trybuild compile-fail for `0 | _ => ...`
- `crates/wgsl-rs/tests/match_switch.rs` — pass test confirming valid patterns (`0 | 1 | 2 => {...}`, `_ => {...}`, explicit defaults) still transpile correctly. Asserts the rendered WGSL contains `case 0, 1, 2:` and a separate `default:` arm, never `case 0, 1, 2, default`.
- `crates/wgsl-rs/tests/trybuild.rs` — registers the new compile-fail test.

## Verification

- `cargo test -p wgsl-rs --test match_switch`: 2/2 pass (including macro-generated `__validate_wgsl`)
- `cargo test -p wgsl-rs --test trybuild`: 6/6 pass (new compile-fail + existing)
- `cargo xtask ci pr-check`: all green, roundtrip 106/106
- `cargo clippy --all-features --all-targets -- -D warnings`: clean

## AI disclosure

Per `AGENTS.md`, this change was produced in collaboration with an AI agent. Commit author: `Schell Carl Scivally with glm-5.2 <efsubenovex@gmail.com>`.