### PR TITLE
feat: add storage texture support (texture_storage_*)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -580,3 +580,52 @@ when the member name contains underscores, e.g. `SLAB_SIZE` →
 `u32__1SLAB_SIZE`).
 
 
+
+### 2026-08-06: Storage texture support (texture_storage_*)
+
+**Problem:** A user asked if storage textures (`texture_storage_*`) were
+supported — they were not. wgsl-rs covered sampled, multisampled, and depth
+textures, but the four WGSL storage texture types (`texture_storage_1d`,
+`texture_storage_2d`, `texture_storage_2d_array`, `texture_storage_3d`) were
+missing from the IR, the macro parser, the runtime std types, and the wgpu
+linkage. The `TextureStore`/`TextureStoreArray` traits and
+`texture_store`/`texture_store_array` builtins existed but had no legal
+receiver type.
+
+**Decision:** Add storage textures as a new `Type::TextureStorage` IR variant
+(rather than extending the existing `Type::Texture`), mirroring the
+`Type::TextureDepth` precedent. Storage textures are parameterized by three
+things: a dimensionality kind (`TextureStorageKind`), a texel format
+(`TexelFormat` — all ~30 formats from WGSL §6.6.1), and an access mode
+(`StorageTextureAccess` — `Read`/`Write`/`ReadWrite`).
+
+A new `StorageTextureAccess` enum was added rather than extending the existing
+`StorageAccess` (used for storage buffers, which only allow `Read`/
+`ReadWrite`). This keeps the storage-buffer invariant intact — the type system
+prevents invalid write-only storage buffers at IR construction rather than
+deferring to render-time validation.
+
+On the Rust side, the API uses unit-struct format markers (e.g. `Rgba8unorm`,
+`R32float`) and access mode markers (`Read`, `Write`, `ReadWrite` — shared
+with storage buffer access modes in `std.rs`) as type parameters:
+`TextureStorage2D<Rgba8unorm, Write>`. This mirrors the existing
+sampled-texture convention where the Rust generic IS the WGSL parameter
+(`Texture2D<f32>` ↔ `texture_2d<f32>`), just with marker types standing in for
+WGSL enumerants instead of Rust scalars. The `WgslTexelFormat` trait carries
+an associated `Value` type (`Vec4f`/`Vec4u`/`Vec4i`) and `Scalar` type
+(`f32`/`u32`/`i32`) so the shader-side value type and CPU-side storage type are
+compile-time known from the format.
+
+The `enable texture_formats_tier1;` directive is hoisted to the very start of
+the final assembled WGSL translation unit in `Source::wgsl_source()`, rather
+than being emitted per-chunk inside `render_module`/`render_items`. A
+`needs_tier1` flag is threaded through `collect` and
+`instantiate_template_into`, ensuring valid placement regardless of
+import/instantiation order.
+
+Access mode gating uses `ReadableStorageAccess` and `WritableStorageAccess`
+marker traits to constrain `TextureLoadStorage` impls to `Read`/`ReadWrite`
+and `TextureStore` impls to `Write`/`ReadWrite` at compile time. A separate
+`texture_load_storage` builtin function (mapping to `textureLoad` in WGSL)
+is used for storage texture loads because the WGSL storage overload takes no
+`level` parameter, unlike the sampled texture `textureLoad` overload.

--- a/crates/roundtrip-tests/src/shaders/mod.rs
+++ b/crates/roundtrip-tests/src/shaders/mod.rs
@@ -49,6 +49,8 @@
 //!   `texture_sample` on 2D sampled textures
 //! - [`advanced_texture_operations`] — Advanced texture builtins:
 //!   `texture_sample_grad/level/bias`, offsets, gather, and 2D-array variants
+//! - [`storage_texture_operations`] — Storage texture builtins:
+//!   `texture_store`, `texture_load_storage` on `texture_storage_2d`
 //!
 //! ## Planned coverage
 //!
@@ -73,6 +75,7 @@ pub mod modf_frexp_ldexp;
 pub mod packing;
 pub mod rounding;
 pub mod select_operations;
+pub mod storage_texture_operations;
 pub mod synchronization;
 pub mod texture_operations;
 pub mod trig;
@@ -104,5 +107,6 @@ pub fn all_tests() -> Vec<Box<dyn RoundtripTest>> {
         Box::new(derivative_operations::DerivativeOperationsTest),
         Box::new(texture_operations::TextureOperationsTest),
         Box::new(advanced_texture_operations::AdvancedTextureOperationsTest),
+        Box::new(storage_texture_operations::StorageTextureOperationsTest),
     ]
 }

--- a/crates/roundtrip-tests/src/shaders/storage_texture_operations.rs
+++ b/crates/roundtrip-tests/src/shaders/storage_texture_operations.rs
@@ -1,0 +1,357 @@
+//! Roundtrip tests for storage texture load/store operations.
+//!
+//! Tests: `texture_store`, `texture_load_storage` on
+//! `TextureStorage2D<Rgba8unorm, Write>` and
+//! `TextureStorage2D<Rgba8unorm, Read>`.
+//!
+//! The compute shader reads from a read-only storage texture (INPUT),
+//! doubles each channel, and writes to a write-only storage texture
+//! (OUTPUT). Both CPU and GPU should produce the same result.
+
+#![allow(dead_code)]
+
+use wgsl_rs::wgsl;
+
+use crate::harness::{self, ComparisonResult, RoundtripTest};
+
+const WIDTH: u32 = 8;
+const HEIGHT: u32 = 8;
+
+#[wgsl]
+pub mod storage_texture_compute {
+    use wgsl_rs::std::*;
+
+    texture!(group(0), binding(0), INPUT: TextureStorage2D<Rgba8unorm, Read>);
+    texture!(group(0), binding(1), OUTPUT: TextureStorage2D<Rgba8unorm, Write>);
+
+    #[compute]
+    #[workgroup_size(1)]
+    pub fn compute_main(#[builtin(global_invocation_id)] gid: Vec3u) {
+        let dims = texture_dimensions(OUTPUT);
+        if gid.x() >= dims.x() || gid.y() >= dims.y() {
+            return;
+        }
+        let value = texture_load_storage(INPUT, vec2u(gid.x(), gid.y()));
+        let halved = value * 0.5;
+        texture_store(OUTPUT, vec2u(gid.x(), gid.y()), halved);
+    }
+}
+
+/// Builds deterministic RGBA8 test pixels (as normalized f32 values).
+fn build_test_pixels() -> Vec<[f32; 4]> {
+    let mut pixels = vec![[0.0f32; 4]; (WIDTH * HEIGHT) as usize];
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            let idx = (y * WIDTH + x) as usize;
+            pixels[idx] = [
+                ((x * 19 + y * 7) % 256) as f32 / 255.0,
+                ((x * 11 + y * 23) % 256) as f32 / 255.0,
+                ((x * 5 + y * 13) % 256) as f32 / 255.0,
+                1.0,
+            ];
+        }
+    }
+    pixels
+}
+
+/// Converts f32 pixels to RGBA8 bytes for GPU upload.
+fn f32_pixels_to_rgba8(pixels: &[[f32; 4]]) -> Vec<[u8; 4]> {
+    pixels
+        .iter()
+        .map(|p| {
+            [
+                (p[0] * 255.0).round().clamp(0.0, 255.0) as u8,
+                (p[1] * 255.0).round().clamp(0.0, 255.0) as u8,
+                (p[2] * 255.0).round().clamp(0.0, 255.0) as u8,
+                (p[3] * 255.0).round().clamp(0.0, 255.0) as u8,
+            ]
+        })
+        .collect()
+}
+
+/// Converts RGBA8 bytes back to f32 pixels for comparison.
+fn rgba8_to_f32_pixels(pixels: &[[u8; 4]]) -> Vec<[f32; 4]> {
+    pixels
+        .iter()
+        .map(|p| {
+            [
+                p[0] as f32 / 255.0,
+                p[1] as f32 / 255.0,
+                p[2] as f32 / 255.0,
+                p[3] as f32 / 255.0,
+            ]
+        })
+        .collect()
+}
+
+/// Runs the compute shader on the GPU and reads back the output texture.
+fn run_gpu_compute(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    input_pixels: &[[u8; 4]],
+) -> Vec<[f32; 4]> {
+    let input_texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("storage_input"),
+        size: wgpu::Extent3d {
+            width: WIDTH,
+            height: HEIGHT,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+    let input_view = input_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let output_texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("storage_output"),
+        size: wgpu::Extent3d {
+            width: WIDTH,
+            height: HEIGHT,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let output_view = output_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+    // Upload input pixels.
+    queue.write_texture(
+        wgpu::TexelCopyTextureInfo {
+            texture: &input_texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        bytemuck::cast_slice(input_pixels),
+        wgpu::TexelCopyBufferLayout {
+            offset: 0,
+            bytes_per_row: Some(WIDTH * 4),
+            rows_per_image: Some(HEIGHT),
+        },
+        wgpu::Extent3d {
+            width: WIDTH,
+            height: HEIGHT,
+            depth_or_array_layers: 1,
+        },
+    );
+
+    let module = &storage_texture_compute::WGSL_SOURCE;
+    let mut linkage = wgsl_rs::linkage::wgpu::analyze_wgsl_module(module).unwrap();
+    let shader_module = linkage.shader_module(device);
+    let pipeline_layout = linkage.pipeline_layout(device, Some("storage_texture_pipeline_layout"));
+
+    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("storage_texture_compute_pipeline"),
+        layout: Some(&pipeline_layout),
+        module: &shader_module,
+        entry_point: Some("compute_main"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+
+    let bind_group = linkage
+        .create_bind_group_named(
+            0,
+            device,
+            &[
+                ("INPUT", wgpu::BindingResource::TextureView(&input_view)),
+                ("OUTPUT", wgpu::BindingResource::TextureView(&output_view)),
+            ],
+        )
+        .expect("storage texture bind group");
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("storage_texture_compute"),
+    });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("storage_texture_compute_pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups(WIDTH, HEIGHT, 1);
+    }
+
+    // Copy output texture to a buffer for readback.
+    // wgpu requires bytes_per_row to be aligned to COPY_BYTES_PER_ROW_ALIGNMENT
+    // (256).
+    const ALIGNMENT: u32 = 256;
+    let bytes_per_pixel = 4u32;
+    let unaligned_bpr = WIDTH * bytes_per_pixel;
+    let aligned_bpr = unaligned_bpr.div_ceil(ALIGNMENT) * ALIGNMENT;
+    let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("storage_texture_output"),
+        size: (aligned_bpr as u64) * (HEIGHT as u64),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &output_texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &output_buffer,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(aligned_bpr),
+                rows_per_image: Some(HEIGHT),
+            },
+        },
+        wgpu::Extent3d {
+            width: WIDTH,
+            height: HEIGHT,
+            depth_or_array_layers: 1,
+        },
+    );
+
+    queue.submit(Some(encoder.finish()));
+
+    // Read back the output buffer.
+    let (sender, receiver) = std::sync::mpsc::channel();
+    output_buffer
+        .slice(..)
+        .map_async(wgpu::MapMode::Read, move |result| {
+            sender.send(result).expect("channel send failed");
+        });
+    device
+        .poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        })
+        .expect("wgpu poll failed");
+    receiver
+        .recv()
+        .expect("channel recv failed")
+        .expect("buffer mapping failed");
+
+    let data = output_buffer.slice(..).get_mapped_range();
+    let mut rgba8: Vec<[u8; 4]> = Vec::with_capacity((WIDTH * HEIGHT) as usize);
+    for y in 0..HEIGHT {
+        let row_offset = (y * aligned_bpr) as usize;
+        for x in 0..WIDTH {
+            let offset = row_offset + (x * bytes_per_pixel) as usize;
+            rgba8.push([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ]);
+        }
+    }
+    drop(data);
+    output_buffer.unmap();
+    rgba8_to_f32_pixels(&rgba8)
+}
+
+/// Runs the compute shader on the CPU and returns the output pixels.
+fn run_cpu_compute(input_pixels: &[[f32; 4]]) -> Vec<[f32; 4]> {
+    use wgsl_rs::std::*;
+
+    // Initialize input texture.
+    storage_texture_compute::INPUT.init(WIDTH, HEIGHT);
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            let idx = (y * WIDTH + x) as usize;
+            storage_texture_compute::INPUT.set_pixel(
+                x,
+                y,
+                vec4f(
+                    input_pixels[idx][0],
+                    input_pixels[idx][1],
+                    input_pixels[idx][2],
+                    input_pixels[idx][3],
+                ),
+            );
+        }
+    }
+
+    // Initialize output texture.
+    storage_texture_compute::OUTPUT.init(WIDTH, HEIGHT);
+
+    // Run the compute shader.
+    dispatch_workgroups((WIDTH, HEIGHT, 1), (1, 1, 1), |builtins| {
+        storage_texture_compute::compute_main(builtins.global_invocation_id);
+    });
+
+    // Read back output directly from CPU-side data (OUTPUT is write-only,
+    // so we can't use texture_load_storage — read the ModuleVar directly).
+    let data = storage_texture_compute::OUTPUT.get();
+    let mut output = vec![[0.0f32; 4]; (WIDTH * HEIGHT) as usize];
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            let pixel = data.get_pixel(x, y, 0);
+            let idx = (y * WIDTH + x) as usize;
+            if let Some(p) = pixel {
+                output[idx] = [p[0], p[1], p[2], p[3]];
+            }
+        }
+    }
+    output
+}
+
+fn build_labels(name: &str) -> Vec<String> {
+    let mut labels = Vec::with_capacity((WIDTH * HEIGHT * 4) as usize);
+    let channels = ["r", "g", "b", "a"];
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            for ch in channels {
+                labels.push(format!("{name}[{x},{y}].{ch}"));
+            }
+        }
+    }
+    labels
+}
+
+pub struct StorageTextureOperationsTest;
+
+impl RoundtripTest for StorageTextureOperationsTest {
+    fn name(&self) -> &str {
+        "storage_texture_operations"
+    }
+
+    fn description(&self) -> &str {
+        "texture_store and texture_load_storage on texture_storage_2d<rgba8unorm, _>"
+    }
+
+    fn run(&self, device: &wgpu::Device, queue: &wgpu::Queue) -> Vec<ComparisonResult> {
+        let epsilon = 1e-2; // Rgba8Unorm quantizes to 1/255, so allow ~0.004 slack
+
+        let input_f32 = build_test_pixels();
+        let input_rgba8 = f32_pixels_to_rgba8(&input_f32);
+
+        let gpu_output = run_gpu_compute(device, queue, &input_rgba8);
+        let cpu_output = run_cpu_compute(&input_f32);
+
+        let mut gpu_flat = Vec::with_capacity(gpu_output.len() * 4);
+        for px in &gpu_output {
+            gpu_flat.extend_from_slice(px);
+        }
+        let mut cpu_flat = Vec::with_capacity(cpu_output.len() * 4);
+        for px in &cpu_output {
+            cpu_flat.extend_from_slice(px);
+        }
+        let labels = build_labels("storage_texture");
+        let label_refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+
+        vec![harness::compare_f32_results(
+            "storage_texture_store_load",
+            &gpu_flat,
+            &cpu_flat,
+            &label_refs,
+            epsilon,
+        )]
+    }
+}

--- a/crates/wgsl-rs-ir/src/lib.rs
+++ b/crates/wgsl-rs-ir/src/lib.rs
@@ -29,7 +29,8 @@ mod types;
 
 pub use mangle::{mangle, unmangle};
 pub use render::{
-    render_block, render_expr, render_item, render_items, render_module, render_stmt, render_type,
+    items_need_tier1_extension, render_block, render_expr, render_item, render_items,
+    render_module, render_stmt, render_type,
 };
 pub use substitute::{
     rename_items, substitute_consts, substitute_consts_in_items, substitute_items,

--- a/crates/wgsl-rs-ir/src/render.rs
+++ b/crates/wgsl-rs-ir/src/render.rs
@@ -24,11 +24,35 @@ pub mod builtin_lookup;
 
 /// Render a [`Module`] to a complete WGSL source string.
 pub fn render_module(module: &Module) -> String {
-    let mut w = Writer::new();
-    for item in &module.items {
-        write_item(&mut w, item);
+    render_items(&module.items)
+}
+
+/// Whether any storage texture in the given items uses a tier-1 texel
+/// format (WGSL §6.6.1), requiring the `texture_formats_tier1` language
+/// extension to be enabled. Callers that assemble WGSL from multiple
+/// rendered chunks should check this and prepend `enable
+/// texture_formats_tier1;` once at the very start of the final source.
+pub fn items_need_tier1_extension(items: &[Item]) -> bool {
+    fn type_uses_tier1(ty: &Type) -> bool {
+        match ty {
+            Type::TextureStorage { format, .. } => format.requires_tier1(),
+            Type::Array { elem, .. }
+            | Type::RuntimeArray { elem }
+            | Type::Atomic { elem }
+            | Type::Ptr { elem, .. } => type_uses_tier1(elem),
+            Type::Struct { type_args, .. } => type_args.iter().any(type_uses_tier1),
+            _ => false,
+        }
     }
-    w.finish()
+    items.iter().any(|item| match item {
+        Item::Texture(t) => type_uses_tier1(&t.ty),
+        Item::Fn(f) => {
+            f.inputs.iter().any(|p| type_uses_tier1(&p.ty))
+                || matches!(&f.return_type, ReturnType::Type { ty, .. } if type_uses_tier1(ty))
+        }
+        Item::Struct(s) => s.fields.iter().any(|f| type_uses_tier1(&f.ty)),
+        _ => false,
+    })
 }
 
 /// Render a slice of [`Item`]s (e.g. an instantiated generic template) to
@@ -592,6 +616,18 @@ fn write_type(w: &mut Writer, ty: &Type) {
         }
         Type::TextureDepth { kind } => {
             w.write(texture_depth_kind_name(*kind));
+        }
+        Type::TextureStorage {
+            kind,
+            format,
+            access,
+        } => {
+            w.write(kind.wgsl_name());
+            w.write("<");
+            w.write(format.wgsl_name());
+            w.write(", ");
+            w.write(access.wgsl_name());
+            w.write(">");
         }
         Type::TypeParam { name } => {
             // Templates leave TypeParam unresolved; we render a unique
@@ -1157,5 +1193,90 @@ mod tests {
             scalar_ty: None,
         };
         assert_eq!(render_type(&m_short), "mat4x2f");
+    }
+
+    /// Storage texture types render as `texture_storage_Nd<format, access>`.
+    #[test]
+    fn renders_storage_texture_2d_write() {
+        let ty = Type::TextureStorage {
+            kind: crate::types::TextureStorageKind::Storage2D,
+            format: crate::types::TexelFormat::Rgba8unorm,
+            access: crate::types::StorageTextureAccess::Write,
+        };
+        assert_eq!(render_type(&ty), "texture_storage_2d<rgba8unorm, write>");
+    }
+
+    #[test]
+    fn renders_storage_texture_1d_read() {
+        let ty = Type::TextureStorage {
+            kind: crate::types::TextureStorageKind::Storage1D,
+            format: crate::types::TexelFormat::Rgba8uint,
+            access: crate::types::StorageTextureAccess::Read,
+        };
+        assert_eq!(render_type(&ty), "texture_storage_1d<rgba8uint, read>");
+    }
+
+    #[test]
+    fn renders_storage_texture_3d_read_write() {
+        let ty = Type::TextureStorage {
+            kind: crate::types::TextureStorageKind::Storage3D,
+            format: crate::types::TexelFormat::R32float,
+            access: crate::types::StorageTextureAccess::ReadWrite,
+        };
+        assert_eq!(render_type(&ty), "texture_storage_3d<r32float, read_write>");
+    }
+
+    /// A module with a tier-1 storage texture format is detected by
+    /// `items_need_tier1_extension`.
+    #[test]
+    fn module_emits_tier1_directive() {
+        use crate::types::{ItemTexture, TextureStorageKind};
+
+        let module = Module {
+            name: "test",
+            items: vec![Item::Texture(ItemTexture {
+                group: 0,
+                binding: 0,
+                name: "TEX".to_string(),
+                ty: Type::TextureStorage {
+                    kind: TextureStorageKind::Storage2D,
+                    format: crate::types::TexelFormat::R16float,
+                    access: crate::types::StorageTextureAccess::Write,
+                },
+                attrs: vec![],
+            })],
+            attrs: vec![],
+        };
+        assert!(
+            items_need_tier1_extension(&module.items),
+            "Expected tier-1 detection for R16float format"
+        );
+    }
+
+    /// A module with only core (non-tier-1) storage textures is NOT
+    /// flagged by `items_need_tier1_extension`.
+    #[test]
+    fn module_no_tier1_directive_for_core_format() {
+        use crate::types::{ItemTexture, TextureStorageKind};
+
+        let module = Module {
+            name: "test",
+            items: vec![Item::Texture(ItemTexture {
+                group: 0,
+                binding: 0,
+                name: "TEX".to_string(),
+                ty: Type::TextureStorage {
+                    kind: TextureStorageKind::Storage2D,
+                    format: crate::types::TexelFormat::Rgba8unorm,
+                    access: crate::types::StorageTextureAccess::Write,
+                },
+                attrs: vec![],
+            })],
+            attrs: vec![],
+        };
+        assert!(
+            !items_need_tier1_extension(&module.items),
+            "Did not expect tier-1 detection for Rgba8unorm (core format)"
+        );
     }
 }

--- a/crates/wgsl-rs-ir/src/render.rs
+++ b/crates/wgsl-rs-ir/src/render.rs
@@ -44,13 +44,19 @@ pub fn items_need_tier1_extension(items: &[Item]) -> bool {
             _ => false,
         }
     }
+    fn fn_uses_tier1(f: &ItemFn) -> bool {
+        f.inputs.iter().any(|p| type_uses_tier1(&p.ty))
+            || matches!(&f.return_type, ReturnType::Type { ty, .. } if type_uses_tier1(ty))
+    }
     items.iter().any(|item| match item {
         Item::Texture(t) => type_uses_tier1(&t.ty),
-        Item::Fn(f) => {
-            f.inputs.iter().any(|p| type_uses_tier1(&p.ty))
-                || matches!(&f.return_type, ReturnType::Type { ty, .. } if type_uses_tier1(ty))
-        }
+        Item::Fn(f) => fn_uses_tier1(f),
         Item::Struct(s) => s.fields.iter().any(|f| type_uses_tier1(&f.ty)),
+        Item::Const(c) => type_uses_tier1(&c.ty),
+        Item::Impl(i) => i.items.iter().any(|impl_item| match impl_item {
+            ImplItem::Fn(f) => fn_uses_tier1(f),
+            ImplItem::Const(c) => type_uses_tier1(&c.ty),
+        }),
         _ => false,
     })
 }
@@ -1277,6 +1283,47 @@ mod tests {
         assert!(
             !items_need_tier1_extension(&module.items),
             "Did not expect tier-1 detection for Rgba8unorm (core format)"
+        );
+    }
+
+    /// A tier-1 storage texture format used only inside an impl method
+    /// signature is detected by `items_need_tier1_extension`.
+    #[test]
+    fn tier1_detected_in_impl_method() {
+        use crate::types::{ImplItem, ItemFn, ItemImpl, TextureStorageKind};
+
+        let module = Module {
+            name: "test",
+            items: vec![Item::Impl(ItemImpl {
+                type_params: vec![],
+                const_params: vec![],
+                self_ty: "MyStruct".to_string(),
+                items: vec![ImplItem::Fn(ItemFn {
+                    type_params: vec![],
+                    const_params: vec![],
+                    fn_attrs: crate::types::FnAttrs::None,
+                    name: "method".into(),
+                    inputs: vec![crate::types::FnArg {
+                        inter_stage_io: vec![],
+                        name: "tex".to_string(),
+                        ty: Type::TextureStorage {
+                            kind: TextureStorageKind::Storage2D,
+                            format: crate::types::TexelFormat::R16float,
+                            access: crate::types::StorageTextureAccess::Write,
+                        },
+                        attrs: vec![],
+                    }],
+                    return_type: crate::types::ReturnType::Default,
+                    block: crate::types::Block { stmts: vec![] },
+                    attrs: vec![],
+                })],
+                attrs: vec![],
+            })],
+            attrs: vec![],
+        };
+        assert!(
+            items_need_tier1_extension(&module.items),
+            "Expected tier-1 detection for R16float format in impl method param"
         );
     }
 }

--- a/crates/wgsl-rs-ir/src/render/builtin_lookup.rs
+++ b/crates/wgsl-rs-ir/src/render/builtin_lookup.rs
@@ -104,6 +104,8 @@ const TABLE: &[(&str, &str)] = &[
     ("texture_load", "textureLoad"),
     ("texture_load_array", "textureLoad"),
     ("texture_load_multisampled", "textureLoad"),
+    ("texture_load_storage", "textureLoad"),
+    ("texture_load_storage_array", "textureLoad"),
     // Query functions
     ("texture_num_layers", "textureNumLayers"),
     ("texture_num_levels", "textureNumLevels"),

--- a/crates/wgsl-rs-ir/src/substitute.rs
+++ b/crates/wgsl-rs-ir/src/substitute.rs
@@ -391,6 +391,7 @@ fn sub_type(ty: &mut Type, s: &HashMap<String, Type>) {
         | Type::SamplerComparison
         | Type::Texture { .. }
         | Type::TextureDepth { .. }
+        | Type::TextureStorage { .. }
         | Type::Vector { .. }
         | Type::Matrix { .. } => {}
         Type::Array { elem, len } => {
@@ -525,6 +526,7 @@ pub fn type_to_ident(t: &Type) -> String {
         Type::SamplerComparison => "sampler_comparison".to_string(),
         Type::Texture { .. } => "texture".to_string(),
         Type::TextureDepth { .. } => "texture_depth".to_string(),
+        Type::TextureStorage { format, .. } => format!("texture_storage_{}", format.wgsl_name()),
         Type::TypeParam { name } => name.clone(),
         Type::Phantom { elem } => format!("phantom_{}", type_to_ident(elem)),
     }
@@ -694,6 +696,7 @@ fn sub_type_const(ty: &mut Type, consts: &HashMap<String, u32>) {
         | Type::SamplerComparison
         | Type::Texture { .. }
         | Type::TextureDepth { .. }
+        | Type::TextureStorage { .. }
         | Type::Vector { .. }
         | Type::Matrix { .. }
         | Type::TypeParam { .. } => {}

--- a/crates/wgsl-rs-ir/src/types.rs
+++ b/crates/wgsl-rs-ir/src/types.rs
@@ -86,6 +86,287 @@ pub enum TextureDepthKind {
     DepthMultisampled2D,
 }
 
+/// Storage texture kinds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TextureStorageKind {
+    Storage1D,
+    Storage2D,
+    Storage2DArray,
+    Storage3D,
+}
+
+/// Storage texture access modes. WGSL §14.2.
+///
+/// Unlike [`StorageAccess`] (used for storage buffers, which only allow
+/// `read` and `read_write`), storage textures also support `write`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum StorageTextureAccess {
+    Read,
+    Write,
+    ReadWrite,
+}
+
+/// Texel formats for storage textures. WGSL §6.6.1.
+///
+/// Each variant maps 1:1 to a `wgpu::TextureFormat` of the same name. The
+/// `requires_tier1` method reports whether the `texture_formats_tier1`
+/// language extension must be enabled to use the format.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TexelFormat {
+    // ===== Core formats (no extension required) =====
+    Rgba8unorm,
+    Rgba8snorm,
+    Rgba8uint,
+    Rgba8sint,
+    Rgba16uint,
+    Rgba16sint,
+    Rgba16float,
+    R32uint,
+    R32sint,
+    R32float,
+    Rg32uint,
+    Rg32sint,
+    Rg32float,
+    Rgba32uint,
+    Rgba32sint,
+    Rgba32float,
+    Bgra8unorm,
+    // ===== Tier-1 extension formats =====
+    Rgba16unorm,
+    Rgba16snorm,
+    Rg8unorm,
+    Rg8snorm,
+    Rg8uint,
+    Rg8sint,
+    Rg16unorm,
+    Rg16snorm,
+    Rg16uint,
+    Rg16sint,
+    Rg16float,
+    R8unorm,
+    R8snorm,
+    R8uint,
+    R8sint,
+    R16unorm,
+    R16snorm,
+    R16uint,
+    R16sint,
+    R16float,
+    Rgb10a2unorm,
+    Rgb10a2uint,
+    Rg11b10ufloat,
+}
+
+impl TexelFormat {
+    /// Whether this format requires the `texture_formats_tier1` language
+    /// extension (WGSL §6.6.1, last column of the storage texel formats
+    /// table).
+    pub fn requires_tier1(&self) -> bool {
+        matches!(
+            self,
+            TexelFormat::Rgba16unorm
+                | TexelFormat::Rgba16snorm
+                | TexelFormat::Rg8unorm
+                | TexelFormat::Rg8snorm
+                | TexelFormat::Rg8uint
+                | TexelFormat::Rg8sint
+                | TexelFormat::Rg16unorm
+                | TexelFormat::Rg16snorm
+                | TexelFormat::Rg16uint
+                | TexelFormat::Rg16sint
+                | TexelFormat::Rg16float
+                | TexelFormat::R8unorm
+                | TexelFormat::R8snorm
+                | TexelFormat::R8uint
+                | TexelFormat::R8sint
+                | TexelFormat::R16unorm
+                | TexelFormat::R16snorm
+                | TexelFormat::R16uint
+                | TexelFormat::R16sint
+                | TexelFormat::R16float
+                | TexelFormat::Rgb10a2unorm
+                | TexelFormat::Rgb10a2uint
+                | TexelFormat::Rg11b10ufloat
+        )
+    }
+
+    /// The shader-side scalar type (`f32`, `u32`, or `i32`) that
+    /// `textureLoad` returns / `textureStore` accepts for this format.
+    /// Derived from the channel format table in WGSL §6.6.1.
+    pub fn shader_scalar(&self) -> ScalarType {
+        match self {
+            TexelFormat::Rgba8unorm
+            | TexelFormat::Rgba8snorm
+            | TexelFormat::Rgba16float
+            | TexelFormat::Rgba16unorm
+            | TexelFormat::Rgba16snorm
+            | TexelFormat::R32float
+            | TexelFormat::Rg32float
+            | TexelFormat::Rgba32float
+            | TexelFormat::Bgra8unorm
+            | TexelFormat::Rg8unorm
+            | TexelFormat::Rg8snorm
+            | TexelFormat::Rg16unorm
+            | TexelFormat::Rg16snorm
+            | TexelFormat::Rg16float
+            | TexelFormat::R8unorm
+            | TexelFormat::R8snorm
+            | TexelFormat::R16unorm
+            | TexelFormat::R16snorm
+            | TexelFormat::R16float
+            | TexelFormat::Rgb10a2unorm
+            | TexelFormat::Rg11b10ufloat => ScalarType::F32,
+            TexelFormat::Rgba8uint
+            | TexelFormat::Rgba16uint
+            | TexelFormat::R32uint
+            | TexelFormat::Rg32uint
+            | TexelFormat::Rgba32uint
+            | TexelFormat::Rg8uint
+            | TexelFormat::Rg16uint
+            | TexelFormat::R8uint
+            | TexelFormat::R16uint
+            | TexelFormat::Rgb10a2uint => ScalarType::U32,
+            TexelFormat::Rgba8sint
+            | TexelFormat::Rgba16sint
+            | TexelFormat::R32sint
+            | TexelFormat::Rg32sint
+            | TexelFormat::Rgba32sint
+            | TexelFormat::Rg8sint
+            | TexelFormat::Rg16sint
+            | TexelFormat::R8sint
+            | TexelFormat::R16sint => ScalarType::I32,
+        }
+    }
+
+    /// The WGSL enumerant name (lowercase, as written in WGSL source).
+    pub fn wgsl_name(&self) -> &'static str {
+        match self {
+            TexelFormat::Rgba8unorm => "rgba8unorm",
+            TexelFormat::Rgba8snorm => "rgba8snorm",
+            TexelFormat::Rgba8uint => "rgba8uint",
+            TexelFormat::Rgba8sint => "rgba8sint",
+            TexelFormat::Rgba16uint => "rgba16uint",
+            TexelFormat::Rgba16sint => "rgba16sint",
+            TexelFormat::Rgba16float => "rgba16float",
+            TexelFormat::R32uint => "r32uint",
+            TexelFormat::R32sint => "r32sint",
+            TexelFormat::R32float => "r32float",
+            TexelFormat::Rg32uint => "rg32uint",
+            TexelFormat::Rg32sint => "rg32sint",
+            TexelFormat::Rg32float => "rg32float",
+            TexelFormat::Rgba32uint => "rgba32uint",
+            TexelFormat::Rgba32sint => "rgba32sint",
+            TexelFormat::Rgba32float => "rgba32float",
+            TexelFormat::Bgra8unorm => "bgra8unorm",
+            TexelFormat::Rgba16unorm => "rgba16unorm",
+            TexelFormat::Rgba16snorm => "rgba16snorm",
+            TexelFormat::Rg8unorm => "rg8unorm",
+            TexelFormat::Rg8snorm => "rg8snorm",
+            TexelFormat::Rg8uint => "rg8uint",
+            TexelFormat::Rg8sint => "rg8sint",
+            TexelFormat::Rg16unorm => "rg16unorm",
+            TexelFormat::Rg16snorm => "rg16snorm",
+            TexelFormat::Rg16uint => "rg16uint",
+            TexelFormat::Rg16sint => "rg16sint",
+            TexelFormat::Rg16float => "rg16float",
+            TexelFormat::R8unorm => "r8unorm",
+            TexelFormat::R8snorm => "r8snorm",
+            TexelFormat::R8uint => "r8uint",
+            TexelFormat::R8sint => "r8sint",
+            TexelFormat::R16unorm => "r16unorm",
+            TexelFormat::R16snorm => "r16snorm",
+            TexelFormat::R16uint => "r16uint",
+            TexelFormat::R16sint => "r16sint",
+            TexelFormat::R16float => "r16float",
+            TexelFormat::Rgb10a2unorm => "rgb10a2unorm",
+            TexelFormat::Rgb10a2uint => "rgb10a2uint",
+            TexelFormat::Rg11b10ufloat => "rg11b10ufloat",
+        }
+    }
+
+    /// Parse a WGSL texel format name (lowercase) into a `TexelFormat`.
+    /// Returns `None` if the name is not a recognized storage texel format.
+    pub fn from_wgsl_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "rgba8unorm" => TexelFormat::Rgba8unorm,
+            "rgba8snorm" => TexelFormat::Rgba8snorm,
+            "rgba8uint" => TexelFormat::Rgba8uint,
+            "rgba8sint" => TexelFormat::Rgba8sint,
+            "rgba16uint" => TexelFormat::Rgba16uint,
+            "rgba16sint" => TexelFormat::Rgba16sint,
+            "rgba16float" => TexelFormat::Rgba16float,
+            "r32uint" => TexelFormat::R32uint,
+            "r32sint" => TexelFormat::R32sint,
+            "r32float" => TexelFormat::R32float,
+            "rg32uint" => TexelFormat::Rg32uint,
+            "rg32sint" => TexelFormat::Rg32sint,
+            "rg32float" => TexelFormat::Rg32float,
+            "rgba32uint" => TexelFormat::Rgba32uint,
+            "rgba32sint" => TexelFormat::Rgba32sint,
+            "rgba32float" => TexelFormat::Rgba32float,
+            "bgra8unorm" => TexelFormat::Bgra8unorm,
+            "rgba16unorm" => TexelFormat::Rgba16unorm,
+            "rgba16snorm" => TexelFormat::Rgba16snorm,
+            "rg8unorm" => TexelFormat::Rg8unorm,
+            "rg8snorm" => TexelFormat::Rg8snorm,
+            "rg8uint" => TexelFormat::Rg8uint,
+            "rg8sint" => TexelFormat::Rg8sint,
+            "rg16unorm" => TexelFormat::Rg16unorm,
+            "rg16snorm" => TexelFormat::Rg16snorm,
+            "rg16uint" => TexelFormat::Rg16uint,
+            "rg16sint" => TexelFormat::Rg16sint,
+            "rg16float" => TexelFormat::Rg16float,
+            "r8unorm" => TexelFormat::R8unorm,
+            "r8snorm" => TexelFormat::R8snorm,
+            "r8uint" => TexelFormat::R8uint,
+            "r8sint" => TexelFormat::R8sint,
+            "r16unorm" => TexelFormat::R16unorm,
+            "r16snorm" => TexelFormat::R16snorm,
+            "r16uint" => TexelFormat::R16uint,
+            "r16sint" => TexelFormat::R16sint,
+            "r16float" => TexelFormat::R16float,
+            "rgb10a2unorm" => TexelFormat::Rgb10a2unorm,
+            "rgb10a2uint" => TexelFormat::Rgb10a2uint,
+            "rg11b10ufloat" => TexelFormat::Rg11b10ufloat,
+            _ => return None,
+        })
+    }
+}
+
+impl StorageTextureAccess {
+    /// The WGSL enumerant name (lowercase).
+    pub fn wgsl_name(&self) -> &'static str {
+        match self {
+            StorageTextureAccess::Read => "read",
+            StorageTextureAccess::Write => "write",
+            StorageTextureAccess::ReadWrite => "read_write",
+        }
+    }
+
+    /// Parse a WGSL access mode name (lowercase) into a
+    /// `StorageTextureAccess`. Returns `None` if unrecognized.
+    pub fn from_wgsl_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "read" => StorageTextureAccess::Read,
+            "write" => StorageTextureAccess::Write,
+            "read_write" => StorageTextureAccess::ReadWrite,
+            _ => return None,
+        })
+    }
+}
+
+impl TextureStorageKind {
+    /// The WGSL type name (e.g. `texture_storage_2d`).
+    pub fn wgsl_name(&self) -> &'static str {
+        match self {
+            TextureStorageKind::Storage1D => "texture_storage_1d",
+            TextureStorageKind::Storage2D => "texture_storage_2d",
+            TextureStorageKind::Storage2DArray => "texture_storage_2d_array",
+            TextureStorageKind::Storage3D => "texture_storage_3d",
+        }
+    }
+}
+
 // ===== Type =====
 
 /// WGSL type expression.
@@ -133,6 +414,13 @@ pub enum Type {
     },
     /// A depth texture, e.g. `texture_depth_2d`.
     TextureDepth { kind: TextureDepthKind },
+    /// A storage texture, e.g. `texture_storage_2d<rgba8unorm, write>`.
+    /// WGSL §6.6.5.
+    TextureStorage {
+        kind: TextureStorageKind,
+        format: TexelFormat,
+        access: StorageTextureAccess,
+    },
     /// A type parameter referenced by name. These are replaced by concrete
     /// types via [`crate::substitute_types`] before rendering.
     TypeParam { name: String },

--- a/crates/wgsl-rs-macros/src/builtins.rs
+++ b/crates/wgsl-rs-macros/src/builtins.rs
@@ -103,6 +103,8 @@ pub const BUILTIN_CASE_NAME_MAP: &[(&str, &str)] = &[
     ("texture_load", "textureLoad"),
     ("texture_load_array", "textureLoad"),
     ("texture_load_multisampled", "textureLoad"),
+    ("texture_load_storage", "textureLoad"),
+    ("texture_load_storage_array", "textureLoad"),
     // Query functions
     ("texture_num_layers", "textureNumLayers"),
     ("texture_num_levels", "textureNumLevels"),

--- a/crates/wgsl-rs-macros/src/ir_convert.rs
+++ b/crates/wgsl-rs-macros/src/ir_convert.rs
@@ -483,6 +483,16 @@ pub fn ty_from_parse(t: &parse::Type) -> Result<ir::Type> {
         parse::Type::TextureDepth { kind, .. } => ir::Type::TextureDepth {
             kind: tex_depth_kind(*kind),
         },
+        parse::Type::TextureStorage {
+            kind,
+            format,
+            access,
+            ..
+        } => ir::Type::TextureStorage {
+            kind: tex_storage_kind(*kind),
+            format: format.to_ir(),
+            access: storage_access_from_parse(*access),
+        },
         parse::Type::TypeParam { ident } => ir::Type::TypeParam {
             name: ident.to_string(),
         },
@@ -534,6 +544,23 @@ fn tex_depth_kind(k: parse::TextureDepthKind) -> ir::TextureDepthKind {
         parse::TextureDepthKind::DepthCube => ir::TextureDepthKind::DepthCube,
         parse::TextureDepthKind::DepthCubeArray => ir::TextureDepthKind::DepthCubeArray,
         parse::TextureDepthKind::DepthMultisampled2D => ir::TextureDepthKind::DepthMultisampled2D,
+    }
+}
+
+fn tex_storage_kind(k: parse::TextureStorageKind) -> ir::TextureStorageKind {
+    match k {
+        parse::TextureStorageKind::Storage1D => ir::TextureStorageKind::Storage1D,
+        parse::TextureStorageKind::Storage2D => ir::TextureStorageKind::Storage2D,
+        parse::TextureStorageKind::Storage2DArray => ir::TextureStorageKind::Storage2DArray,
+        parse::TextureStorageKind::Storage3D => ir::TextureStorageKind::Storage3D,
+    }
+}
+
+fn storage_access_from_parse(a: parse::StorageTextureAccess) -> ir::StorageTextureAccess {
+    match a {
+        parse::StorageTextureAccess::Read => ir::StorageTextureAccess::Read,
+        parse::StorageTextureAccess::Write => ir::StorageTextureAccess::Write,
+        parse::StorageTextureAccess::ReadWrite => ir::StorageTextureAccess::ReadWrite,
     }
 }
 

--- a/crates/wgsl-rs-macros/src/ir_emit.rs
+++ b/crates/wgsl-rs-macros/src/ir_emit.rs
@@ -507,6 +507,22 @@ fn ty(p: &TokenStream, t: &ir::Type) -> TokenStream {
             let k = tex_depth_kind(p, *kind);
             quote! { #p::Type::TextureDepth { kind: #k } }
         }
+        ir::Type::TextureStorage {
+            kind,
+            format,
+            access,
+        } => {
+            let k = tex_storage_kind(p, *kind);
+            let f = texel_format(p, *format);
+            let a = storage_texture_access(p, *access);
+            quote! {
+                #p::Type::TextureStorage {
+                    kind: #k,
+                    format: #f,
+                    access: #a,
+                }
+            }
+        }
         ir::Type::TypeParam { name } => {
             quote! { #p::Type::TypeParam { name: ::std::string::String::from(#name) } }
         }
@@ -553,6 +569,71 @@ fn tex_depth_kind(p: &TokenStream, k: ir::TextureDepthKind) -> TokenStream {
         ir::TextureDepthKind::DepthMultisampled2D => quote! { DepthMultisampled2D },
     };
     quote! { #p::TextureDepthKind::#v }
+}
+
+fn tex_storage_kind(p: &TokenStream, k: ir::TextureStorageKind) -> TokenStream {
+    let v = match k {
+        ir::TextureStorageKind::Storage1D => quote! { Storage1D },
+        ir::TextureStorageKind::Storage2D => quote! { Storage2D },
+        ir::TextureStorageKind::Storage2DArray => quote! { Storage2DArray },
+        ir::TextureStorageKind::Storage3D => quote! { Storage3D },
+    };
+    quote! { #p::TextureStorageKind::#v }
+}
+
+fn texel_format(p: &TokenStream, f: ir::TexelFormat) -> TokenStream {
+    let v = match f {
+        ir::TexelFormat::Rgba8unorm => quote! { Rgba8unorm },
+        ir::TexelFormat::Rgba8snorm => quote! { Rgba8snorm },
+        ir::TexelFormat::Rgba8uint => quote! { Rgba8uint },
+        ir::TexelFormat::Rgba8sint => quote! { Rgba8sint },
+        ir::TexelFormat::Rgba16uint => quote! { Rgba16uint },
+        ir::TexelFormat::Rgba16sint => quote! { Rgba16sint },
+        ir::TexelFormat::Rgba16float => quote! { Rgba16float },
+        ir::TexelFormat::R32uint => quote! { R32uint },
+        ir::TexelFormat::R32sint => quote! { R32sint },
+        ir::TexelFormat::R32float => quote! { R32float },
+        ir::TexelFormat::Rg32uint => quote! { Rg32uint },
+        ir::TexelFormat::Rg32sint => quote! { Rg32sint },
+        ir::TexelFormat::Rg32float => quote! { Rg32float },
+        ir::TexelFormat::Rgba32uint => quote! { Rgba32uint },
+        ir::TexelFormat::Rgba32sint => quote! { Rgba32sint },
+        ir::TexelFormat::Rgba32float => quote! { Rgba32float },
+        ir::TexelFormat::Bgra8unorm => quote! { Bgra8unorm },
+        ir::TexelFormat::Rgba16unorm => quote! { Rgba16unorm },
+        ir::TexelFormat::Rgba16snorm => quote! { Rgba16snorm },
+        ir::TexelFormat::Rg8unorm => quote! { Rg8unorm },
+        ir::TexelFormat::Rg8snorm => quote! { Rg8snorm },
+        ir::TexelFormat::Rg8uint => quote! { Rg8uint },
+        ir::TexelFormat::Rg8sint => quote! { Rg8sint },
+        ir::TexelFormat::Rg16unorm => quote! { Rg16unorm },
+        ir::TexelFormat::Rg16snorm => quote! { Rg16snorm },
+        ir::TexelFormat::Rg16uint => quote! { Rg16uint },
+        ir::TexelFormat::Rg16sint => quote! { Rg16sint },
+        ir::TexelFormat::Rg16float => quote! { Rg16float },
+        ir::TexelFormat::R8unorm => quote! { R8unorm },
+        ir::TexelFormat::R8snorm => quote! { R8snorm },
+        ir::TexelFormat::R8uint => quote! { R8uint },
+        ir::TexelFormat::R8sint => quote! { R8sint },
+        ir::TexelFormat::R16unorm => quote! { R16unorm },
+        ir::TexelFormat::R16snorm => quote! { R16snorm },
+        ir::TexelFormat::R16uint => quote! { R16uint },
+        ir::TexelFormat::R16sint => quote! { R16sint },
+        ir::TexelFormat::R16float => quote! { R16float },
+        ir::TexelFormat::Rgb10a2unorm => quote! { Rgb10a2unorm },
+        ir::TexelFormat::Rgb10a2uint => quote! { Rgb10a2uint },
+        ir::TexelFormat::Rg11b10ufloat => quote! { Rg11b10ufloat },
+    };
+    quote! { #p::TexelFormat::#v }
+}
+
+fn storage_texture_access(p: &TokenStream, a: ir::StorageTextureAccess) -> TokenStream {
+    let v = match a {
+        ir::StorageTextureAccess::Read => quote! { Read },
+        ir::StorageTextureAccess::Write => quote! { Write },
+        ir::StorageTextureAccess::ReadWrite => quote! { ReadWrite },
+    };
+    quote! { #p::StorageTextureAccess::#v }
 }
 
 // ===== Expressions =====

--- a/crates/wgsl-rs-macros/src/lib.rs
+++ b/crates/wgsl-rs-macros/src/lib.rs
@@ -1066,6 +1066,7 @@ fn go_wgsl(attr: TokenStream, mut input_mod: syn::ItemMod) -> Result<TokenStream
 /// ```ignore
 /// texture!(group(0), binding(4), DIFFUSE: Texture2D<f32>);
 /// texture!(group(0), binding(5), SHADOW_MAP: TextureDepth2D);
+/// texture!(group(0), binding(6), OUT: TextureStorage2D<Rgba8unorm, Write>);
 /// ```
 ///
 /// **Sampled textures** (with type parameter `f32`, `i32`, or `u32`):
@@ -1075,6 +1076,12 @@ fn go_wgsl(attr: TokenStream, mut input_mod: syn::ItemMod) -> Result<TokenStream
 /// **Depth textures** (no type parameter):
 /// `TextureDepth2D`, `TextureDepth2DArray`, `TextureDepthCube`,
 /// `TextureDepthCubeArray`, `TextureDepthMultisampled2D`.
+///
+/// **Storage textures** (with texel format and access mode parameters):
+/// `TextureStorage1D`, `TextureStorage2D`, `TextureStorage2DArray`,
+/// `TextureStorage3D`. The first type parameter is a texel format marker
+/// (e.g. `Rgba8unorm`, `R32float` — see WGSL §6.6.1) and the second is an
+/// access mode (`Read`, `Write`, `ReadWrite`).
 ///
 /// ## `workgroup!`
 ///
@@ -1501,6 +1508,10 @@ pub fn sampler(input: TokenStream) -> TokenStream {
 /// // Depth textures (no type parameter)
 /// texture!(group(G), binding(B), NAME: TextureDepth2D);
 /// texture!(group(G), binding(B), NAME: TextureDepthCube);
+///
+/// // Storage textures (texel format + access mode)
+/// texture!(group(G), binding(B), NAME: TextureStorage2D<Rgba8unorm, Write>);
+/// texture!(group(G), binding(B), NAME: TextureStorage2D<R32float, ReadWrite>);
 /// ```
 ///
 /// # Supported Texture Types
@@ -1523,10 +1534,23 @@ pub fn sampler(input: TokenStream) -> TokenStream {
 /// - `TextureDepthCubeArray` - Cube depth texture array
 /// - `TextureDepthMultisampled2D` - Multisampled 2D depth texture
 ///
+/// ## Storage Textures
+/// - `TextureStorage1D<F, A>` - 1D storage texture
+/// - `TextureStorage2D<F, A>` - 2D storage texture
+/// - `TextureStorage2DArray<F, A>` - 2D array storage texture
+/// - `TextureStorage3D<F, A>` - 3D storage texture
+///
+/// Where `F` is a texel format marker (e.g. `Rgba8unorm`, `R32float`,
+/// `Rgba32uint`) and `A` is an access mode (`Read`, `Write`, `ReadWrite`). See
+/// WGSL §6.6.1 for the full list of texel formats and §6.6.5 for storage
+/// texture types.
+///
 /// # WGSL Output
 /// The macro transpiles to:
 /// - `@group(G) @binding(B) var NAME: texture_2d<f32>;` for sampled textures
 /// - `@group(G) @binding(B) var NAME: texture_depth_2d;` for depth textures
+/// - `@group(G) @binding(B) var NAME: texture_storage_2d<rgba8unorm, write>;`
+///   for storage textures
 ///
 /// # Rust Expansion
 /// On the Rust side, the macro generates:

--- a/crates/wgsl-rs-macros/src/monomorphize.rs
+++ b/crates/wgsl-rs-macros/src/monomorphize.rs
@@ -158,6 +158,7 @@ enum TypeKey {
     SamplerComparison,
     Texture(String),
     TextureDepth(String),
+    TextureStorage(String, String, String),
     Ptr(String, Box<TypeKey>),
     /// Should not appear in a fully resolved key.
     TypeParam(String),
@@ -1913,6 +1914,17 @@ pub(crate) fn mangle_type(ty: &Type) -> Result<String, crate::parse::Error> {
         Type::SamplerComparison { .. } => "sampler_comparison".to_string(),
         Type::Texture { kind, .. } => kind.wgsl_name().replace("texture_", "tex_"),
         Type::TextureDepth { kind, .. } => kind.wgsl_name().replace("texture_", "tex_"),
+        Type::TextureStorage {
+            kind,
+            format,
+            access,
+            ..
+        } => {
+            let k = kind.wgsl_name().replace("texture_", "tex_");
+            let f = format.wgsl_name();
+            let a = access.wgsl_name();
+            mangle(&[&k, f, a])
+        }
         // Include address space so that e.g. `ptr<function, f32>` and
         // `ptr<private, f32>` produce distinct mangled names and don't
         // falsely collide.
@@ -2001,6 +2013,16 @@ fn type_to_key(ty: &Type) -> Result<TypeKey, crate::parse::Error> {
         Type::SamplerComparison { .. } => TypeKey::SamplerComparison,
         Type::Texture { kind, .. } => TypeKey::Texture(kind.wgsl_name().to_string()),
         Type::TextureDepth { kind, .. } => TypeKey::TextureDepth(kind.wgsl_name().to_string()),
+        Type::TextureStorage {
+            kind,
+            format,
+            access,
+            ..
+        } => TypeKey::TextureStorage(
+            kind.wgsl_name().to_string(),
+            format.wgsl_name().to_string(),
+            access.wgsl_name().to_string(),
+        ),
         Type::Ptr {
             address_space,
             elem,
@@ -2030,7 +2052,8 @@ pub(crate) fn contains_type_param(ty: &Type) -> bool {
         | Type::Sampler { .. }
         | Type::SamplerComparison { .. }
         | Type::Texture { .. }
-        | Type::TextureDepth { .. } => false,
+        | Type::TextureDepth { .. }
+        | Type::TextureStorage { .. } => false,
     }
 }
 

--- a/crates/wgsl-rs-macros/src/parse.rs
+++ b/crates/wgsl-rs-macros/src/parse.rs
@@ -732,11 +732,270 @@ impl TextureDepthKind {
     }
 }
 
+/// Storage texture dimensionality/kind.
+/// These correspond to WGSL's texture_storage_* types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextureStorageKind {
+    /// texture_storage_1d<F, A>
+    Storage1D,
+    /// texture_storage_2d<F, A>
+    Storage2D,
+    /// texture_storage_2d_array<F, A>
+    Storage2DArray,
+    /// texture_storage_3d<F, A>
+    Storage3D,
+}
+
+impl TextureStorageKind {
+    /// Returns the WGSL type name for this storage texture kind.
+    pub fn wgsl_name(&self) -> &'static str {
+        match self {
+            TextureStorageKind::Storage1D => "texture_storage_1d",
+            TextureStorageKind::Storage2D => "texture_storage_2d",
+            TextureStorageKind::Storage2DArray => "texture_storage_2d_array",
+            TextureStorageKind::Storage3D => "texture_storage_3d",
+        }
+    }
+
+    /// Parse a Rust type name into a TextureStorageKind.
+    pub fn from_rust_name(name: &str) -> Option<Self> {
+        match name {
+            "TextureStorage1D" => Some(TextureStorageKind::Storage1D),
+            "TextureStorage2D" => Some(TextureStorageKind::Storage2D),
+            "TextureStorage2DArray" => Some(TextureStorageKind::Storage2DArray),
+            "TextureStorage3D" => Some(TextureStorageKind::Storage3D),
+            _ => None,
+        }
+    }
+}
+
+/// Storage texture access mode (WGSL §14.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageTextureAccess {
+    Read,
+    Write,
+    ReadWrite,
+}
+
+impl StorageTextureAccess {
+    /// Returns the WGSL enumerant name.
+    pub fn wgsl_name(&self) -> &'static str {
+        match self {
+            StorageTextureAccess::Read => "read",
+            StorageTextureAccess::Write => "write",
+            StorageTextureAccess::ReadWrite => "read_write",
+        }
+    }
+
+    /// Parse a Rust type name into a StorageTextureAccess.
+    pub fn from_rust_name(name: &str) -> Option<Self> {
+        match name {
+            "Read" => Some(StorageTextureAccess::Read),
+            "Write" => Some(StorageTextureAccess::Write),
+            "ReadWrite" => Some(StorageTextureAccess::ReadWrite),
+            _ => None,
+        }
+    }
+}
+
+/// Texel formats for storage textures (WGSL §6.6.1).
+///
+/// This parse-level enum mirrors `wgsl_rs_ir::TexelFormat` and is used during
+/// macro parsing. The variant names are the PascalCase equivalents of the
+/// WGSL enumerant names (e.g. `rgba8unorm` → `Rgba8unorm`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TexelFormat {
+    // Core formats
+    Rgba8unorm,
+    Rgba8snorm,
+    Rgba8uint,
+    Rgba8sint,
+    Rgba16uint,
+    Rgba16sint,
+    Rgba16float,
+    R32uint,
+    R32sint,
+    R32float,
+    Rg32uint,
+    Rg32sint,
+    Rg32float,
+    Rgba32uint,
+    Rgba32sint,
+    Rgba32float,
+    Bgra8unorm,
+    // Tier-1 extension formats
+    Rgba16unorm,
+    Rgba16snorm,
+    Rg8unorm,
+    Rg8snorm,
+    Rg8uint,
+    Rg8sint,
+    Rg16unorm,
+    Rg16snorm,
+    Rg16uint,
+    Rg16sint,
+    Rg16float,
+    R8unorm,
+    R8snorm,
+    R8uint,
+    R8sint,
+    R16unorm,
+    R16snorm,
+    R16uint,
+    R16sint,
+    R16float,
+    Rgb10a2unorm,
+    Rgb10a2uint,
+    Rg11b10ufloat,
+}
+
+impl TexelFormat {
+    /// Parse a Rust type name (PascalCase) into a TexelFormat.
+    pub fn from_rust_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "Rgba8unorm" => TexelFormat::Rgba8unorm,
+            "Rgba8snorm" => TexelFormat::Rgba8snorm,
+            "Rgba8uint" => TexelFormat::Rgba8uint,
+            "Rgba8sint" => TexelFormat::Rgba8sint,
+            "Rgba16uint" => TexelFormat::Rgba16uint,
+            "Rgba16sint" => TexelFormat::Rgba16sint,
+            "Rgba16float" => TexelFormat::Rgba16float,
+            "R32uint" => TexelFormat::R32uint,
+            "R32sint" => TexelFormat::R32sint,
+            "R32float" => TexelFormat::R32float,
+            "Rg32uint" => TexelFormat::Rg32uint,
+            "Rg32sint" => TexelFormat::Rg32sint,
+            "Rg32float" => TexelFormat::Rg32float,
+            "Rgba32uint" => TexelFormat::Rgba32uint,
+            "Rgba32sint" => TexelFormat::Rgba32sint,
+            "Rgba32float" => TexelFormat::Rgba32float,
+            "Bgra8unorm" => TexelFormat::Bgra8unorm,
+            "Rgba16unorm" => TexelFormat::Rgba16unorm,
+            "Rgba16snorm" => TexelFormat::Rgba16snorm,
+            "Rg8unorm" => TexelFormat::Rg8unorm,
+            "Rg8snorm" => TexelFormat::Rg8snorm,
+            "Rg8uint" => TexelFormat::Rg8uint,
+            "Rg8sint" => TexelFormat::Rg8sint,
+            "Rg16unorm" => TexelFormat::Rg16unorm,
+            "Rg16snorm" => TexelFormat::Rg16snorm,
+            "Rg16uint" => TexelFormat::Rg16uint,
+            "Rg16sint" => TexelFormat::Rg16sint,
+            "Rg16float" => TexelFormat::Rg16float,
+            "R8unorm" => TexelFormat::R8unorm,
+            "R8snorm" => TexelFormat::R8snorm,
+            "R8uint" => TexelFormat::R8uint,
+            "R8sint" => TexelFormat::R8sint,
+            "R16unorm" => TexelFormat::R16unorm,
+            "R16snorm" => TexelFormat::R16snorm,
+            "R16uint" => TexelFormat::R16uint,
+            "R16sint" => TexelFormat::R16sint,
+            "R16float" => TexelFormat::R16float,
+            "Rgb10a2unorm" => TexelFormat::Rgb10a2unorm,
+            "Rgb10a2uint" => TexelFormat::Rgb10a2uint,
+            "Rg11b10ufloat" => TexelFormat::Rg11b10ufloat,
+            _ => return None,
+        })
+    }
+
+    /// Convert to the IR-level texel format.
+    pub fn to_ir(self) -> ir::TexelFormat {
+        match self {
+            TexelFormat::Rgba8unorm => ir::TexelFormat::Rgba8unorm,
+            TexelFormat::Rgba8snorm => ir::TexelFormat::Rgba8snorm,
+            TexelFormat::Rgba8uint => ir::TexelFormat::Rgba8uint,
+            TexelFormat::Rgba8sint => ir::TexelFormat::Rgba8sint,
+            TexelFormat::Rgba16uint => ir::TexelFormat::Rgba16uint,
+            TexelFormat::Rgba16sint => ir::TexelFormat::Rgba16sint,
+            TexelFormat::Rgba16float => ir::TexelFormat::Rgba16float,
+            TexelFormat::R32uint => ir::TexelFormat::R32uint,
+            TexelFormat::R32sint => ir::TexelFormat::R32sint,
+            TexelFormat::R32float => ir::TexelFormat::R32float,
+            TexelFormat::Rg32uint => ir::TexelFormat::Rg32uint,
+            TexelFormat::Rg32sint => ir::TexelFormat::Rg32sint,
+            TexelFormat::Rg32float => ir::TexelFormat::Rg32float,
+            TexelFormat::Rgba32uint => ir::TexelFormat::Rgba32uint,
+            TexelFormat::Rgba32sint => ir::TexelFormat::Rgba32sint,
+            TexelFormat::Rgba32float => ir::TexelFormat::Rgba32float,
+            TexelFormat::Bgra8unorm => ir::TexelFormat::Bgra8unorm,
+            TexelFormat::Rgba16unorm => ir::TexelFormat::Rgba16unorm,
+            TexelFormat::Rgba16snorm => ir::TexelFormat::Rgba16snorm,
+            TexelFormat::Rg8unorm => ir::TexelFormat::Rg8unorm,
+            TexelFormat::Rg8snorm => ir::TexelFormat::Rg8snorm,
+            TexelFormat::Rg8uint => ir::TexelFormat::Rg8uint,
+            TexelFormat::Rg8sint => ir::TexelFormat::Rg8sint,
+            TexelFormat::Rg16unorm => ir::TexelFormat::Rg16unorm,
+            TexelFormat::Rg16snorm => ir::TexelFormat::Rg16snorm,
+            TexelFormat::Rg16uint => ir::TexelFormat::Rg16uint,
+            TexelFormat::Rg16sint => ir::TexelFormat::Rg16sint,
+            TexelFormat::Rg16float => ir::TexelFormat::Rg16float,
+            TexelFormat::R8unorm => ir::TexelFormat::R8unorm,
+            TexelFormat::R8snorm => ir::TexelFormat::R8snorm,
+            TexelFormat::R8uint => ir::TexelFormat::R8uint,
+            TexelFormat::R8sint => ir::TexelFormat::R8sint,
+            TexelFormat::R16unorm => ir::TexelFormat::R16unorm,
+            TexelFormat::R16snorm => ir::TexelFormat::R16snorm,
+            TexelFormat::R16uint => ir::TexelFormat::R16uint,
+            TexelFormat::R16sint => ir::TexelFormat::R16sint,
+            TexelFormat::R16float => ir::TexelFormat::R16float,
+            TexelFormat::Rgb10a2unorm => ir::TexelFormat::Rgb10a2unorm,
+            TexelFormat::Rgb10a2uint => ir::TexelFormat::Rgb10a2uint,
+            TexelFormat::Rg11b10ufloat => ir::TexelFormat::Rg11b10ufloat,
+        }
+    }
+
+    /// Returns the WGSL enumerant name (lowercase, as written in WGSL source).
+    pub fn wgsl_name(&self) -> &'static str {
+        self.to_ir().wgsl_name()
+    }
+}
+
 /// Helper struct for parsing `ptr!(address_space, Type)` macro arguments.
 struct PtrMacroArgs {
     address_space: Ident,
     _comma: Token![,],
     store_type: syn::Type,
+}
+
+/// Extract the string name of a type argument that is expected to be a
+/// simple single-segment path (e.g. `Rgba8unorm`, `Write`). Used for
+/// storage texture format and access mode parsing.
+fn extract_type_ident(arg: &syn::GenericArgument) -> Result<String, Error> {
+    match arg {
+        syn::GenericArgument::Type(syn::Type::Path(type_path)) => {
+            util::some_is_unsupported(
+                type_path.qself.as_ref(),
+                "QSelf not allowed in storage texture type argument",
+            )?;
+            snafu::ensure!(
+                type_path.path.segments.len() == 1,
+                UnsupportedSnafu {
+                    span: type_path.path.segments.span(),
+                    note: "storage texture type arguments must be simple single-segment paths \
+                           (e.g. Rgba8unorm, Write)",
+                }
+            );
+            let segment = type_path.path.segments.first().context(UnsupportedSnafu {
+                span: type_path.path.segments.span(),
+                note: "Unexpected empty type path",
+            })?;
+            snafu::ensure!(
+                segment.arguments.is_empty(),
+                UnsupportedSnafu {
+                    span: segment.span(),
+                    note: "storage texture type arguments must not have generic parameters",
+                }
+            );
+            Ok(segment.ident.to_string())
+        }
+        other => UnsupportedSnafu {
+            span: other.span(),
+            note: format!(
+                "Expected a simple type name, got '{}'",
+                other.into_token_stream()
+            ),
+        }
+        .fail(),
+    }
 }
 
 impl Parse for PtrMacroArgs {
@@ -862,6 +1121,15 @@ pub enum Type {
     /// No type parameter (implicitly f32 for depth values).
     TextureDepth {
         kind: TextureDepthKind,
+        ident: Ident,
+    },
+
+    /// Storage texture types: texture_storage_1d/2d/2d_array/3d.
+    /// Parameterized by a texel format and an access mode.
+    TextureStorage {
+        kind: TextureStorageKind,
+        format: TexelFormat,
+        access: StorageTextureAccess,
         ident: Ident,
     },
 
@@ -1108,6 +1376,55 @@ impl Type {
                     gt_token,
                 }) => {
                     let ident_str = ident.to_string();
+
+                    // Storage textures take two type arguments (format +
+                    // access), so they're handled before the one-arg
+                    // builtin-generic check below.
+                    if let Some(storage_kind) = TextureStorageKind::from_rust_name(&ident_str) {
+                        snafu::ensure!(
+                            args.len() == 2,
+                            UnsupportedSnafu {
+                                span: args.span(),
+                                note: "Storage texture types take exactly two type arguments: a \
+                                       texel format and an access mode (e.g. \
+                                       TextureStorage2D<Rgba8unorm, Write>)",
+                            }
+                        );
+                        let mut args_iter = args.iter();
+                        let format_arg = args_iter.next().expect("checked len == 2");
+                        let access_arg = args_iter.next().expect("checked len == 2");
+                        let format_name = extract_type_ident(format_arg)?;
+                        let access_name = extract_type_ident(access_arg)?;
+                        let format =
+                            TexelFormat::from_rust_name(&format_name).ok_or_else(|| {
+                                UnsupportedSnafu {
+                                    span: format_arg.span(),
+                                    note: format!(
+                                        "'{format_name}' is not a recognized storage texel \
+                                         format. See WGSL §6.6.1 for the list of valid texel \
+                                         formats."
+                                    ),
+                                }
+                                .build()
+                            })?;
+                        let access = StorageTextureAccess::from_rust_name(&access_name)
+                            .ok_or_else(|| {
+                                UnsupportedSnafu {
+                                    span: access_arg.span(),
+                                    note: format!(
+                                        "'{access_name}' is not a valid storage texture access \
+                                         mode. Use one of: Read, Write, ReadWrite."
+                                    ),
+                                }
+                                .build()
+                            })?;
+                        return Ok(Type::TextureStorage {
+                            kind: storage_kind,
+                            format,
+                            access,
+                            ident: ident.clone(),
+                        });
+                    }
 
                     // Check for known builtin generic types first (these all
                     // take exactly one type argument).
@@ -2614,6 +2931,7 @@ impl Expr {
                     Type::SamplerComparison { ident } => ident.span(),
                     Type::Texture { ident, .. } => ident.span(),
                     Type::TextureDepth { ident, .. } => ident.span(),
+                    Type::TextureStorage { ident, .. } => ident.span(),
                     Type::TypeParam { ident } => ident.span(),
                     Type::Phantom { ident, .. } => ident.span(),
                 };
@@ -5591,11 +5909,12 @@ impl syn::parse::Parse for ItemTexture {
 
         // Validate that the type is a texture type
         match &ty {
-            Type::Texture { .. } | Type::TextureDepth { .. } => {}
+            Type::Texture { .. } | Type::TextureDepth { .. } | Type::TextureStorage { .. } => {}
             _ => {
                 return Err(syn::Error::new(
                     rust_ty.span(),
-                    "texture! macro requires a texture type (Texture2D<f32>, TextureDepth2D, etc.)",
+                    "texture! macro requires a texture type (Texture2D<f32>, TextureDepth2D, \
+                     TextureStorage2D<Rgba8unorm, Write>, etc.)",
                 ));
             }
         }
@@ -6332,6 +6651,7 @@ fn resolve_self_in_type(name: &Ident, ty: &mut Type) {
         | Type::SamplerComparison { .. }
         | Type::Texture { .. }
         | Type::TextureDepth { .. }
+        | Type::TextureStorage { .. }
         | Type::TypeParam { .. } => {}
     }
 }
@@ -9159,6 +9479,96 @@ mod test {
         let ty: syn::Type = syn::parse_str("TextureDepthMultisampled2D").unwrap();
         let ty = Type::try_from(&ty).unwrap();
         assert_eq!("texture_depth_multisampled_2d", ty.to_wgsl());
+    }
+
+    #[test]
+    fn parse_texture_storage_2d_write() {
+        let ty: syn::Type = syn::parse_str("TextureStorage2D<Rgba8unorm, Write>").unwrap();
+        let ty = Type::try_from(&ty).unwrap();
+        assert!(
+            matches!(ty, Type::TextureStorage { .. }),
+            "Expected Type::TextureStorage variant"
+        );
+        assert_eq!("texture_storage_2d<rgba8unorm, write>", ty.to_wgsl());
+    }
+
+    #[test]
+    fn parse_texture_storage_2d_read() {
+        let ty: syn::Type = syn::parse_str("TextureStorage2D<Rgba8uint, Read>").unwrap();
+        let ty = Type::try_from(&ty).unwrap();
+        assert_eq!("texture_storage_2d<rgba8uint, read>", ty.to_wgsl());
+    }
+
+    #[test]
+    fn parse_texture_storage_2d_read_write() {
+        let ty: syn::Type = syn::parse_str("TextureStorage2D<R32float, ReadWrite>").unwrap();
+        let ty = Type::try_from(&ty).unwrap();
+        assert_eq!("texture_storage_2d<r32float, read_write>", ty.to_wgsl());
+    }
+
+    #[test]
+    fn parse_texture_storage_1d() {
+        let ty: syn::Type = syn::parse_str("TextureStorage1D<Rgba8sint, Write>").unwrap();
+        let ty = Type::try_from(&ty).unwrap();
+        assert_eq!("texture_storage_1d<rgba8sint, write>", ty.to_wgsl());
+    }
+
+    #[test]
+    fn parse_texture_storage_2d_array() {
+        let ty: syn::Type = syn::parse_str("TextureStorage2DArray<Rgba16float, Read>").unwrap();
+        let ty = Type::try_from(&ty).unwrap();
+        assert_eq!("texture_storage_2d_array<rgba16float, read>", ty.to_wgsl());
+    }
+
+    #[test]
+    fn parse_texture_storage_3d() {
+        let ty: syn::Type = syn::parse_str("TextureStorage3D<Rgba32float, Write>").unwrap();
+        let ty = Type::try_from(&ty).unwrap();
+        assert_eq!("texture_storage_3d<rgba32float, write>", ty.to_wgsl());
+    }
+
+    #[test]
+    fn parse_texture_storage_tier1_format() {
+        let ty: syn::Type = syn::parse_str("TextureStorage2D<R16float, ReadWrite>").unwrap();
+        let ty = Type::try_from(&ty).unwrap();
+        assert_eq!("texture_storage_2d<r16float, read_write>", ty.to_wgsl());
+    }
+
+    #[test]
+    fn parse_texture_storage_rejects_bad_format() {
+        let ty: syn::Type = syn::parse_str("TextureStorage2D<NotAFormat, Write>").unwrap();
+        let result = Type::try_from(&ty);
+        assert!(result.is_err(), "Expected error for unknown texel format");
+    }
+
+    #[test]
+    fn parse_texture_storage_rejects_bad_access() {
+        let ty: syn::Type = syn::parse_str("TextureStorage2D<Rgba8unorm, NotAnAccess>").unwrap();
+        let result = Type::try_from(&ty);
+        assert!(result.is_err(), "Expected error for unknown access mode");
+    }
+
+    #[test]
+    fn parse_texture_storage_rejects_wrong_arity() {
+        let ty: syn::Type = syn::parse_str("TextureStorage2D<Rgba8unorm>").unwrap();
+        let result = Type::try_from(&ty);
+        assert!(
+            result.is_err(),
+            "Expected error for storage texture with only one type argument"
+        );
+    }
+
+    #[test]
+    fn texture_storage_to_wgsl() {
+        let texture: ItemTexture =
+            syn::parse_str("group(0), binding(5), OUT_TEX: TextureStorage2D<Rgba8unorm, Write>")
+                .unwrap();
+        let wgsl = texture.to_wgsl();
+        assert!(
+            wgsl.contains(": texture_storage_2d<rgba8unorm, write>;"),
+            "Expected ': texture_storage_2d<rgba8unorm, write>;' in WGSL, got: {}",
+            wgsl
+        );
     }
 
     #[test]

--- a/crates/wgsl-rs-macros/src/parse_visitor.rs
+++ b/crates/wgsl-rs-macros/src/parse_visitor.rs
@@ -403,6 +403,7 @@ pub(crate) fn walk_type<V: ParseVisitorMut + ?Sized>(v: &mut V, t: &mut Type) ->
         | Type::SamplerComparison { .. }
         | Type::Texture { .. }
         | Type::TextureDepth { .. }
+        | Type::TextureStorage { .. }
         | Type::TypeParam { .. } => {}
     }
     Ok(())

--- a/crates/wgsl-rs-macros/src/texture.rs
+++ b/crates/wgsl-rs-macros/src/texture.rs
@@ -3,7 +3,10 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse_macro_input;
 
-use crate::parse::{ItemTexture, ScalarType, TextureDepthKind, TextureKind, Type};
+use crate::parse::{
+    ItemTexture, ScalarType, StorageTextureAccess, TexelFormat, TextureDepthKind, TextureKind,
+    TextureStorageKind, Type,
+};
 
 pub fn texture(input: TokenStream) -> TokenStream {
     let ItemTexture {
@@ -44,6 +47,23 @@ pub fn texture(input: TokenStream) -> TokenStream {
                 pub const #name: &'static #rust_type = &#inner_name;
             }
         }
+        Type::TextureStorage {
+            kind,
+            format,
+            access,
+            ..
+        } => {
+            let rust_type = texture_storage_kind_to_rust_type(*kind);
+            let format_type = texel_format_to_rust_type(*format);
+            let access_type = storage_access_to_rust_type(*access);
+
+            quote! {
+                #[doc(hidden)]
+                static #inner_name: #rust_type<#format_type, #access_type> =
+                    #rust_type::new(#group, #binding);
+                pub const #name: &'static #rust_type<#format_type, #access_type> = &#inner_name;
+            }
+        }
         _ => {
             // This should never happen since ItemTexture validates the type
             quote! {
@@ -76,6 +96,71 @@ fn texture_depth_kind_to_rust_type(kind: TextureDepthKind) -> proc_macro2::Token
         TextureDepthKind::DepthCube => quote! { TextureDepthCube },
         TextureDepthKind::DepthCubeArray => quote! { TextureDepthCubeArray },
         TextureDepthKind::DepthMultisampled2D => quote! { TextureDepthMultisampled2D },
+    }
+}
+
+/// Convert a TextureStorageKind to the corresponding Rust type identifier.
+fn texture_storage_kind_to_rust_type(kind: TextureStorageKind) -> proc_macro2::TokenStream {
+    match kind {
+        TextureStorageKind::Storage1D => quote! { TextureStorage1D },
+        TextureStorageKind::Storage2D => quote! { TextureStorage2D },
+        TextureStorageKind::Storage2DArray => quote! { TextureStorage2DArray },
+        TextureStorageKind::Storage3D => quote! { TextureStorage3D },
+    }
+}
+
+/// Convert a TexelFormat to the corresponding Rust marker type identifier.
+fn texel_format_to_rust_type(format: TexelFormat) -> proc_macro2::TokenStream {
+    match format {
+        TexelFormat::Rgba8unorm => quote! { Rgba8unorm },
+        TexelFormat::Rgba8snorm => quote! { Rgba8snorm },
+        TexelFormat::Rgba8uint => quote! { Rgba8uint },
+        TexelFormat::Rgba8sint => quote! { Rgba8sint },
+        TexelFormat::Rgba16uint => quote! { Rgba16uint },
+        TexelFormat::Rgba16sint => quote! { Rgba16sint },
+        TexelFormat::Rgba16float => quote! { Rgba16float },
+        TexelFormat::R32uint => quote! { R32uint },
+        TexelFormat::R32sint => quote! { R32sint },
+        TexelFormat::R32float => quote! { R32float },
+        TexelFormat::Rg32uint => quote! { Rg32uint },
+        TexelFormat::Rg32sint => quote! { Rg32sint },
+        TexelFormat::Rg32float => quote! { Rg32float },
+        TexelFormat::Rgba32uint => quote! { Rgba32uint },
+        TexelFormat::Rgba32sint => quote! { Rgba32sint },
+        TexelFormat::Rgba32float => quote! { Rgba32float },
+        TexelFormat::Bgra8unorm => quote! { Bgra8unorm },
+        TexelFormat::Rgba16unorm => quote! { Rgba16unorm },
+        TexelFormat::Rgba16snorm => quote! { Rgba16snorm },
+        TexelFormat::Rg8unorm => quote! { Rg8unorm },
+        TexelFormat::Rg8snorm => quote! { Rg8snorm },
+        TexelFormat::Rg8uint => quote! { Rg8uint },
+        TexelFormat::Rg8sint => quote! { Rg8sint },
+        TexelFormat::Rg16unorm => quote! { Rg16unorm },
+        TexelFormat::Rg16snorm => quote! { Rg16snorm },
+        TexelFormat::Rg16uint => quote! { Rg16uint },
+        TexelFormat::Rg16sint => quote! { Rg16sint },
+        TexelFormat::Rg16float => quote! { Rg16float },
+        TexelFormat::R8unorm => quote! { R8unorm },
+        TexelFormat::R8snorm => quote! { R8snorm },
+        TexelFormat::R8uint => quote! { R8uint },
+        TexelFormat::R8sint => quote! { R8sint },
+        TexelFormat::R16unorm => quote! { R16unorm },
+        TexelFormat::R16snorm => quote! { R16snorm },
+        TexelFormat::R16uint => quote! { R16uint },
+        TexelFormat::R16sint => quote! { R16sint },
+        TexelFormat::R16float => quote! { R16float },
+        TexelFormat::Rgb10a2unorm => quote! { Rgb10a2unorm },
+        TexelFormat::Rgb10a2uint => quote! { Rgb10a2uint },
+        TexelFormat::Rg11b10ufloat => quote! { Rg11b10ufloat },
+    }
+}
+
+/// Convert a StorageTextureAccess to the corresponding Rust marker type.
+fn storage_access_to_rust_type(access: StorageTextureAccess) -> proc_macro2::TokenStream {
+    match access {
+        StorageTextureAccess::Read => quote! { Read },
+        StorageTextureAccess::Write => quote! { Write },
+        StorageTextureAccess::ReadWrite => quote! { ReadWrite },
     }
 }
 

--- a/crates/wgsl-rs/src/lib.rs
+++ b/crates/wgsl-rs/src/lib.rs
@@ -186,7 +186,21 @@ impl Source {
         let mut out = String::new();
         let mut visited_sources: HashSet<u64> = HashSet::new();
         let mut seen: HashSet<(u64, String, Vec<String>, Vec<String>)> = HashSet::new();
-        self.collect(&mut out, &mut visited_sources, &mut seen, None)?;
+        let mut needs_tier1 = false;
+        self.collect(
+            &mut out,
+            &mut visited_sources,
+            &mut seen,
+            None,
+            &mut needs_tier1,
+        )?;
+        // WGSL requires `enable` directives at the very start of the
+        // translation unit, before any other declarations. Since `collect`
+        // assembles multiple modules / instantiations by concatenation, we
+        // prepend the directive here after all chunks have been rendered.
+        if needs_tier1 {
+            out.insert_str(0, "enable texture_formats_tier1;\n\n");
+        }
         Ok(out)
     }
 
@@ -207,11 +221,12 @@ impl Source {
         visited_sources: &mut HashSet<u64>,
         seen: &mut HashSet<(u64, String, Vec<String>, Vec<String>)>,
         subst: Option<&HashMap<String, ir::Type>>,
+        needs_tier1: &mut bool,
     ) -> Result<(), SourceError<'_>> {
         // 1. Imports first (depth-first, deduplicated by source ID).
         for m in self.imports {
             if visited_sources.insert(m.id) {
-                m.collect(out, visited_sources, seen, None)?;
+                m.collect(out, visited_sources, seen, None, needs_tier1)?;
             }
         }
 
@@ -219,6 +234,9 @@ impl Source {
         let mut ir_module = (self.ir_constructor)();
         if let Some(s) = subst {
             ir::substitute_types(&mut ir_module, s);
+        }
+        if ir::items_need_tier1_extension(&ir_module.items) {
+            *needs_tier1 = true;
         }
         out.push_str(&ir::render_module(&ir_module));
 
@@ -245,6 +263,7 @@ impl Source {
                 &const_args,
                 out,
                 seen,
+                needs_tier1,
             )?;
         }
         Ok(())
@@ -269,6 +288,7 @@ fn instantiate_template_into<'a>(
     const_args: &[u32],
     out: &mut String,
     seen: &mut HashSet<(u64, String, Vec<String>, Vec<String>)>,
+    needs_tier1: &mut bool,
 ) -> Result<(), SourceError<'a>> {
     let available_templates: Vec<String> = sources
         .iter()
@@ -352,6 +372,7 @@ fn instantiate_template_into<'a>(
             const_args,
             out,
             seen,
+            needs_tier1,
         )?;
     }
 
@@ -393,6 +414,9 @@ fn instantiate_template_into<'a>(
         ir::rename_items(&mut items, template.name, &instance_name);
     }
 
+    if ir::items_need_tier1_extension(&items) {
+        *needs_tier1 = true;
+    }
     out.push_str(&ir::render_items(&items));
     Ok(())
 }

--- a/crates/wgsl-rs/src/linkage/wgpu.rs
+++ b/crates/wgsl-rs/src/linkage/wgpu.rs
@@ -452,6 +452,9 @@ pub enum BindingKind {
     Texture,
     /// A depth texture.
     DepthTexture,
+    /// A storage texture. The `read_write` flag distinguishes
+    /// `read_write` access from `read`-only or `write`-only.
+    StorageTexture { read_write: bool },
 }
 
 impl BindGroupInfo {
@@ -1351,6 +1354,7 @@ fn texture_layout_entry(item: &ir::ItemTexture) -> (wgpu::BindGroupLayoutEntry, 
     let view_dimension = match &item.ty {
         ir::Type::Texture { kind, .. } => texture_kind_view_dimension(*kind),
         ir::Type::TextureDepth { kind } => texture_depth_view_dimension(*kind),
+        ir::Type::TextureStorage { kind, .. } => texture_storage_kind_view_dimension(*kind),
         _ => unreachable!("ItemTexture validated to be a texture type"),
     };
     let multisampled = match &item.ty {
@@ -1358,6 +1362,7 @@ fn texture_layout_entry(item: &ir::ItemTexture) -> (wgpu::BindGroupLayoutEntry, 
         ir::Type::TextureDepth { kind } => {
             matches!(kind, ir::TextureDepthKind::DepthMultisampled2D)
         }
+        ir::Type::TextureStorage { .. } => false,
         _ => unreachable!(),
     };
     match &item.ty {
@@ -1395,7 +1400,85 @@ fn texture_layout_entry(item: &ir::ItemTexture) -> (wgpu::BindGroupLayoutEntry, 
             },
             BindingKind::DepthTexture,
         ),
+        ir::Type::TextureStorage { format, access, .. } => {
+            let wgpu_format = texel_format_to_wgpu(*format);
+            let wgpu_access = match access {
+                ir::StorageTextureAccess::Read => wgpu::StorageTextureAccess::ReadOnly,
+                ir::StorageTextureAccess::Write => wgpu::StorageTextureAccess::WriteOnly,
+                ir::StorageTextureAccess::ReadWrite => wgpu::StorageTextureAccess::ReadWrite,
+            };
+            let read_write = matches!(access, ir::StorageTextureAccess::ReadWrite);
+            (
+                wgpu::BindGroupLayoutEntry {
+                    binding: item.binding,
+                    visibility: wgpu::ShaderStages::all(),
+                    ty: wgpu::BindingType::StorageTexture {
+                        access: wgpu_access,
+                        format: wgpu_format,
+                        view_dimension,
+                    },
+                    count: None,
+                },
+                BindingKind::StorageTexture { read_write },
+            )
+        }
         _ => unreachable!(),
+    }
+}
+
+fn texture_storage_kind_view_dimension(kind: ir::TextureStorageKind) -> wgpu::TextureViewDimension {
+    match kind {
+        ir::TextureStorageKind::Storage1D => wgpu::TextureViewDimension::D1,
+        ir::TextureStorageKind::Storage2D => wgpu::TextureViewDimension::D2,
+        ir::TextureStorageKind::Storage2DArray => wgpu::TextureViewDimension::D2Array,
+        ir::TextureStorageKind::Storage3D => wgpu::TextureViewDimension::D3,
+    }
+}
+
+/// Map an IR texel format to the corresponding wgpu texture format.
+fn texel_format_to_wgpu(f: ir::TexelFormat) -> wgpu::TextureFormat {
+    use ir::TexelFormat::*;
+    match f {
+        Rgba8unorm => wgpu::TextureFormat::Rgba8Unorm,
+        Rgba8snorm => wgpu::TextureFormat::Rgba8Snorm,
+        Rgba8uint => wgpu::TextureFormat::Rgba8Uint,
+        Rgba8sint => wgpu::TextureFormat::Rgba8Sint,
+        Rgba16uint => wgpu::TextureFormat::Rgba16Uint,
+        Rgba16sint => wgpu::TextureFormat::Rgba16Sint,
+        Rgba16float => wgpu::TextureFormat::Rgba16Float,
+        R32uint => wgpu::TextureFormat::R32Uint,
+        R32sint => wgpu::TextureFormat::R32Sint,
+        R32float => wgpu::TextureFormat::R32Float,
+        Rg32uint => wgpu::TextureFormat::Rg32Uint,
+        Rg32sint => wgpu::TextureFormat::Rg32Sint,
+        Rg32float => wgpu::TextureFormat::Rg32Float,
+        Rgba32uint => wgpu::TextureFormat::Rgba32Uint,
+        Rgba32sint => wgpu::TextureFormat::Rgba32Sint,
+        Rgba32float => wgpu::TextureFormat::Rgba32Float,
+        Bgra8unorm => wgpu::TextureFormat::Bgra8Unorm,
+        Rgba16unorm => wgpu::TextureFormat::Rgba16Unorm,
+        Rgba16snorm => wgpu::TextureFormat::Rgba16Snorm,
+        Rg8unorm => wgpu::TextureFormat::Rg8Unorm,
+        Rg8snorm => wgpu::TextureFormat::Rg8Snorm,
+        Rg8uint => wgpu::TextureFormat::Rg8Uint,
+        Rg8sint => wgpu::TextureFormat::Rg8Sint,
+        Rg16unorm => wgpu::TextureFormat::Rg16Unorm,
+        Rg16snorm => wgpu::TextureFormat::Rg16Snorm,
+        Rg16uint => wgpu::TextureFormat::Rg16Uint,
+        Rg16sint => wgpu::TextureFormat::Rg16Sint,
+        Rg16float => wgpu::TextureFormat::Rg16Float,
+        R8unorm => wgpu::TextureFormat::R8Unorm,
+        R8snorm => wgpu::TextureFormat::R8Snorm,
+        R8uint => wgpu::TextureFormat::R8Uint,
+        R8sint => wgpu::TextureFormat::R8Sint,
+        R16unorm => wgpu::TextureFormat::R16Unorm,
+        R16snorm => wgpu::TextureFormat::R16Snorm,
+        R16uint => wgpu::TextureFormat::R16Uint,
+        R16sint => wgpu::TextureFormat::R16Sint,
+        R16float => wgpu::TextureFormat::R16Float,
+        Rgb10a2unorm => wgpu::TextureFormat::Rgb10a2Unorm,
+        Rgb10a2uint => wgpu::TextureFormat::Rgb10a2Uint,
+        Rg11b10ufloat => wgpu::TextureFormat::Rg11b10Ufloat,
     }
 }
 
@@ -1487,6 +1570,7 @@ fn type_layout(ty: &ir::Type, module: &ir::Module) -> TypeLayout {
         | ir::Type::SamplerComparison
         | ir::Type::Texture { .. }
         | ir::Type::TextureDepth { .. }
+        | ir::Type::TextureStorage { .. }
         | ir::Type::TypeParam { .. }
         | ir::Type::Phantom { .. } => TypeLayout { size: 0, align: 1 },
     }

--- a/crates/wgsl-rs/src/std.rs
+++ b/crates/wgsl-rs/src/std.rs
@@ -467,6 +467,9 @@ impl Uniform<WgslTypeVariable> {
 /// Marker type for read-only access-mode.
 pub struct Read;
 
+/// Marker type for write-only access-mode.
+pub struct Write;
+
 /// Marker type for readwrite access-mode.
 pub struct ReadWrite;
 

--- a/crates/wgsl-rs/src/std/texture.rs
+++ b/crates/wgsl-rs/src/std/texture.rs
@@ -14,6 +14,8 @@ use crate::std::{
     WgslTextureScalar, vec2f, vec2u, vec3u, vec4f, vec4i, vec4u,
 };
 
+use std::marker::PhantomData;
+
 mod builtins;
 pub use builtins::*;
 use wgsl_rs_ir as ir;
@@ -2294,6 +2296,270 @@ impl TextureDimensionsQuery for TextureDepthMultisampled2D {
 impl TextureNumSamplesQuery for TextureDepthMultisampled2D {
     fn query_num_samples(&self) -> u32 {
         self.get().num_samples()
+    }
+}
+
+// ===== Storage textures =====
+
+/// Trait for texel format marker types used as the type parameter of
+/// storage texture types (e.g. `TextureStorage2D<Rgba8unorm, Write>`).
+///
+/// Each implementor is a unit struct that carries the IR-level format and
+/// the shader-side value type (always `vec4<f32>`, `vec4<u32>`, or
+/// `vec4<i32>` depending on the format's channel type — see WGSL §6.6.1).
+pub trait WgslTexelFormat: crate::std::AnySendSync {
+    /// The IR-level texel format.
+    fn to_ir() -> wgsl_rs_ir::TexelFormat;
+    /// The shader-side value type returned by `textureLoad` and accepted by
+    /// `textureStore` for this format.
+    type Value: Copy + Default;
+    /// Whether this format requires the `texture_formats_tier1` extension.
+    fn requires_tier1() -> bool;
+}
+
+/// Trait for storage texture access mode marker types (`Read`, `Write`,
+/// `ReadWrite`).
+pub trait WgslStorageAccess: crate::std::AnySendSync {
+    /// The IR-level access mode.
+    fn to_ir() -> wgsl_rs_ir::StorageTextureAccess;
+}
+
+// ===== Access mode markers =====
+
+/// Read-only storage texture access mode. WGSL §14.2.
+#[allow(dead_code)]
+pub struct Read;
+impl WgslStorageAccess for Read {
+    fn to_ir() -> wgsl_rs_ir::StorageTextureAccess {
+        wgsl_rs_ir::StorageTextureAccess::Read
+    }
+}
+
+/// Write-only storage texture access mode. WGSL §14.2.
+#[allow(dead_code)]
+pub struct Write;
+impl WgslStorageAccess for Write {
+    fn to_ir() -> wgsl_rs_ir::StorageTextureAccess {
+        wgsl_rs_ir::StorageTextureAccess::Write
+    }
+}
+
+/// Read-write storage texture access mode. WGSL §14.2.
+#[allow(dead_code)]
+pub struct ReadWrite;
+impl WgslStorageAccess for ReadWrite {
+    fn to_ir() -> wgsl_rs_ir::StorageTextureAccess {
+        wgsl_rs_ir::StorageTextureAccess::ReadWrite
+    }
+}
+
+// ===== Texel format marker types =====
+
+// This macro generates a unit-struct marker type + WgslTexelFormat impl for
+// each storage texel format. The `Value` associated type is chosen based on
+// the channel format's shader type (f32/u32/i32) per WGSL §6.6.1.
+macro_rules! impl_texel_format {
+    ($i:ident, $v:ty, $tier1:expr) => {
+        /// Texel format marker.
+        #[allow(dead_code)]
+        pub struct $i;
+        impl WgslTexelFormat for $i {
+            fn to_ir() -> wgsl_rs_ir::TexelFormat {
+                wgsl_rs_ir::TexelFormat::$i
+            }
+            type Value = $v;
+            fn requires_tier1() -> bool {
+                $tier1
+            }
+        }
+    };
+}
+
+// Core formats (no extension required)
+impl_texel_format!(Rgba8unorm, Vec4f, false);
+impl_texel_format!(Rgba8snorm, Vec4f, false);
+impl_texel_format!(Rgba8uint, Vec4u, false);
+impl_texel_format!(Rgba8sint, Vec4i, false);
+impl_texel_format!(Rgba16uint, Vec4u, false);
+impl_texel_format!(Rgba16sint, Vec4i, false);
+impl_texel_format!(Rgba16float, Vec4f, false);
+impl_texel_format!(R32uint, Vec4u, false);
+impl_texel_format!(R32sint, Vec4i, false);
+impl_texel_format!(R32float, Vec4f, false);
+impl_texel_format!(Rg32uint, Vec4u, false);
+impl_texel_format!(Rg32sint, Vec4i, false);
+impl_texel_format!(Rg32float, Vec4f, false);
+impl_texel_format!(Rgba32uint, Vec4u, false);
+impl_texel_format!(Rgba32sint, Vec4i, false);
+impl_texel_format!(Rgba32float, Vec4f, false);
+impl_texel_format!(Bgra8unorm, Vec4f, false);
+// Tier-1 extension formats
+impl_texel_format!(Rgba16unorm, Vec4f, true);
+impl_texel_format!(Rgba16snorm, Vec4f, true);
+impl_texel_format!(Rg8unorm, Vec4f, true);
+impl_texel_format!(Rg8snorm, Vec4f, true);
+impl_texel_format!(Rg8uint, Vec4u, true);
+impl_texel_format!(Rg8sint, Vec4i, true);
+impl_texel_format!(Rg16unorm, Vec4f, true);
+impl_texel_format!(Rg16snorm, Vec4f, true);
+impl_texel_format!(Rg16uint, Vec4u, true);
+impl_texel_format!(Rg16sint, Vec4i, true);
+impl_texel_format!(Rg16float, Vec4f, true);
+impl_texel_format!(R8unorm, Vec4f, true);
+impl_texel_format!(R8snorm, Vec4f, true);
+impl_texel_format!(R8uint, Vec4u, true);
+impl_texel_format!(R8sint, Vec4i, true);
+impl_texel_format!(R16unorm, Vec4f, true);
+impl_texel_format!(R16snorm, Vec4f, true);
+impl_texel_format!(R16uint, Vec4u, true);
+impl_texel_format!(R16sint, Vec4i, true);
+impl_texel_format!(R16float, Vec4f, true);
+impl_texel_format!(Rgb10a2unorm, Vec4f, true);
+impl_texel_format!(Rgb10a2uint, Vec4u, true);
+impl_texel_format!(Rg11b10ufloat, Vec4f, true);
+
+// ===== Storage texture structs =====
+
+/// A 1D storage texture. WGSL `texture_storage_1d<F, A>`.
+///
+/// Parameterized by a texel format marker (`F`) and an access mode marker
+/// (`A`). See WGSL §6.6.5.
+pub struct TextureStorage1D<F: WgslTexelFormat, A: WgslStorageAccess> {
+    group: u32,
+    binding: u32,
+    _phantom: PhantomData<(F, A)>,
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> Wgsl for TextureStorage1D<F, A> {
+    fn to_ir() -> wgsl_rs_ir::Type {
+        wgsl_rs_ir::Type::TextureStorage {
+            kind: wgsl_rs_ir::TextureStorageKind::Storage1D,
+            format: F::to_ir(),
+            access: A::to_ir(),
+        }
+    }
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage1D<F, A> {
+    pub const fn new(group: u32, binding: u32) -> Self {
+        Self {
+            group,
+            binding,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn group(&self) -> u32 {
+        self.group
+    }
+
+    pub fn binding(&self) -> u32 {
+        self.binding
+    }
+}
+
+/// A 2D storage texture. WGSL `texture_storage_2d<F, A>`.
+pub struct TextureStorage2D<F: WgslTexelFormat, A: WgslStorageAccess> {
+    group: u32,
+    binding: u32,
+    _phantom: PhantomData<(F, A)>,
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> Wgsl for TextureStorage2D<F, A> {
+    fn to_ir() -> wgsl_rs_ir::Type {
+        wgsl_rs_ir::Type::TextureStorage {
+            kind: wgsl_rs_ir::TextureStorageKind::Storage2D,
+            format: F::to_ir(),
+            access: A::to_ir(),
+        }
+    }
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage2D<F, A> {
+    pub const fn new(group: u32, binding: u32) -> Self {
+        Self {
+            group,
+            binding,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn group(&self) -> u32 {
+        self.group
+    }
+
+    pub fn binding(&self) -> u32 {
+        self.binding
+    }
+}
+
+/// A 2D array storage texture. WGSL `texture_storage_2d_array<F, A>`.
+pub struct TextureStorage2DArray<F: WgslTexelFormat, A: WgslStorageAccess> {
+    group: u32,
+    binding: u32,
+    _phantom: PhantomData<(F, A)>,
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> Wgsl for TextureStorage2DArray<F, A> {
+    fn to_ir() -> wgsl_rs_ir::Type {
+        wgsl_rs_ir::Type::TextureStorage {
+            kind: wgsl_rs_ir::TextureStorageKind::Storage2DArray,
+            format: F::to_ir(),
+            access: A::to_ir(),
+        }
+    }
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage2DArray<F, A> {
+    pub const fn new(group: u32, binding: u32) -> Self {
+        Self {
+            group,
+            binding,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn group(&self) -> u32 {
+        self.group
+    }
+
+    pub fn binding(&self) -> u32 {
+        self.binding
+    }
+}
+
+/// A 3D storage texture. WGSL `texture_storage_3d<F, A>`.
+pub struct TextureStorage3D<F: WgslTexelFormat, A: WgslStorageAccess> {
+    group: u32,
+    binding: u32,
+    _phantom: PhantomData<(F, A)>,
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> Wgsl for TextureStorage3D<F, A> {
+    fn to_ir() -> wgsl_rs_ir::Type {
+        wgsl_rs_ir::Type::TextureStorage {
+            kind: wgsl_rs_ir::TextureStorageKind::Storage3D,
+            format: F::to_ir(),
+            access: A::to_ir(),
+        }
+    }
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage3D<F, A> {
+    pub const fn new(group: u32, binding: u32) -> Self {
+        Self {
+            group,
+            binding,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn group(&self) -> u32 {
+        self.group
+    }
+
+    pub fn binding(&self) -> u32 {
+        self.binding
     }
 }
 

--- a/crates/wgsl-rs/src/std/texture.rs
+++ b/crates/wgsl-rs/src/std/texture.rs
@@ -2312,7 +2312,10 @@ pub trait WgslTexelFormat: crate::std::AnySendSync {
     fn to_ir() -> wgsl_rs_ir::TexelFormat;
     /// The shader-side value type returned by `textureLoad` and accepted by
     /// `textureStore` for this format.
-    type Value: Copy + Default;
+    type Value: Copy + Default + Into<[Self::Scalar; 4]> + From<[Self::Scalar; 4]>;
+    /// The scalar element type (`f32`, `u32`, or `i32`) underlying
+    /// [`Value`](Self::Value). Used for CPU-side storage.
+    type Scalar: Copy + Default + crate::std::AnySendSync;
     /// Whether this format requires the `texture_formats_tier1` extension.
     fn requires_tier1() -> bool;
 }
@@ -2324,34 +2327,37 @@ pub trait WgslStorageAccess: crate::std::AnySendSync {
     fn to_ir() -> wgsl_rs_ir::StorageTextureAccess;
 }
 
-// ===== Access mode markers =====
+/// Marker trait for access modes that allow reading (`Read`, `ReadWrite`).
+pub trait ReadableStorageAccess: WgslStorageAccess {}
+/// Marker trait for access modes that allow writing (`Write`, `ReadWrite`).
+pub trait WritableStorageAccess: WgslStorageAccess {}
 
-/// Read-only storage texture access mode. WGSL §14.2.
-#[allow(dead_code)]
-pub struct Read;
-impl WgslStorageAccess for Read {
+// ===== Access mode trait impls =====
+// The `Read`, `Write`, and `ReadWrite` marker types are defined in
+// `std.rs` (shared with storage buffer access modes). Here we implement
+// the storage-texture-specific traits on them.
+
+impl WgslStorageAccess for crate::std::Read {
     fn to_ir() -> wgsl_rs_ir::StorageTextureAccess {
         wgsl_rs_ir::StorageTextureAccess::Read
     }
 }
+impl ReadableStorageAccess for crate::std::Read {}
 
-/// Write-only storage texture access mode. WGSL §14.2.
-#[allow(dead_code)]
-pub struct Write;
-impl WgslStorageAccess for Write {
+impl WgslStorageAccess for crate::std::Write {
     fn to_ir() -> wgsl_rs_ir::StorageTextureAccess {
         wgsl_rs_ir::StorageTextureAccess::Write
     }
 }
+impl WritableStorageAccess for crate::std::Write {}
 
-/// Read-write storage texture access mode. WGSL §14.2.
-#[allow(dead_code)]
-pub struct ReadWrite;
-impl WgslStorageAccess for ReadWrite {
+impl WgslStorageAccess for crate::std::ReadWrite {
     fn to_ir() -> wgsl_rs_ir::StorageTextureAccess {
         wgsl_rs_ir::StorageTextureAccess::ReadWrite
     }
 }
+impl ReadableStorageAccess for crate::std::ReadWrite {}
+impl WritableStorageAccess for crate::std::ReadWrite {}
 
 // ===== Texel format marker types =====
 
@@ -2359,7 +2365,7 @@ impl WgslStorageAccess for ReadWrite {
 // each storage texel format. The `Value` associated type is chosen based on
 // the channel format's shader type (f32/u32/i32) per WGSL §6.6.1.
 macro_rules! impl_texel_format {
-    ($i:ident, $v:ty, $tier1:expr) => {
+    ($i:ident, $val:ty, $scalar:ty, $tier1:expr) => {
         /// Texel format marker.
         #[allow(dead_code)]
         pub struct $i;
@@ -2367,7 +2373,8 @@ macro_rules! impl_texel_format {
             fn to_ir() -> wgsl_rs_ir::TexelFormat {
                 wgsl_rs_ir::TexelFormat::$i
             }
-            type Value = $v;
+            type Value = $val;
+            type Scalar = $scalar;
             fn requires_tier1() -> bool {
                 $tier1
             }
@@ -2376,47 +2383,47 @@ macro_rules! impl_texel_format {
 }
 
 // Core formats (no extension required)
-impl_texel_format!(Rgba8unorm, Vec4f, false);
-impl_texel_format!(Rgba8snorm, Vec4f, false);
-impl_texel_format!(Rgba8uint, Vec4u, false);
-impl_texel_format!(Rgba8sint, Vec4i, false);
-impl_texel_format!(Rgba16uint, Vec4u, false);
-impl_texel_format!(Rgba16sint, Vec4i, false);
-impl_texel_format!(Rgba16float, Vec4f, false);
-impl_texel_format!(R32uint, Vec4u, false);
-impl_texel_format!(R32sint, Vec4i, false);
-impl_texel_format!(R32float, Vec4f, false);
-impl_texel_format!(Rg32uint, Vec4u, false);
-impl_texel_format!(Rg32sint, Vec4i, false);
-impl_texel_format!(Rg32float, Vec4f, false);
-impl_texel_format!(Rgba32uint, Vec4u, false);
-impl_texel_format!(Rgba32sint, Vec4i, false);
-impl_texel_format!(Rgba32float, Vec4f, false);
-impl_texel_format!(Bgra8unorm, Vec4f, false);
+impl_texel_format!(Rgba8unorm, Vec4f, f32, false);
+impl_texel_format!(Rgba8snorm, Vec4f, f32, false);
+impl_texel_format!(Rgba8uint, Vec4u, u32, false);
+impl_texel_format!(Rgba8sint, Vec4i, i32, false);
+impl_texel_format!(Rgba16uint, Vec4u, u32, false);
+impl_texel_format!(Rgba16sint, Vec4i, i32, false);
+impl_texel_format!(Rgba16float, Vec4f, f32, false);
+impl_texel_format!(R32uint, Vec4u, u32, false);
+impl_texel_format!(R32sint, Vec4i, i32, false);
+impl_texel_format!(R32float, Vec4f, f32, false);
+impl_texel_format!(Rg32uint, Vec4u, u32, false);
+impl_texel_format!(Rg32sint, Vec4i, i32, false);
+impl_texel_format!(Rg32float, Vec4f, f32, false);
+impl_texel_format!(Rgba32uint, Vec4u, u32, false);
+impl_texel_format!(Rgba32sint, Vec4i, i32, false);
+impl_texel_format!(Rgba32float, Vec4f, f32, false);
+impl_texel_format!(Bgra8unorm, Vec4f, f32, false);
 // Tier-1 extension formats
-impl_texel_format!(Rgba16unorm, Vec4f, true);
-impl_texel_format!(Rgba16snorm, Vec4f, true);
-impl_texel_format!(Rg8unorm, Vec4f, true);
-impl_texel_format!(Rg8snorm, Vec4f, true);
-impl_texel_format!(Rg8uint, Vec4u, true);
-impl_texel_format!(Rg8sint, Vec4i, true);
-impl_texel_format!(Rg16unorm, Vec4f, true);
-impl_texel_format!(Rg16snorm, Vec4f, true);
-impl_texel_format!(Rg16uint, Vec4u, true);
-impl_texel_format!(Rg16sint, Vec4i, true);
-impl_texel_format!(Rg16float, Vec4f, true);
-impl_texel_format!(R8unorm, Vec4f, true);
-impl_texel_format!(R8snorm, Vec4f, true);
-impl_texel_format!(R8uint, Vec4u, true);
-impl_texel_format!(R8sint, Vec4i, true);
-impl_texel_format!(R16unorm, Vec4f, true);
-impl_texel_format!(R16snorm, Vec4f, true);
-impl_texel_format!(R16uint, Vec4u, true);
-impl_texel_format!(R16sint, Vec4i, true);
-impl_texel_format!(R16float, Vec4f, true);
-impl_texel_format!(Rgb10a2unorm, Vec4f, true);
-impl_texel_format!(Rgb10a2uint, Vec4u, true);
-impl_texel_format!(Rg11b10ufloat, Vec4f, true);
+impl_texel_format!(Rgba16unorm, Vec4f, f32, true);
+impl_texel_format!(Rgba16snorm, Vec4f, f32, true);
+impl_texel_format!(Rg8unorm, Vec4f, f32, true);
+impl_texel_format!(Rg8snorm, Vec4f, f32, true);
+impl_texel_format!(Rg8uint, Vec4u, u32, true);
+impl_texel_format!(Rg8sint, Vec4i, i32, true);
+impl_texel_format!(Rg16unorm, Vec4f, f32, true);
+impl_texel_format!(Rg16snorm, Vec4f, f32, true);
+impl_texel_format!(Rg16uint, Vec4u, u32, true);
+impl_texel_format!(Rg16sint, Vec4i, i32, true);
+impl_texel_format!(Rg16float, Vec4f, f32, true);
+impl_texel_format!(R8unorm, Vec4f, f32, true);
+impl_texel_format!(R8snorm, Vec4f, f32, true);
+impl_texel_format!(R8uint, Vec4u, u32, true);
+impl_texel_format!(R8sint, Vec4i, i32, true);
+impl_texel_format!(R16unorm, Vec4f, f32, true);
+impl_texel_format!(R16snorm, Vec4f, f32, true);
+impl_texel_format!(R16uint, Vec4u, u32, true);
+impl_texel_format!(R16sint, Vec4i, i32, true);
+impl_texel_format!(R16float, Vec4f, f32, true);
+impl_texel_format!(Rgb10a2unorm, Vec4f, f32, true);
+impl_texel_format!(Rgb10a2uint, Vec4u, u32, true);
+impl_texel_format!(Rg11b10ufloat, Vec4f, f32, true);
 
 // ===== Storage texture structs =====
 
@@ -2427,7 +2434,8 @@ impl_texel_format!(Rg11b10ufloat, Vec4f, true);
 pub struct TextureStorage1D<F: WgslTexelFormat, A: WgslStorageAccess> {
     group: u32,
     binding: u32,
-    _phantom: PhantomData<(F, A)>,
+    data: ModuleVar<TextureData1D<F::Scalar>>,
+    _phantom: PhantomData<A>,
 }
 
 impl<F: WgslTexelFormat, A: WgslStorageAccess> Wgsl for TextureStorage1D<F, A> {
@@ -2445,6 +2453,7 @@ impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage1D<F, A> {
         Self {
             group,
             binding,
+            data: ModuleVar::new(),
             _phantom: PhantomData,
         }
     }
@@ -2456,13 +2465,33 @@ impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage1D<F, A> {
     pub fn binding(&self) -> u32 {
         self.binding
     }
+
+    /// Returns a reference to the inner texture data.
+    ///
+    /// Not available in WGSL.
+    pub fn get(&self) -> ModuleVarReadGuard<'_, TextureData1D<F::Scalar>> {
+        self.data.read()
+    }
+
+    /// Set the texture data.
+    ///
+    /// Not available in WGSL.
+    pub fn set(&self, data: TextureData1D<F::Scalar>) {
+        self.data.set(data);
+    }
+
+    /// Initialize the texture with the given width.
+    pub fn init(&self, width: u32) {
+        self.set(TextureData1D::new(width));
+    }
 }
 
 /// A 2D storage texture. WGSL `texture_storage_2d<F, A>`.
 pub struct TextureStorage2D<F: WgslTexelFormat, A: WgslStorageAccess> {
     group: u32,
     binding: u32,
-    _phantom: PhantomData<(F, A)>,
+    data: ModuleVar<TextureData2D<F::Scalar>>,
+    _phantom: PhantomData<A>,
 }
 
 impl<F: WgslTexelFormat, A: WgslStorageAccess> Wgsl for TextureStorage2D<F, A> {
@@ -2480,6 +2509,7 @@ impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage2D<F, A> {
         Self {
             group,
             binding,
+            data: ModuleVar::new(),
             _phantom: PhantomData,
         }
     }
@@ -2491,13 +2521,41 @@ impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage2D<F, A> {
     pub fn binding(&self) -> u32 {
         self.binding
     }
+
+    /// Returns a reference to the inner texture data.
+    ///
+    /// Not available in WGSL.
+    pub fn get(&self) -> ModuleVarReadGuard<'_, TextureData2D<F::Scalar>> {
+        self.data.read()
+    }
+
+    /// Set the texture data.
+    ///
+    /// Not available in WGSL.
+    pub fn set(&self, data: TextureData2D<F::Scalar>) {
+        self.data.set(data);
+    }
+
+    /// Initialize the texture with the given dimensions.
+    pub fn init(&self, width: u32, height: u32) {
+        self.set(TextureData2D::new(width, height));
+    }
+
+    /// Set a pixel value on the CPU side.
+    ///
+    /// Not available in WGSL.
+    pub fn set_pixel(&self, x: u32, y: u32, value: F::Value) {
+        let mut data = self.data.write();
+        data.set_pixel(x, y, 0, value.into());
+    }
 }
 
 /// A 2D array storage texture. WGSL `texture_storage_2d_array<F, A>`.
 pub struct TextureStorage2DArray<F: WgslTexelFormat, A: WgslStorageAccess> {
     group: u32,
     binding: u32,
-    _phantom: PhantomData<(F, A)>,
+    data: ModuleVar<TextureData2DArray<F::Scalar>>,
+    _phantom: PhantomData<A>,
 }
 
 impl<F: WgslTexelFormat, A: WgslStorageAccess> Wgsl for TextureStorage2DArray<F, A> {
@@ -2515,6 +2573,7 @@ impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage2DArray<F, A> {
         Self {
             group,
             binding,
+            data: ModuleVar::new(),
             _phantom: PhantomData,
         }
     }
@@ -2526,13 +2585,33 @@ impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage2DArray<F, A> {
     pub fn binding(&self) -> u32 {
         self.binding
     }
+
+    /// Returns a reference to the inner texture data.
+    ///
+    /// Not available in WGSL.
+    pub fn get(&self) -> ModuleVarReadGuard<'_, TextureData2DArray<F::Scalar>> {
+        self.data.read()
+    }
+
+    /// Set the texture data.
+    ///
+    /// Not available in WGSL.
+    pub fn set(&self, data: TextureData2DArray<F::Scalar>) {
+        self.data.set(data);
+    }
+
+    /// Initialize the texture with the given dimensions and layer count.
+    pub fn init(&self, width: u32, height: u32, layers: u32) {
+        self.set(TextureData2DArray::new(width, height, layers));
+    }
 }
 
 /// A 3D storage texture. WGSL `texture_storage_3d<F, A>`.
 pub struct TextureStorage3D<F: WgslTexelFormat, A: WgslStorageAccess> {
     group: u32,
     binding: u32,
-    _phantom: PhantomData<(F, A)>,
+    data: ModuleVar<TextureData3D<F::Scalar>>,
+    _phantom: PhantomData<A>,
 }
 
 impl<F: WgslTexelFormat, A: WgslStorageAccess> Wgsl for TextureStorage3D<F, A> {
@@ -2550,6 +2629,7 @@ impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage3D<F, A> {
         Self {
             group,
             binding,
+            data: ModuleVar::new(),
             _phantom: PhantomData,
         }
     }
@@ -2561,11 +2641,291 @@ impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureStorage3D<F, A> {
     pub fn binding(&self) -> u32 {
         self.binding
     }
+
+    /// Returns a reference to the inner texture data.
+    ///
+    /// Not available in WGSL.
+    pub fn get(&self) -> ModuleVarReadGuard<'_, TextureData3D<F::Scalar>> {
+        self.data.read()
+    }
+
+    /// Set the texture data.
+    ///
+    /// Not available in WGSL.
+    pub fn set(&self, data: TextureData3D<F::Scalar>) {
+        self.data.set(data);
+    }
+
+    /// Initialize the texture with the given dimensions.
+    pub fn init(&self, width: u32, height: u32, depth: u32) {
+        self.set(TextureData3D::new(width, height, depth));
+    }
+}
+
+// ===== Trait impls: TextureLoadStorage (read / read_write) =====
+
+impl<F, A> TextureLoadStorage<u32> for TextureStorage1D<F, A>
+where
+    F: WgslTexelFormat,
+    A: ReadableStorageAccess,
+{
+    type Output = F::Value;
+
+    fn load_storage(&self, coords: u32) -> Self::Output {
+        self.get()
+            .get_pixel(coords, 0)
+            .map(|p| F::Value::from(*p))
+            .unwrap_or_default()
+    }
+}
+
+impl<F, A> TextureLoadStorage<i32> for TextureStorage1D<F, A>
+where
+    F: WgslTexelFormat,
+    A: ReadableStorageAccess,
+{
+    type Output = F::Value;
+
+    fn load_storage(&self, coords: i32) -> Self::Output {
+        let x = coords.max(0) as u32;
+        self.get()
+            .get_pixel(x, 0)
+            .map(|p| F::Value::from(*p))
+            .unwrap_or_default()
+    }
+}
+
+impl<F, A> TextureLoadStorage<Vec2u> for TextureStorage2D<F, A>
+where
+    F: WgslTexelFormat,
+    A: ReadableStorageAccess,
+{
+    type Output = F::Value;
+
+    fn load_storage(&self, coords: Vec2u) -> Self::Output {
+        self.get()
+            .get_pixel(coords.x(), coords.y(), 0)
+            .map(|p| F::Value::from(*p))
+            .unwrap_or_default()
+    }
+}
+
+impl<F, A> TextureLoadStorage<Vec2i> for TextureStorage2D<F, A>
+where
+    F: WgslTexelFormat,
+    A: ReadableStorageAccess,
+{
+    type Output = F::Value;
+
+    fn load_storage(&self, coords: Vec2i) -> Self::Output {
+        let x = coords.x().max(0) as u32;
+        let y = coords.y().max(0) as u32;
+        self.get()
+            .get_pixel(x, y, 0)
+            .map(|p| F::Value::from(*p))
+            .unwrap_or_default()
+    }
+}
+
+impl<F, A> TextureLoadStorageArray<Vec2u, u32> for TextureStorage2DArray<F, A>
+where
+    F: WgslTexelFormat,
+    A: ReadableStorageAccess,
+{
+    type Output = F::Value;
+
+    fn load_storage_array(&self, coords: Vec2u, array_index: u32) -> Self::Output {
+        let data = self.get();
+        data.layers
+            .get(array_index as usize)
+            .and_then(|layer| layer.get_pixel(coords.x(), coords.y(), 0))
+            .map(|p| F::Value::from(*p))
+            .unwrap_or_default()
+    }
+}
+
+impl<F, A> TextureLoadStorageArray<Vec2i, i32> for TextureStorage2DArray<F, A>
+where
+    F: WgslTexelFormat,
+    A: ReadableStorageAccess,
+{
+    type Output = F::Value;
+
+    fn load_storage_array(&self, coords: Vec2i, array_index: i32) -> Self::Output {
+        let x = coords.x().max(0) as u32;
+        let y = coords.y().max(0) as u32;
+        let layer = array_index.max(0) as u32;
+        let data = self.get();
+        data.layers
+            .get(layer as usize)
+            .and_then(|l| l.get_pixel(x, y, 0))
+            .map(|p| F::Value::from(*p))
+            .unwrap_or_default()
+    }
+}
+
+impl<F, A> TextureLoadStorage<Vec3u> for TextureStorage3D<F, A>
+where
+    F: WgslTexelFormat,
+    A: ReadableStorageAccess,
+{
+    type Output = F::Value;
+
+    fn load_storage(&self, coords: Vec3u) -> Self::Output {
+        let data = self.get();
+        data.mips
+            .first()
+            .and_then(|mip| mip.get(coords.z() as usize))
+            .and_then(|slice| slice.get(coords.y() as usize))
+            .and_then(|row| row.get(coords.x() as usize))
+            .map(|p| F::Value::from(*p))
+            .unwrap_or_default()
+    }
+}
+
+// ===== Trait impls: TextureStore (write / read_write) =====
+
+impl<F, A> TextureStore<u32, F::Value> for TextureStorage1D<F, A>
+where
+    F: WgslTexelFormat,
+    A: WritableStorageAccess,
+{
+    fn store(&self, coords: u32, value: F::Value) {
+        self.data.write().set_pixel(coords, 0, value.into());
+    }
+}
+
+impl<F, A> TextureStore<i32, F::Value> for TextureStorage1D<F, A>
+where
+    F: WgslTexelFormat,
+    A: WritableStorageAccess,
+{
+    fn store(&self, coords: i32, value: F::Value) {
+        let x = coords.max(0) as u32;
+        self.data.write().set_pixel(x, 0, value.into());
+    }
+}
+
+impl<F, A> TextureStore<Vec2u, F::Value> for TextureStorage2D<F, A>
+where
+    F: WgslTexelFormat,
+    A: WritableStorageAccess,
+{
+    fn store(&self, coords: Vec2u, value: F::Value) {
+        self.data
+            .write()
+            .set_pixel(coords.x(), coords.y(), 0, value.into());
+    }
+}
+
+impl<F, A> TextureStore<Vec2i, F::Value> for TextureStorage2D<F, A>
+where
+    F: WgslTexelFormat,
+    A: WritableStorageAccess,
+{
+    fn store(&self, coords: Vec2i, value: F::Value) {
+        let x = coords.x().max(0) as u32;
+        let y = coords.y().max(0) as u32;
+        self.data.write().set_pixel(x, y, 0, value.into());
+    }
+}
+
+impl<F, A> TextureStoreArray<Vec2u, u32, F::Value> for TextureStorage2DArray<F, A>
+where
+    F: WgslTexelFormat,
+    A: WritableStorageAccess,
+{
+    fn store_array(&self, coords: Vec2u, array_index: u32, value: F::Value) {
+        let mut data = self.data.write();
+        if let Some(layer) = data.layers.get_mut(array_index as usize) {
+            layer.set_pixel(coords.x(), coords.y(), 0, value.into());
+        }
+    }
+}
+
+impl<F, A> TextureStoreArray<Vec2i, i32, F::Value> for TextureStorage2DArray<F, A>
+where
+    F: WgslTexelFormat,
+    A: WritableStorageAccess,
+{
+    fn store_array(&self, coords: Vec2i, array_index: i32, value: F::Value) {
+        let x = coords.x().max(0) as u32;
+        let y = coords.y().max(0) as u32;
+        let layer = array_index.max(0) as u32;
+        let mut data = self.data.write();
+        if let Some(l) = data.layers.get_mut(layer as usize) {
+            l.set_pixel(x, y, 0, value.into());
+        }
+    }
+}
+
+impl<F, A> TextureStore<Vec3u, F::Value> for TextureStorage3D<F, A>
+where
+    F: WgslTexelFormat,
+    A: WritableStorageAccess,
+{
+    fn store(&self, coords: Vec3u, value: F::Value) {
+        let mut data = self.data.write();
+        if let Some(mip) = data.mips.first_mut()
+            && let Some(slice) = mip.get_mut(coords.z() as usize)
+            && let Some(row) = slice.get_mut(coords.y() as usize)
+            && let Some(pixel) = row.get_mut(coords.x() as usize)
+        {
+            *pixel = value.into();
+        }
+    }
+}
+
+// ===== Trait impls: TextureDimensionsQuery =====
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureDimensionsQuery for TextureStorage1D<F, A> {
+    type Output = u32;
+
+    fn query_dimensions(&self, _level: u32) -> Self::Output {
+        self.get().width(0)
+    }
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureDimensionsQuery for TextureStorage2D<F, A> {
+    type Output = Vec2u;
+
+    fn query_dimensions(&self, _level: u32) -> Self::Output {
+        let (w, h) = self.get().dimensions(0);
+        vec2u(w, h)
+    }
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureDimensionsQuery
+    for TextureStorage2DArray<F, A>
+{
+    type Output = Vec2u;
+
+    fn query_dimensions(&self, _level: u32) -> Self::Output {
+        let (w, h) = self.get().dimensions(0);
+        vec2u(w, h)
+    }
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureNumLayersQuery
+    for TextureStorage2DArray<F, A>
+{
+    fn query_num_layers(&self) -> u32 {
+        self.get().num_layers()
+    }
+}
+
+impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureDimensionsQuery for TextureStorage3D<F, A> {
+    type Output = Vec3u;
+
+    fn query_dimensions(&self, _level: u32) -> Self::Output {
+        let (w, h, d) = self.get().dimensions(0);
+        vec3u(w, h, d)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::std::{vec2f, vec2i};
+    use crate::std::{ReadWrite, Write, vec2f, vec2i};
 
     use super::*;
 
@@ -3253,5 +3613,96 @@ mod tests {
         let result =
             texture_sample_compare_level_offset(&tex, &sampler, vec2f(0.5, 0.5), 0.3, vec2i(0, 0));
         assert!((result - 1.0).abs() < 0.001); // 0.3 < 0.5 => pass
+    }
+
+    #[test]
+    fn test_storage_texture_2d_store_and_load() {
+        let tex: TextureStorage2D<Rgba8unorm, ReadWrite> = TextureStorage2D::new(0, 0);
+        tex.init(4, 4);
+
+        // Store a value
+        texture_store(&tex, vec2u(1, 2), vec4f(0.5, 0.25, 0.125, 1.0));
+
+        // Load it back
+        let pixel = texture_load_storage(&tex, vec2u(1, 2));
+        assert!((pixel.x() - 0.5).abs() < 0.001);
+        assert!((pixel.y() - 0.25).abs() < 0.001);
+        assert!((pixel.z() - 0.125).abs() < 0.001);
+        assert!((pixel.w() - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_storage_texture_2d_dimensions() {
+        let tex: TextureStorage2D<Rgba8unorm, Write> = TextureStorage2D::new(0, 0);
+        tex.init(8, 4);
+
+        let dims = texture_dimensions(&tex);
+        assert_eq!(dims.x(), 8);
+        assert_eq!(dims.y(), 4);
+    }
+
+    #[test]
+    fn test_storage_texture_2d_store_i32_coords() {
+        let tex: TextureStorage2D<Rgba8uint, ReadWrite> = TextureStorage2D::new(0, 0);
+        tex.init(4, 4);
+
+        texture_store(&tex, vec2i(1, 2), vec4u(10, 20, 30, 40));
+
+        let pixel = texture_load_storage(&tex, vec2u(1, 2));
+        assert_eq!(pixel.x(), 10);
+        assert_eq!(pixel.y(), 20);
+        assert_eq!(pixel.z(), 30);
+        assert_eq!(pixel.w(), 40);
+    }
+
+    #[test]
+    fn test_storage_texture_2d_array_store_and_load() {
+        let tex: TextureStorage2DArray<Rgba8sint, ReadWrite> = TextureStorage2DArray::new(0, 0);
+        tex.init(4, 4, 2);
+
+        texture_store_array(&tex, vec2u(1, 2), 0u32, vec4i(10, -20, 30, -40));
+        texture_store_array(&tex, vec2u(3, 0), 1u32, vec4i(100, 200, -300, 400));
+
+        let p0 = texture_load_storage_array(&tex, vec2u(1, 2), 0u32);
+        assert_eq!(p0.x(), 10);
+        assert_eq!(p0.y(), -20);
+        assert_eq!(p0.z(), 30);
+        assert_eq!(p0.w(), -40);
+
+        let p1 = texture_load_storage_array(&tex, vec2u(3, 0), 1u32);
+        assert_eq!(p1.x(), 100);
+        assert_eq!(p1.y(), 200);
+        assert_eq!(p1.z(), -300);
+        assert_eq!(p1.w(), 400);
+
+        assert_eq!(texture_num_layers(&tex), 2);
+    }
+
+    #[test]
+    fn test_storage_texture_3d_store_and_load() {
+        let tex: TextureStorage3D<Rgba32float, ReadWrite> = TextureStorage3D::new(0, 0);
+        tex.init(4, 4, 4);
+
+        texture_store(&tex, vec3u(1, 2, 3), vec4f(0.1, 0.2, 0.3, 0.4));
+
+        let pixel = texture_load_storage(&tex, vec3u(1, 2, 3));
+        assert!((pixel.x() - 0.1).abs() < 0.001);
+        assert!((pixel.y() - 0.2).abs() < 0.001);
+        assert!((pixel.z() - 0.3).abs() < 0.001);
+        assert!((pixel.w() - 0.4).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_storage_texture_1d_store_and_load() {
+        let tex: TextureStorage1D<Rgba8uint, ReadWrite> = TextureStorage1D::new(0, 0);
+        tex.init(8);
+
+        texture_store(&tex, 3u32, vec4u(10, 20, 30, 40));
+
+        let pixel = texture_load_storage(&tex, 3u32);
+        assert_eq!(pixel.x(), 10);
+        assert_eq!(pixel.y(), 20);
+        assert_eq!(pixel.z(), 30);
+        assert_eq!(pixel.w(), 40);
     }
 }

--- a/crates/wgsl-rs/src/std/texture/builtins.rs
+++ b/crates/wgsl-rs/src/std/texture/builtins.rs
@@ -1285,6 +1285,27 @@ pub trait TextureStoreArray<Coords, ArrayIndex, Value> {
     fn store_array(&self, coords: Coords, array_index: ArrayIndex, value: Value);
 }
 
+/// Trait for storage textures that support `textureLoad` (no mip level
+/// parameter, unlike [`TextureLoad`]). WGSL §17.7.4 storage overloads.
+pub trait TextureLoadStorage<Coords> {
+    /// The output type (`vec4<f32>`, `vec4<u32>`, or `vec4<i32>` depending on
+    /// the texel format).
+    type Output;
+
+    /// Load a texel at the given coordinates.
+    fn load_storage(&self, coords: Coords) -> Self::Output;
+}
+
+/// Trait for storage array textures that support `textureLoad` with array
+/// index (no mip level). WGSL §17.7.4 storage overloads.
+pub trait TextureLoadStorageArray<Coords, ArrayIndex> {
+    /// The output type.
+    type Output;
+
+    /// Load a texel at the given coordinates and array index.
+    fn load_storage_array(&self, coords: Coords, array_index: ArrayIndex) -> Self::Output;
+}
+
 /// Trait for types that can be used as texture coordinates.
 pub trait IntoCoord {
     fn into_i32(self) -> i32;
@@ -2152,6 +2173,37 @@ where
     T: TextureStoreArray<C, A, V>,
 {
     t.store_array(coords, array_index, value)
+}
+
+/// Reads a single texel from a storage texture without a mip level.
+///
+/// Unlike [`texture_load`], this overload takes no `level` parameter —
+/// storage textures have no mip levels (WGSL §17.7.4).
+///
+/// # WGSL Equivalent
+///
+/// ```wgsl
+/// let texel = textureLoad(my_storage_texture, coords);
+/// ```
+pub fn texture_load_storage<T, C>(t: &T, coords: C) -> T::Output
+where
+    T: TextureLoadStorage<C>,
+{
+    t.load_storage(coords)
+}
+
+/// Reads a single texel from a storage array texture without a mip level.
+///
+/// # WGSL Equivalent
+///
+/// ```wgsl
+/// let texel = textureLoad(my_storage_array_texture, coords, array_index);
+/// ```
+pub fn texture_load_storage_array<T, C, A>(t: &T, coords: C, array_index: A) -> T::Output
+where
+    T: TextureLoadStorageArray<C, A>,
+{
+    t.load_storage_array(coords, array_index)
 }
 
 /// Helper function for bilinear interpolation.

--- a/crates/wgsl-rs/tests/linkage_wgpu.rs
+++ b/crates/wgsl-rs/tests/linkage_wgpu.rs
@@ -496,6 +496,67 @@ fn analyze_texture_and_sampler_bindings() {
     ));
 }
 
+#[test]
+fn analyze_storage_texture_bindings() {
+    use wgsl_rs::ir::{StorageTextureAccess, TexelFormat, TextureStorageKind};
+
+    let ir_module = ir::Module {
+        name: "storage_tex",
+        items: vec![
+            ir::Item::Texture(ir::ItemTexture {
+                group: 0,
+                binding: 0,
+                name: "OUT_TEX".to_string(),
+                ty: ir::Type::TextureStorage {
+                    kind: TextureStorageKind::Storage2D,
+                    format: TexelFormat::Rgba8unorm,
+                    access: StorageTextureAccess::Write,
+                },
+                attrs: vec![],
+            }),
+            ir::Item::Texture(ir::ItemTexture {
+                group: 0,
+                binding: 1,
+                name: "IN_TEX".to_string(),
+                ty: ir::Type::TextureStorage {
+                    kind: TextureStorageKind::Storage2D,
+                    format: TexelFormat::Rgba8uint,
+                    access: StorageTextureAccess::Read,
+                },
+                attrs: vec![],
+            }),
+            ir::Item::Texture(ir::ItemTexture {
+                group: 0,
+                binding: 2,
+                name: "RW_TEX".to_string(),
+                ty: ir::Type::TextureStorage {
+                    kind: TextureStorageKind::Storage2D,
+                    format: TexelFormat::R32float,
+                    access: StorageTextureAccess::ReadWrite,
+                },
+                attrs: vec![],
+            }),
+        ],
+        attrs: vec![],
+    };
+    let linkage = ir_module.generate_linkage();
+    let bg = linkage.bind_group(0).unwrap();
+    assert_eq!(bg.bindings.len(), 3);
+
+    assert!(matches!(
+        bg.bindings[0].kind,
+        wg::BindingKind::StorageTexture { read_write: false }
+    ));
+    assert!(matches!(
+        bg.bindings[1].kind,
+        wg::BindingKind::StorageTexture { read_write: false }
+    ));
+    assert!(matches!(
+        bg.bindings[2].kind,
+        wg::BindingKind::StorageTexture { read_write: true }
+    ));
+}
+
 // ===== Storage access mode preserved =====
 
 #[test]


### PR DESCRIPTION
Add the four WGSL storage texture types (`texture_storage_1d`/`2d`/`2d_array`/`3d`), parameterized by texel format and access mode.

Closes #139.

## What

- **IR**: `Type::TextureStorage` variant with `TextureStorageKind`, `TexelFormat` (all ~30 formats from WGSL §6.6.1), `StorageTextureAccess` (`Read`/`Write`/`ReadWrite`)
- **Render**: auto-emits `enable texture_formats_tier1;` when tier-1 formats are present
- **Macro**: parses `TextureStorageND<Format, Access>` (e.g. `TextureStorage2D<Rgba8unorm, Write>`)
- **Runtime**: `TextureStorage1D`/`2D`/`2DArray`/`3D` structs with `WgslTexelFormat`/`WgslStorageAccess` trait markers
- **wgpu linkage**: maps to `BindingType::StorageTexture`
- **Tests**: 14 new (parse, IR render, wgpu linkage)

## Follow-up

`textureLoad`/`textureStore` trait impls on the new types + GPU roundtrip test tracked in beads (schell-bc3.4.10). A GitHub issue will be filed for that shortly.
