### PR TITLE
feat: allow non-pub associated consts in trait impls

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -554,3 +554,29 @@ need this, but downstream extensions that manipulate generic instantiations do.
 `std::marker::PhantomData<T>` continues to be rejected by the existing
 single-segment-path rule (a `use` import is required).
 
+### 2026-08-07: Trait-impl associated consts may omit `pub`
+
+Associated constants provided by a trait impl (`impl Trait for Type {
+const N: usize = 1; ... }`) are now accepted without a `pub` visibility
+qualifier, matching the relaxation already applied to trait-impl
+methods.
+
+**Problem:** Rust forbids `pub` on any item in a trait impl (`E0449:
+visibility qualifiers are not permitted here`), so trait-impl methods
+were long ago exempted from wgsl-rs's "impl items must be `pub`" rule
+(`ItemFn::try_from_impl_fn` gates the `pub` requirement on
+`!is_trait_impl`). The same exemption was never added for
+`ItemConst::try_from_impl_const`, which always required `pub`. The
+result: `impl SlabItem for u32 { const SLAB_SIZE: usize = 1; ... }`
+was unrepresentable — Rust rejects `pub`, wgsl-rs required `pub`.
+
+**Decision:** Thread `is_trait_impl` into `try_from_impl_const` and gate
+the `pub` requirement the same way `try_from_impl_fn` does. Inherent
+impl consts (`impl Type { pub const ... }`) are unchanged — they still
+require `pub`. The trait definition itself remains Rust-only passthrough
+(`Item::Trait` produces no WGSL); only the trait impl's const value is
+emitted, mangled to `Type_MEMBER` (escaped per `wgsl_rs_ir::mangle`
+when the member name contains underscores, e.g. `SLAB_SIZE` →
+`u32__1SLAB_SIZE`).
+
+

--- a/crates/wgsl-rs-macros/src/parse.rs
+++ b/crates/wgsl-rs-macros/src/parse.rs
@@ -4849,7 +4849,10 @@ impl ItemConst {
     ///
     /// This is similar to `TryFrom<&syn::ItemConst>` but handles the slightly
     /// different structure of `syn::ImplItemConst`.
-    pub fn try_from_impl_const(value: &syn::ImplItemConst) -> Result<Self, Error> {
+    pub fn try_from_impl_const(
+        value: &syn::ImplItemConst,
+        is_trait_impl: bool,
+    ) -> Result<Self, Error> {
         let syn::ImplItemConst {
             attrs,
             vis,
@@ -4871,13 +4874,17 @@ impl ItemConst {
             "default constants are not supported in WGSL",
         )?;
 
-        snafu::ensure!(
-            matches!(vis, syn::Visibility::Public(_)),
-            VisibilitySnafu {
-                span: const_token.span(),
-                item: "Impl constants"
-            }
-        );
+        // Trait impl consts have inherited visibility (no `pub` keyword), so
+        // we only require `pub` on inherent impl consts.
+        if !is_trait_impl {
+            snafu::ensure!(
+                matches!(vis, syn::Visibility::Public(_)),
+                VisibilitySnafu {
+                    span: const_token.span(),
+                    item: "Impl constants"
+                }
+            );
+        }
 
         // Reject generics on constants
         if !generics.params.is_empty() {
@@ -6200,7 +6207,7 @@ impl TryFrom<&syn::ItemImpl> for ItemImpl {
                     parsed_items.push(ImplItem::Fn(Box::new(item_fn)));
                 }
                 syn::ImplItem::Const(impl_const) => {
-                    let item_const = ItemConst::try_from_impl_const(impl_const)?;
+                    let item_const = ItemConst::try_from_impl_const(impl_const, is_trait_impl)?;
                     parsed_items.push(ImplItem::Const(Box::new(item_const)));
                 }
                 other => {
@@ -7368,6 +7375,35 @@ mod test {
     }
 
     #[test]
+    fn parse_trait_impl_with_const() {
+        // Trait impl items have inherited visibility (no `pub`), so an
+        // associated const provided by a trait impl must be accepted
+        // without `pub` — mirroring the existing relaxation for trait
+        // impl methods.
+        let item: syn::Item = syn::parse_quote! {
+            impl SomeTrait for Light {
+                const N: usize = 1;
+                fn foo() {}
+            }
+        };
+        let result = Item::try_from(&item).expect("trait impl with const should parse");
+        match &result {
+            Item::Impl(impl_item) => {
+                assert_eq!(2, impl_item.items.len());
+                match &impl_item.items[0] {
+                    ImplItem::Const(c) => assert_eq!(c.ident, "N"),
+                    _ => panic!("Expected ImplItem::Const"),
+                }
+                match &impl_item.items[1] {
+                    ImplItem::Fn(f) => assert_eq!(f.ident, "foo"),
+                    _ => panic!("Expected ImplItem::Fn"),
+                }
+            }
+            _ => panic!("Expected Item::Impl"),
+        }
+    }
+
+    #[test]
     fn parse_trait_impl_for_array_type() {
         let item: syn::Item = syn::parse_quote! {
             impl Zeroable for [u32; 4] {
@@ -7565,6 +7601,25 @@ mod test {
         assert!(
             wgsl.contains("const Light_INTENSITY"),
             "Expected 'const Light_INTENSITY' in WGSL output, got: {}",
+            wgsl
+        );
+    }
+
+    #[test]
+    fn trait_impl_const_generates_mangled_name() {
+        // Trait impl consts have no `pub` (Rust E0449 forbids it). The
+        // const should still render as `Type_MEMBER` at module scope,
+        // the same as an inherent impl const. `usize` is lowered to `u32`.
+        let item: syn::Item = syn::parse_quote! {
+            impl SomeTrait for u32 {
+                const N: usize = 1;
+            }
+        };
+        let item = Item::try_from(&item).unwrap();
+        let wgsl = item.to_wgsl();
+        assert!(
+            wgsl.contains("const u32_N: u32 = 1"),
+            "Expected 'const u32_N: u32 = 1' in WGSL output, got: {}",
             wgsl
         );
     }

--- a/crates/wgsl-rs/tests/trait_impl_consts.rs
+++ b/crates/wgsl-rs/tests/trait_impl_consts.rs
@@ -1,0 +1,51 @@
+//! Tests for associated constants provided by trait impls.
+//!
+//! Rust forbids `pub` on any item in a trait impl (`E0449`), so wgsl-rs
+//! must accept non-`pub` associated consts in trait impl blocks — the same
+//! relaxation already applied to trait-impl methods. These tests guard the
+//! `usize` case: `usize` is lowered to `u32` in WGSL.
+
+#![allow(dead_code)]
+
+use wgsl_rs::wgsl;
+
+#[wgsl(skip_validation)]
+mod trait_impl_const {
+    pub trait SlabItem {
+        const SLAB_SIZE: usize;
+        fn read_at(slab_index: u32) -> Self;
+    }
+
+    impl SlabItem for u32 {
+        const SLAB_SIZE: usize = 1;
+        fn read_at(slab_index: u32) -> u32 {
+            slab_index
+        }
+    }
+
+    pub fn caller() -> u32 {
+        u32::read_at(7u32)
+    }
+}
+
+#[test]
+fn trait_impl_const_transpiles() {
+    let src = trait_impl_const::WGSL_SOURCE.wgsl_source().unwrap();
+    // `SLAB_SIZE` contains one underscore, so the mangle pass escapes it as
+    // `_1SLAB_SIZE` (see `wgsl_rs_ir::mangle`). The full mangled const is
+    // `u32__1SLAB_SIZE`.
+    assert!(
+        src.contains("const u32__1SLAB_SIZE: u32 = 1"),
+        "expected 'const u32__1SLAB_SIZE: u32 = 1' in WGSL, got:\n{src}"
+    );
+    assert!(
+        src.contains("fn u32__1read_at"),
+        "expected 'fn u32__1read_at' in WGSL, got:\n{src}"
+    );
+}
+
+#[test]
+fn trait_impl_const_runs_on_cpu() {
+    assert_eq!(trait_impl_const::caller(), 7u32);
+    assert_eq!(<u32 as trait_impl_const::SlabItem>::SLAB_SIZE, 1);
+}


### PR DESCRIPTION
Allows `const N: usize = 1;` (no `pub`) in trait impl blocks, mirroring the existing relaxation for trait-impl methods.

## Why
Rust forbids `pub` on trait-impl items (E0449), but wgsl-rs required `pub` on all impl consts — so `impl Trait for Type { const N: usize = 1; ... }` was unrepresentable.

## What
- Thread `is_trait_impl` into `ItemConst::try_from_impl_const` and gate the `pub` requirement, mirroring `ItemFn::try_from_impl_fn`.
- Trait definitions stay Rust-only passthrough; only the trait impl's const value renders (mangled to `Type_MEMBER`).

## Tests
- `parse_trait_impl_with_const`, `trait_impl_const_generates_mangled_name` (parse-side)
- `tests/trait_impl_consts.rs` — full `#[wgsl]` module with `usize` associated const; asserts WGSL output + CPU behavior

`cargo xtask ci pr-check` passes (793 tests + 106 roundtrip).