### PR TITLE
Consolidate slab_read_array! and slab_write_array! into slab_copy!

### DIFF
--- a/crates/example/src/examples.rs
+++ b/crates/example/src/examples.rs
@@ -1404,7 +1404,7 @@ pub mod slab_read_write {
         {
             // Extract the u32 data from the slab
             let mut array_data = Data::array_container();
-            slab_read_array!(get!(SLAB), index, array_data, Data::SLAB_SIZE);
+            slab_copy!(get!(SLAB), index, array_data, 0, Data::SLAB_SIZE);
             data = Data::from_array(array_data);
         }
 
@@ -1413,7 +1413,7 @@ pub mod slab_read_write {
 
         // Write the modified `Data` struct back to the slab
         let out_array = Data::to_array(data);
-        slab_write_array!(get_mut!(SLAB), index, out_array, Data::SLAB_SIZE);
+        slab_copy!(out_array, 0, get_mut!(SLAB), index, Data::SLAB_SIZE);
     }
 }
 

--- a/crates/wgsl-rs-ir/src/render.rs
+++ b/crates/wgsl-rs-ir/src/render.rs
@@ -1097,10 +1097,11 @@ fn write_stmt(w: &mut Writer, s: &Stmt) {
             write_block(w, b);
             w.newline();
         }
-        Stmt::SlabRead {
-            slab,
-            offset,
+        Stmt::SlabCopy {
+            src,
+            src_offset,
             dest,
+            dest_offset,
             size,
         } => {
             w.start_line();
@@ -1111,43 +1112,13 @@ fn write_stmt(w: &mut Writer, s: &Stmt) {
             w.indent += 1;
             w.start_line();
             write_expr(w, dest);
-            w.write("[_i] = ");
-            write_expr(w, slab);
             w.write("[");
-            write_expr(w, offset);
-            w.write(" + _i];");
-            w.newline();
-            w.indent -= 1;
-            w.start_line();
-            w.write("}");
-            w.newline();
-        }
-        Stmt::SlabWrite {
-            slab,
-            offset,
-            src,
-            size,
-        } => {
-            w.start_line();
-            w.write("for (var _i: u32 = 0u; _i < ");
-            match size {
-                Some(sz) => write_expr(w, sz),
-                None => {
-                    w.write("arrayLength(&");
-                    write_expr(w, slab);
-                    w.write(")");
-                }
-            }
-            w.write("; _i++) {");
-            w.newline();
-            w.indent += 1;
-            w.start_line();
-            write_expr(w, slab);
-            w.write("[");
-            write_expr(w, offset);
+            write_expr(w, dest_offset);
             w.write(" + _i] = ");
             write_expr(w, src);
-            w.write("[_i];");
+            w.write("[");
+            write_expr(w, src_offset);
+            w.write(" + _i];");
             w.newline();
             w.indent -= 1;
             w.start_line();

--- a/crates/wgsl-rs-ir/src/substitute.rs
+++ b/crates/wgsl-rs-ir/src/substitute.rs
@@ -290,29 +290,18 @@ fn rename_stmt(s: &mut Stmt, from: &str, to: &str) {
             }
         }
         Stmt::Block(b) => rename_block(b, from, to),
-        Stmt::SlabRead {
-            slab,
-            offset,
-            dest,
-            size,
-        } => {
-            rename_expr(slab, from, to);
-            rename_expr(offset, from, to);
-            rename_expr(dest, from, to);
-            rename_expr(size, from, to);
-        }
-        Stmt::SlabWrite {
-            slab,
-            offset,
+        Stmt::SlabCopy {
             src,
+            src_offset,
+            dest,
+            dest_offset,
             size,
         } => {
-            rename_expr(slab, from, to);
-            rename_expr(offset, from, to);
             rename_expr(src, from, to);
-            if let Some(sz) = size {
-                rename_expr(sz, from, to);
-            }
+            rename_expr(src_offset, from, to);
+            rename_expr(dest, from, to);
+            rename_expr(dest_offset, from, to);
+            rename_expr(size, from, to);
         }
         Stmt::Macro { .. } => {}
     }
@@ -607,29 +596,18 @@ fn sub_stmt(st: &mut Stmt, s: &HashMap<String, Type>) {
             }
         }
         Stmt::Block(b) => sub_block(b, s),
-        Stmt::SlabRead {
-            slab,
-            offset,
-            dest,
-            size,
-        } => {
-            sub_expr(slab, s);
-            sub_expr(offset, s);
-            sub_expr(dest, s);
-            sub_expr(size, s);
-        }
-        Stmt::SlabWrite {
-            slab,
-            offset,
+        Stmt::SlabCopy {
             src,
+            src_offset,
+            dest,
+            dest_offset,
             size,
         } => {
-            sub_expr(slab, s);
-            sub_expr(offset, s);
             sub_expr(src, s);
-            if let Some(sz) = size {
-                sub_expr(sz, s);
-            }
+            sub_expr(src_offset, s);
+            sub_expr(dest, s);
+            sub_expr(dest_offset, s);
+            sub_expr(size, s);
         }
         Stmt::Macro { .. } => {}
     }
@@ -865,29 +843,18 @@ fn sub_stmt_const(st: &mut Stmt, consts: &HashMap<String, u32>) {
             }
         }
         Stmt::Block(b) => sub_block_const(b, consts),
-        Stmt::SlabRead {
-            slab,
-            offset,
-            dest,
-            size,
-        } => {
-            sub_expr_const(slab, consts);
-            sub_expr_const(offset, consts);
-            sub_expr_const(dest, consts);
-            sub_expr_const(size, consts);
-        }
-        Stmt::SlabWrite {
-            slab,
-            offset,
+        Stmt::SlabCopy {
             src,
+            src_offset,
+            dest,
+            dest_offset,
             size,
         } => {
-            sub_expr_const(slab, consts);
-            sub_expr_const(offset, consts);
             sub_expr_const(src, consts);
-            if let Some(sz) = size {
-                sub_expr_const(sz, consts);
-            }
+            sub_expr_const(src_offset, consts);
+            sub_expr_const(dest, consts);
+            sub_expr_const(dest_offset, consts);
+            sub_expr_const(size, consts);
         }
         Stmt::Macro { .. } => {}
     }

--- a/crates/wgsl-rs-ir/src/types.rs
+++ b/crates/wgsl-rs-ir/src/types.rs
@@ -694,30 +694,27 @@ pub enum Stmt {
     For(ForLoop),
     Switch(StmtSwitch),
     Block(Block),
-    /// Slab read: copy `size` elements from `slab[offset..]` into `dest`.
-    SlabRead {
-        slab: Expr,
-        offset: Expr,
-        dest: Expr,
-        size: Expr,
-    },
-    /// Slab write: copy elements from `src` into `slab[offset..]`. When
-    /// `size` is `None`, the loop bound is `arrayLength(&slab)`.
-    SlabWrite {
-        slab: Expr,
-        offset: Expr,
+    /// Slab copy: copy `size` elements from `src[src_offset..]` into
+    /// `dest[dest_offset..]`.
+    ///
+    /// This is the bidirectional consolidation of the former `SlabRead` and
+    /// `SlabWrite` variants. The renderer emits a WGSL `for` loop of the
+    /// form `dest[dest_offset + i] = src[src_offset + i]`.
+    SlabCopy {
         src: Expr,
-        size: Option<Expr>,
+        src_offset: Expr,
+        dest: Expr,
+        dest_offset: Expr,
+        size: Expr,
     },
     Discard,
     /// An unrecognized statement macro, preserved for extension lowering.
     ///
     /// When the `#[wgsl]` parser encounters a statement macro that is not
-    /// one of its builtins (`slab_read_array!`, `slab_write_array!`,
-    /// `discard!`), it emits this variant instead of rejecting the macro.
-    /// A `WgslExtension` (in the `wgsl-rs` crate) can then recognize the
-    /// macro by name in its `modify_ir` method and replace this statement
-    /// with lowered IR.
+    /// one of its builtins (`slab_copy!`, `discard!`), it emits this variant
+    /// instead of rejecting the macro. A `WgslExtension` (in the `wgsl-rs`
+    /// crate) can then recognize the macro by name in its `modify_ir`
+    /// method and replace this statement with lowered IR.
     ///
     /// The `#[wgsl]` macro emits a compile-time `const` check verifying
     /// that at least one listed extension claims the macro name via its

--- a/crates/wgsl-rs-ir/tests/smoke.rs
+++ b/crates/wgsl-rs-ir/tests/smoke.rs
@@ -356,7 +356,7 @@ fn fn_call_translates_builtin_names() {
 }
 
 #[test]
-fn slab_read_lowers_to_for_loop() {
+fn slab_copy_lowers_to_for_loop() {
     let m = Module {
         name: "t",
         items: vec![Item::Fn(ItemFn {
@@ -367,10 +367,11 @@ fn slab_read_lowers_to_for_loop() {
             inputs: vec![],
             return_type: ReturnType::Default,
             block: Block {
-                stmts: vec![Stmt::SlabRead {
-                    slab: ident("slab"),
-                    offset: ident("o"),
+                stmts: vec![Stmt::SlabCopy {
+                    src: ident("slab"),
+                    src_offset: ident("o"),
                     dest: ident("d"),
+                    dest_offset: lit_u(0),
                     size: lit_u(4),
                 }],
             },
@@ -383,7 +384,7 @@ fn slab_read_lowers_to_for_loop() {
         wgsl.contains("for (var _i: u32 = 0u; _i < 4u; _i++)"),
         "got: {wgsl}"
     );
-    assert!(wgsl.contains("d[_i] = slab[o + _i];"), "got: {wgsl}");
+    assert!(wgsl.contains("d[0u + _i] = slab[o + _i];"), "got: {wgsl}");
 }
 
 #[test]

--- a/crates/wgsl-rs-macros/src/builder.rs
+++ b/crates/wgsl-rs-macros/src/builder.rs
@@ -639,30 +639,17 @@ fn walk_expr_for_linkage_constraints(
                             // storage/uniform buffers); the parser rejects this.
             | Stmt::Discard { .. }
             | Stmt::Macro { .. } => {}
-            Stmt::SlabRead { slab, offset, dest, size, .. } => {
-                for expr in [slab, offset, dest, size] {
+            Stmt::SlabCopy {
+                src,
+                src_offset,
+                dest,
+                dest_offset,
+                size,
+                ..
+            } => {
+                for expr in [src, src_offset, dest, dest_offset, size] {
                     walk_expr_for_constraints_recursive(
                         expr,
-                        fn_name,
-                        is_entry_point,
-                        fn_type_params,
-                        constraints,
-                    );
-                }
-            }
-            Stmt::SlabWrite { slab, offset, src, size, .. } => {
-                for expr in [slab, offset, src] {
-                    walk_expr_for_constraints_recursive(
-                        expr,
-                        fn_name,
-                        is_entry_point,
-                        fn_type_params,
-                        constraints,
-                    );
-                }
-                if let Some(size_expr) = size {
-                    walk_expr_for_constraints_recursive(
-                        size_expr,
                         fn_name,
                         is_entry_point,
                         fn_type_params,

--- a/crates/wgsl-rs-macros/src/ir_convert.rs
+++ b/crates/wgsl-rs-macros/src/ir_convert.rs
@@ -849,29 +849,19 @@ fn stmt_from_parse(s: &parse::Stmt) -> Result<ir::Stmt> {
             has_explicit_default: s.has_explicit_default,
         }),
         parse::Stmt::Block(b) => ir::Stmt::Block(block_from_parse(b)?),
-        parse::Stmt::SlabRead {
-            slab,
-            offset,
-            dest,
-            size,
-            ..
-        } => ir::Stmt::SlabRead {
-            slab: expr_from_parse(slab)?,
-            offset: expr_from_parse(offset)?,
-            dest: expr_from_parse(dest)?,
-            size: expr_from_parse(size)?,
-        },
-        parse::Stmt::SlabWrite {
-            slab,
-            offset,
+        parse::Stmt::SlabCopy {
             src,
+            src_offset,
+            dest,
+            dest_offset,
             size,
             ..
-        } => ir::Stmt::SlabWrite {
-            slab: expr_from_parse(slab)?,
-            offset: expr_from_parse(offset)?,
+        } => ir::Stmt::SlabCopy {
             src: expr_from_parse(src)?,
-            size: size.as_ref().map(expr_from_parse).transpose()?,
+            src_offset: expr_from_parse(src_offset)?,
+            dest: expr_from_parse(dest)?,
+            dest_offset: expr_from_parse(dest_offset)?,
+            size: expr_from_parse(size)?,
         },
         parse::Stmt::Discard { .. } => ir::Stmt::Discard,
         parse::Stmt::Macro { name, args, .. } => ir::Stmt::Macro {

--- a/crates/wgsl-rs-macros/src/ir_emit.rs
+++ b/crates/wgsl-rs-macros/src/ir_emit.rs
@@ -1021,38 +1021,26 @@ fn stmt(p: &TokenStream, s: &ir::Stmt) -> TokenStream {
             let b = block(p, b);
             quote! { #p::Stmt::Block(#b) }
         }
-        ir::Stmt::SlabRead {
-            slab,
-            offset,
-            dest,
-            size,
-        } => {
-            let sl = expr(p, slab);
-            let o = expr(p, offset);
-            let d = expr(p, dest);
-            let s = expr(p, size);
-            quote! {
-                #p::Stmt::SlabRead { slab: #sl, offset: #o, dest: #d, size: #s }
-            }
-        }
-        ir::Stmt::SlabWrite {
-            slab,
-            offset,
+        ir::Stmt::SlabCopy {
             src,
+            src_offset,
+            dest,
+            dest_offset,
             size,
         } => {
-            let sl = expr(p, slab);
-            let o = expr(p, offset);
-            let sr = expr(p, src);
-            let s = match size {
-                Some(s) => {
-                    let s = expr(p, s);
-                    quote! { ::std::option::Option::Some(#s) }
-                }
-                None => quote! { ::std::option::Option::None },
-            };
+            let s = expr(p, src);
+            let so = expr(p, src_offset);
+            let d = expr(p, dest);
+            let do_ = expr(p, dest_offset);
+            let sz = expr(p, size);
             quote! {
-                #p::Stmt::SlabWrite { slab: #sl, offset: #o, src: #sr, size: #s }
+                #p::Stmt::SlabCopy {
+                    src: #s,
+                    src_offset: #so,
+                    dest: #d,
+                    dest_offset: #do_,
+                    size: #sz
+                }
             }
         }
         ir::Stmt::Discard => quote! { #p::Stmt::Discard },

--- a/crates/wgsl-rs-macros/src/lib.rs
+++ b/crates/wgsl-rs-macros/src/lib.rs
@@ -1270,16 +1270,19 @@ fn collect_macro_names_from_stmt(stmt: &parse::Stmt, names: &mut Vec<String>) {
 /// get_mut!(MY_BUFFER).field = 42;
 /// ```
 ///
-/// ## `slab_read_array!` / `slab_write_array!`
+/// ## `slab_copy!`
 ///
-/// Bulk read/write operations on storage buffer slabs.
+/// Bulk copy between a storage buffer slab and a local array (or between
+/// two arrays). Bidirectional: pass a slab as the first argument to read,
+/// or as the third argument to write.
 ///
 /// ```ignore
-/// slab_read_array!(get!(SLAB), offset, dest_array, count);
-/// slab_write_array!(get_mut!(SLAB), offset, src_array, count);
+/// slab_copy!(get!(SLAB), offset, dest_array, 0, count);
+/// slab_copy!(src_array, 0, get_mut!(SLAB), offset, count);
 /// ```
 ///
-/// These expand to indexed for-loops in WGSL.
+/// Expands to an indexed `for` loop in WGSL of the form
+/// `dest[dest_offset + i] = src[src_offset + i]`.
 ///
 /// # Warning Suppression
 ///

--- a/crates/wgsl-rs-macros/src/monomorphize.rs
+++ b/crates/wgsl-rs-macros/src/monomorphize.rs
@@ -2493,45 +2493,27 @@ fn resolve_assoc_in_stmt(stmt: &mut Stmt, index: &BTreeMap<(String, String), Typ
                 changed = true;
             }
         }
-        Stmt::SlabRead {
-            slab,
-            offset,
+        Stmt::SlabCopy {
+            src,
+            src_offset,
             dest,
+            dest_offset,
             size,
             ..
         } => {
-            if resolve_assoc_in_expr(slab, index) {
+            if resolve_assoc_in_expr(src, index) {
                 changed = true;
             }
-            if resolve_assoc_in_expr(offset, index) {
+            if resolve_assoc_in_expr(src_offset, index) {
                 changed = true;
             }
             if resolve_assoc_in_expr(dest, index) {
                 changed = true;
             }
+            if resolve_assoc_in_expr(dest_offset, index) {
+                changed = true;
+            }
             if resolve_assoc_in_expr(size, index) {
-                changed = true;
-            }
-        }
-        Stmt::SlabWrite {
-            slab,
-            offset,
-            src,
-            size,
-            ..
-        } => {
-            if resolve_assoc_in_expr(slab, index) {
-                changed = true;
-            }
-            if resolve_assoc_in_expr(offset, index) {
-                changed = true;
-            }
-            if resolve_assoc_in_expr(src, index) {
-                changed = true;
-            }
-            if let Some(s) = size
-                && resolve_assoc_in_expr(s, index)
-            {
                 changed = true;
             }
         }

--- a/crates/wgsl-rs-macros/src/parse.rs
+++ b/crates/wgsl-rs-macros/src/parse.rs
@@ -3187,11 +3187,14 @@ impl Local {
     }
 }
 
-/// Helper for parsing the four comma-separated arguments of `slab_read_array!`
-/// and `slab_write_array!` statement macros.
-struct SlabMacroArgs(syn::Expr, syn::Expr, syn::Expr, syn::Expr);
+/// Helper for parsing the five comma-separated arguments of `slab_copy!`:
+///
+/// ```ignore
+/// slab_copy!(src, src_offset, dest, dest_offset, size);
+/// ```
+struct SlabCopyMacroArgs(syn::Expr, syn::Expr, syn::Expr, syn::Expr, syn::Expr);
 
-impl Parse for SlabMacroArgs {
+impl Parse for SlabCopyMacroArgs {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let a = input.parse()?;
         input.parse::<Token![,]>()?;
@@ -3200,40 +3203,16 @@ impl Parse for SlabMacroArgs {
         let c = input.parse()?;
         input.parse::<Token![,]>()?;
         let d = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let e = input.parse()?;
         // Allow optional trailing comma
         let _ = input.parse::<Option<Token![,]>>();
-        Ok(SlabMacroArgs(a, b, c, d))
-    }
-}
-
-/// Helper for parsing the arguments of `slab_write_array!`, where the fourth
-/// (size) argument is optional:
-///
-/// ```ignore
-/// slab_write_array!(slab, offset, src, size);  // 4-arg form
-/// slab_write_array!(slab, offset, src);        // 3-arg form, size = arrayLength(&slab)
-/// ```
-struct SlabWriteMacroArgs(syn::Expr, syn::Expr, syn::Expr, Option<syn::Expr>);
-
-impl Parse for SlabWriteMacroArgs {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let a = input.parse()?;
-        input.parse::<Token![,]>()?;
-        let b = input.parse()?;
-        input.parse::<Token![,]>()?;
-        let c = input.parse()?;
-        let d = if input.parse::<Option<Token![,]>>()?.is_some() && !input.is_empty() {
-            Some(input.parse()?)
-        } else {
-            None
-        };
-        // Allow optional trailing comma
-        let _ = input.parse::<Option<Token![,]>>();
-        Ok(SlabWriteMacroArgs(a, b, c, d))
+        Ok(SlabCopyMacroArgs(a, b, c, d, e))
     }
 }
 
 #[derive(Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum Stmt {
     Local(Box<Local>),
     Const(Box<ItemConst>),
@@ -3297,25 +3276,18 @@ pub enum Stmt {
     ///
     /// Transpiles to a WGSL compound statement.
     Block(Block),
-    /// `slab_read_array!(slab, offset, dest, size);` -- copy from storage
-    /// buffer to local array.
-    SlabRead {
-        slab: Expr,
-        offset: Expr,
-        dest: Expr,
-        size: Expr,
-        span: Span,
-    },
-    /// `slab_write_array!(slab, offset, src, size);` -- copy from local array
-    /// to storage buffer.
+    /// `slab_copy!(src, src_offset, dest, dest_offset, size);` -- copy
+    /// `size` elements from `src[src_offset..]` to `dest[dest_offset..]`.
     ///
-    /// When `size` is `None` (3-arg form), the WGSL code generator emits
-    /// `arrayLength(&slab)` as the loop bound.
-    SlabWrite {
-        slab: Expr,
-        offset: Expr,
+    /// Bidirectional: pass a slab as `src` to read from a storage buffer
+    /// into a local array, or pass a slab as `dest` to write from a local
+    /// array into a storage buffer.
+    SlabCopy {
         src: Expr,
-        size: Option<Expr>,
+        src_offset: Expr,
+        dest: Expr,
+        dest_offset: Expr,
+        size: Expr,
         span: Span,
     },
     /// `discard!();` -- discard the current fragment (fragment shaders only).
@@ -3537,31 +3509,18 @@ impl Stmt {
                     .unwrap_or_default();
                 let span = mac.path.span();
                 match macro_name.as_str() {
-                    "slab_read_array" => {
-                        let args: SlabMacroArgs =
+                    "slab_copy" => {
+                        let args: SlabCopyMacroArgs =
                             syn::parse2(mac.tokens.clone()).map_err(|e| Error::Unsupported {
                                 span,
-                                note: format!("slab_read_array! parse error: {e}"),
+                                note: format!("slab_copy! parse error: {e}"),
                             })?;
-                        Ok(Stmt::SlabRead {
-                            slab: Expr::parse(&args.0, ctx)?,
-                            offset: Expr::parse(&args.1, ctx)?,
+                        Ok(Stmt::SlabCopy {
+                            src: Expr::parse(&args.0, ctx)?,
+                            src_offset: Expr::parse(&args.1, ctx)?,
                             dest: Expr::parse(&args.2, ctx)?,
-                            size: Expr::parse(&args.3, ctx)?,
-                            span,
-                        })
-                    }
-                    "slab_write_array" => {
-                        let args: SlabWriteMacroArgs =
-                            syn::parse2(mac.tokens.clone()).map_err(|e| Error::Unsupported {
-                                span,
-                                note: format!("slab_write_array! parse error: {e}"),
-                            })?;
-                        Ok(Stmt::SlabWrite {
-                            slab: Expr::parse(&args.0, ctx)?,
-                            offset: Expr::parse(&args.1, ctx)?,
-                            src: Expr::parse(&args.2, ctx)?,
-                            size: args.3.as_ref().map(|e| Expr::parse(e, ctx)).transpose()?,
+                            dest_offset: Expr::parse(&args.3, ctx)?,
+                            size: Expr::parse(&args.4, ctx)?,
                             span,
                         })
                     }
@@ -6849,31 +6808,19 @@ fn resolve_self_in_stmt(name: &Ident, stmt: &mut Stmt) {
                 resolve_self_in_block(name, &mut arm.body);
             }
         }
-        Stmt::SlabRead {
-            slab,
-            offset,
-            dest,
-            size,
-            ..
-        } => {
-            resolve_self_in_expr(name, slab);
-            resolve_self_in_expr(name, offset);
-            resolve_self_in_expr(name, dest);
-            resolve_self_in_expr(name, size);
-        }
-        Stmt::SlabWrite {
-            slab,
-            offset,
+        Stmt::SlabCopy {
             src,
+            src_offset,
+            dest,
+            dest_offset,
             size,
             ..
         } => {
-            resolve_self_in_expr(name, slab);
-            resolve_self_in_expr(name, offset);
             resolve_self_in_expr(name, src);
-            if let Some(size) = size {
-                resolve_self_in_expr(name, size);
-            }
+            resolve_self_in_expr(name, src_offset);
+            resolve_self_in_expr(name, dest);
+            resolve_self_in_expr(name, dest_offset);
+            resolve_self_in_expr(name, size);
         }
         Stmt::Macro { .. } => {}
     }
@@ -9770,17 +9717,17 @@ mod test {
         );
     }
 
-    // --- slab_read_array! / slab_write_array! statement macro tests ---
+    // --- slab_copy! statement macro tests ---
 
     #[test]
-    fn slab_read_parses_and_generates_wgsl() {
+    fn slab_copy_read_parses_and_generates_wgsl() {
         let stmt: syn::Stmt = syn::parse_quote! {
-            slab_read_array!(SLAB, offset, raw, 4);
+            slab_copy!(SLAB, offset, raw, 0, 4);
         };
         let stmt = Stmt::try_from(&stmt).unwrap();
         assert!(
-            matches!(&stmt, Stmt::SlabRead { .. }),
-            "Expected Stmt::SlabRead, got: {:#?}",
+            matches!(&stmt, Stmt::SlabCopy { .. }),
+            "Expected Stmt::SlabCopy, got: {:#?}",
             std::mem::discriminant(&stmt)
         );
         let wgsl = stmt.to_wgsl();
@@ -9790,21 +9737,22 @@ mod test {
             wgsl
         );
         assert!(
-            wgsl.contains("raw[_i] = SLAB[offset + _i];"),
+            wgsl.contains("raw[0u + _i] = SLAB[offset + _i];")
+                || wgsl.contains("raw[0 + _i] = SLAB[offset + _i];"),
             "Expected read body in WGSL, got: {}",
             wgsl
         );
     }
 
     #[test]
-    fn slab_write_parses_and_generates_wgsl() {
+    fn slab_copy_write_parses_and_generates_wgsl() {
         let stmt: syn::Stmt = syn::parse_quote! {
-            slab_write_array!(_arraySLAB, offset, arr, 4);
+            slab_copy!(arr, 0, _arraySLAB, offset, 4);
         };
         let stmt = Stmt::try_from(&stmt).unwrap();
         assert!(
-            matches!(&stmt, Stmt::SlabWrite { .. }),
-            "Expected Stmt::SlabWrite, got: {:#?}",
+            matches!(&stmt, Stmt::SlabCopy { .. }),
+            "Expected Stmt::SlabCopy, got: {:#?}",
             std::mem::discriminant(&stmt)
         );
         let wgsl = stmt.to_wgsl();
@@ -9814,16 +9762,17 @@ mod test {
             wgsl
         );
         assert!(
-            wgsl.contains("SLAB[offset + _i] = arr[_i];"),
+            wgsl.contains("SLAB[offset + _i] = arr[0u + _i];")
+                || wgsl.contains("SLAB[offset + _i] = arr[0 + _i];"),
             "Expected write body in WGSL, got: {}",
             wgsl
         );
     }
 
     #[test]
-    fn slab_read_with_get_macro_strips_get() {
+    fn slab_copy_read_with_get_macro_strips_get() {
         let stmt: syn::Stmt = syn::parse_quote! {
-            slab_read_array!(get!(SLAB), offset, raw, DATA_SIZE);
+            slab_copy!(get!(SLAB), offset, raw, 0, DATA_SIZE);
         };
         let stmt = Stmt::try_from(&stmt).unwrap();
         let wgsl = stmt.to_wgsl();
@@ -9836,9 +9785,9 @@ mod test {
     }
 
     #[test]
-    fn slab_write_with_get_mut_macro_strips_get_mut() {
+    fn slab_copy_write_with_get_mut_macro_strips_get_mut() {
         let stmt: syn::Stmt = syn::parse_quote! {
-            slab_write_array!(get_mut!(SLAB), offset, arr, DATA_SIZE);
+            slab_copy!(arr, 0, get_mut!(SLAB), offset, DATA_SIZE);
         };
         let stmt = Stmt::try_from(&stmt).unwrap();
         let wgsl = stmt.to_wgsl();
@@ -9851,32 +9800,9 @@ mod test {
     }
 
     #[test]
-    fn slab_write_three_arg_emits_array_length() {
+    fn slab_copy_read_with_const_size_emits_const_name() {
         let stmt: syn::Stmt = syn::parse_quote! {
-            slab_write_array!(get_mut!(SLAB), offset, arr);
-        };
-        let stmt = Stmt::try_from(&stmt).unwrap();
-        assert!(
-            matches!(&stmt, Stmt::SlabWrite { size: None, .. }),
-            "Expected Stmt::SlabWrite with size=None"
-        );
-        let wgsl = stmt.to_wgsl();
-        assert!(
-            wgsl.contains("_i < arrayLength(&SLAB)"),
-            "Expected arrayLength(&SLAB) as loop bound, got: {}",
-            wgsl
-        );
-        assert!(
-            wgsl.contains("SLAB[offset + _i] = arr[_i];"),
-            "Expected write body in WGSL, got: {}",
-            wgsl
-        );
-    }
-
-    #[test]
-    fn slab_read_with_const_size_emits_const_name() {
-        let stmt: syn::Stmt = syn::parse_quote! {
-            slab_read_array!(SLAB, id.inner, raw, MY_STRUCT_SLAB_SIZE);
+            slab_copy!(SLAB, id.inner, raw, 0, MY_STRUCT_SLAB_SIZE);
         };
         let stmt = Stmt::try_from(&stmt).unwrap();
         let wgsl = stmt.to_wgsl();

--- a/crates/wgsl-rs-macros/src/parse_visitor.rs
+++ b/crates/wgsl-rs-macros/src/parse_visitor.rs
@@ -260,31 +260,19 @@ pub(crate) fn walk_stmt<V: ParseVisitorMut + ?Sized>(v: &mut V, s: &mut Stmt) ->
         Stmt::Block(block) => {
             v.visit_block(block)?;
         }
-        Stmt::SlabRead {
-            slab,
-            offset,
-            dest,
-            size,
-            ..
-        } => {
-            v.visit_expr(slab)?;
-            v.visit_expr(offset)?;
-            v.visit_expr(dest)?;
-            v.visit_expr(size)?;
-        }
-        Stmt::SlabWrite {
-            slab,
-            offset,
+        Stmt::SlabCopy {
             src,
+            src_offset,
+            dest,
+            dest_offset,
             size,
             ..
         } => {
-            v.visit_expr(slab)?;
-            v.visit_expr(offset)?;
             v.visit_expr(src)?;
-            if let Some(s) = size {
-                v.visit_expr(s)?;
-            }
+            v.visit_expr(src_offset)?;
+            v.visit_expr(dest)?;
+            v.visit_expr(dest_offset)?;
+            v.visit_expr(size)?;
         }
         Stmt::Break { .. } | Stmt::Continue { .. } | Stmt::Discard { .. } | Stmt::Macro { .. } => {}
     }

--- a/crates/wgsl-rs/src/extension.rs
+++ b/crates/wgsl-rs/src/extension.rs
@@ -17,7 +17,7 @@
 //! # Statement macro lowering
 //!
 //! When the `#[wgsl]` parser encounters a statement macro that is not one of
-//! its builtins (`slab_read_array!`, `slab_write_array!`, `discard!`), it
+//! its builtins (`slab_copy!`, `discard!`), it
 //! passes it through as a [`crate::ir::Stmt::Macro`] variant instead of
 //! rejecting it. An extension can then recognize the macro by name in
 //! `modify_ir` and replace the `Stmt::Macro` with lowered IR.

--- a/crates/wgsl-rs/src/linkage/wgpu.rs
+++ b/crates/wgsl-rs/src/linkage/wgpu.rs
@@ -1075,29 +1075,18 @@ fn collect_idents_in_stmt(out: &mut std::collections::HashSet<String>, stmt: &ir
             }
         }
         ir::Stmt::Block(b) => collect_idents_in_block(out, b),
-        ir::Stmt::SlabRead {
-            slab,
-            offset,
-            dest,
-            size,
-        } => {
-            collect_idents_in_expr(out, slab);
-            collect_idents_in_expr(out, offset);
-            collect_idents_in_expr(out, dest);
-            collect_idents_in_expr(out, size);
-        }
-        ir::Stmt::SlabWrite {
-            slab,
-            offset,
+        ir::Stmt::SlabCopy {
             src,
+            src_offset,
+            dest,
+            dest_offset,
             size,
         } => {
-            collect_idents_in_expr(out, slab);
-            collect_idents_in_expr(out, offset);
             collect_idents_in_expr(out, src);
-            if let Some(s) = size {
-                collect_idents_in_expr(out, s);
-            }
+            collect_idents_in_expr(out, src_offset);
+            collect_idents_in_expr(out, dest);
+            collect_idents_in_expr(out, dest_offset);
+            collect_idents_in_expr(out, size);
         }
         ir::Stmt::Break
         | ir::Stmt::Continue

--- a/crates/wgsl-rs/src/std.rs
+++ b/crates/wgsl-rs/src/std.rs
@@ -30,7 +30,7 @@ pub use wgsl_rs_macros::{
     wgsl_ignore, workgroup, workgroup_size,
 };
 
-pub use crate::{discard, get, get_mut, slab_read_array, slab_write_array};
+pub use crate::{discard, get, get_mut, slab_copy};
 
 mod atomic;
 mod bitcast;
@@ -640,58 +640,30 @@ macro_rules! get_mut {
     };
 }
 
-/// Copy `$size` elements from `$slab` starting at `$offset` into `$dst`.
+/// Copy `$size` elements from `$src` starting at `$src_offset` into `$dest`
+/// starting at `$dest_offset`.
 ///
 /// On the GPU side (inside `#[wgsl]` modules), this emits a WGSL `for` loop
-/// that copies from a storage buffer into a local `array<u32, N>`.
+/// of the form `dest[dest_offset + i] = src[src_offset + i]`.
 ///
 /// On the CPU side, this is a simple element-by-element copy.
+///
+/// The macro is bidirectional: pass the slab as `$src` to read from a storage
+/// buffer into a local array, or pass the slab as `$dest` to write from a
+/// local array into a storage buffer.
 ///
 /// # Example
 /// ```ignore
 /// let mut raw = [0u32; 4];
-/// slab_read_array!(get!(SLAB), offset, raw, 4);
+/// slab_copy!(get!(SLAB), offset, raw, 0, 4);
 /// ```
 #[macro_export]
-macro_rules! slab_read_array {
-    ($slab:expr, $offset:expr, $dst:expr, $size:expr) => {{
-        let offset = $offset as usize;
+macro_rules! slab_copy {
+    ($src:expr, $src_offset:expr, $dest:expr, $dest_offset:expr, $size:expr) => {{
+        let src_offset = $src_offset as usize;
+        let dest_offset = $dest_offset as usize;
         for i in 0..$size as usize {
-            $dst[i] = $slab[offset + i];
-        }
-    }};
-}
-
-/// Copy `$size` elements from `$src` into `$slab` starting at `$offset`.
-///
-/// On the GPU side (inside `#[wgsl]` modules), this emits a WGSL `for` loop
-/// that copies from a local `array<u32, N>` into a storage buffer.
-///
-/// On the CPU side, this is a simple element-by-element copy.
-///
-/// # Example
-/// ```ignore
-/// let arr = [1u32, 2, 3, 4];
-/// slab_write_array!(get_mut!(SLAB), offset, arr, 4);
-/// ```
-///
-/// The last parameter is optional. When omitted, the proc-macro emits
-/// `arrayLength(&slab)` as the loop bound in WGSL. On the CPU side, this
-/// form uses the source array's `.len()`:
-/// ```ignore
-/// let arr = [1u32, 2, 3, 4];
-/// slab_write_array!(get_mut!(SLAB), offset, arr);
-/// ```
-#[macro_export]
-macro_rules! slab_write_array {
-    ($slab:expr, $offset:expr, $src:expr) => {
-        slab_write_array!($slab, $offset, $src, $src.len())
-    };
-
-    ($slab:expr, $offset:expr, $src:expr, $size:expr) => {{
-        let offset = $offset as usize;
-        for i in 0..$size as usize {
-            $slab[offset + i] = $src[i];
+            $dest[dest_offset + i] = $src[src_offset + i];
         }
     }};
 }


### PR DESCRIPTION
Replaces the two unidirectional slab copy macros with a single bidirectional `slab_copy!(src, src_offset, dest, dest_offset, size)`.

The former macros had different parameter orders and one had an optional 3-arg `arrayLength` form. The unified macro takes 5 required args and copies `dest[dest_offset + i] = src[src_offset + i]` for `i in 0..size`:

- Read: `slab_copy!(get!(SLAB), index, local, 0, SIZE)`
- Write: `slab_copy!(local, 0, get_mut!(SLAB), index, SIZE)`

Drops the 3-arg `arrayLength` convenience form (only one test used it, no examples or external call sites did). Adds `#[allow(clippy::large_enum_variant)]` on the parse `Stmt` enum since the 5-field `SlabCopy` variant tips it over clippy's 200-byte threshold — the enum is a short-lived parse-tree type so the size is not perf-sensitive.

All 246 macro tests, 17 GPU tests, and 107 roundtrip tests pass.