### PR TITLE
fix: render uninitialized `let x: f32;` as `var` in WGSL (#148)

### DIFF
--- a/crates/wgsl-rs-ir/src/types.rs
+++ b/crates/wgsl-rs-ir/src/types.rs
@@ -599,8 +599,9 @@ pub enum Expr {
 /// A `let` / `var` / `const` initializer.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Local {
-    /// `true` when this should render as `var` (Rust `let mut`); `false`
-    /// for `let` (Rust `let`).
+    /// `true` when this should render as `var` (Rust `let mut`, or
+    /// uninitialized `let` — WGSL `let` requires an initializer);
+    /// `false` for `let` (Rust `let` with initializer).
     pub mutable: bool,
     pub name: String,
     pub ty: Option<Type>,

--- a/crates/wgsl-rs-macros/src/ir_convert.rs
+++ b/crates/wgsl-rs-macros/src/ir_convert.rs
@@ -784,7 +784,10 @@ pub fn block_from_parse(b: &parse::Block) -> Result<ir::Block> {
 fn stmt_from_parse(s: &parse::Stmt) -> Result<ir::Stmt> {
     Ok(match s {
         parse::Stmt::Local(l) => ir::Stmt::Local(ir::Local {
-            mutable: l.mutability.is_some(),
+            // WGSL `let` requires an initializer; `var` does not (defaults to
+            // zero value). So an uninitialized `let x: f32;` must render as
+            // `var` to be valid WGSL. See issue #148.
+            mutable: l.mutability.is_some() || l.init.is_none(),
             name: l.ident.to_string(),
             ty: l.ty.as_ref().map(|(_, t)| ty_from_parse(t)).transpose()?,
             init: l

--- a/crates/wgsl-rs-macros/src/parse.rs
+++ b/crates/wgsl-rs-macros/src/parse.rs
@@ -3095,7 +3095,9 @@ impl LocalInit {
 pub struct Local {
     pub let_token: Token![let],
     /// If `mutability` is `Some`, this is a `var` binding, otherwise this is a
-    /// `let` binding.
+    /// `let` binding. Note: an uninitialized `let x: f32;` (no `mut`, no init)
+    /// is rendered as `var` in WGSL, because WGSL `let` requires an
+    /// initializer. See issue #148.
     pub mutability: Option<Token![mut]>,
     pub ident: Ident,
     pub ty: Option<(Token![:], Type)>,
@@ -8938,6 +8940,44 @@ mod test {
         assert!(
             wgsl.contains("x += 1u;"),
             "Expected 'x += 1u;' in WGSL output, got: {}",
+            wgsl
+        );
+    }
+
+    #[test]
+    fn uninit_let_renders_as_var() {
+        let item: syn::Item = syn::parse_quote! {
+            pub fn f() {
+                let x: f32;
+                x = 1.0;
+            }
+        };
+        let item = Item::try_from(&item).unwrap();
+        let wgsl = item.to_wgsl();
+        assert!(
+            wgsl.contains("var x: f32;"),
+            "Expected 'var x: f32;' for uninitialized let, got: {}",
+            wgsl
+        );
+        assert!(
+            !wgsl.contains("let x: f32;"),
+            "Should not emit 'let x: f32;' (invalid WGSL), got: {}",
+            wgsl
+        );
+    }
+
+    #[test]
+    fn init_let_renders_as_let() {
+        let item: syn::Item = syn::parse_quote! {
+            pub fn f() {
+                let x: f32 = 1.0;
+            }
+        };
+        let item = Item::try_from(&item).unwrap();
+        let wgsl = item.to_wgsl();
+        assert!(
+            wgsl.contains("let x: f32 = 1.0;"),
+            "Expected 'let x: f32 = 1.0;' for initialized let, got: {}",
             wgsl
         );
     }


### PR DESCRIPTION
Fixes #148 

WGSL `let` requires an initializer; `var` does not (defaults to zero value). An uninitialized Rust `let x: f32;` was rendered verbatim as `let x: f32;` which naga rejects. Now it renders as `var x: f32;`.

The fix is one line in ir_convert.rs: an uninitialized `let` (no `mut`, no init) now sets `mutable: true` so the renderer emits `var` instead of `let`.