### PR TITLE
fix: deshadow same-scope variable redefinitions for valid WGSL (#149)

### DIFF
--- a/crates/wgsl-rs-ir/src/deshadow.rs
+++ b/crates/wgsl-rs-ir/src/deshadow.rs
@@ -1,0 +1,645 @@
+//! Deshadow pass: rename same-scope variable redeclarations so the
+//! rendered WGSL is valid.
+//!
+//! Rust allows shadowing within the same scope (`let x = 1.0; let x =
+//! 2.0;`), but WGSL rejects two declarations with the same name and the
+//! same end-of-scope. This pass walks each function body with a scope
+//! stack and renames any shadowed binding (and all subsequent references
+//! to it) to a unique mangled name like `x_1`.
+//!
+//! WGSL does allow shadowing in nested blocks (different end-of-scope),
+//! so this pass only renames when a name is redeclared within the same
+//! block scope.
+
+use std::collections::HashSet;
+
+use crate::{Block, ElseBranch, Expr, ForLoop, Item, ItemFn, Module, Stmt, StmtIf, StmtSwitch};
+
+/// Rename same-scope shadowed locals in every function in the module so
+/// the rendered WGSL is valid.
+pub fn deshadow_module(module: &mut Module) {
+    for item in &mut module.items {
+        if let Item::Fn(f) = item {
+            deshadow_fn(f);
+        }
+    }
+}
+
+/// Like [`deshadow_module`] but operates on a bare slice of items.
+pub fn deshadow_items(items: &mut [Item]) {
+    for item in items {
+        if let Item::Fn(f) = item {
+            deshadow_fn(f);
+        }
+    }
+}
+
+/// Deshadow a single function. Function parameters and the function
+/// body share the same scope (same end-of-scope in WGSL), so locals
+/// in the top-level body that shadow a parameter must be renamed.
+fn deshadow_fn(f: &mut ItemFn) {
+    let mut ctx = DeshadowCtx::new();
+    let mut base = HashSet::new();
+    for arg in &f.inputs {
+        base.insert(arg.name.clone());
+    }
+    ctx.scopes.push(base);
+
+    // Process the function body statements directly in the param scope
+    // (don't push a new scope — params and body share the same
+    // end-of-scope in WGSL).
+    let mut renames: Vec<(String, String)> = Vec::new();
+    for stmt in &mut f.block.stmts {
+        for (from, to) in &renames {
+            rename_in_expr_stmt(stmt, from, to);
+        }
+        collect_decls_and_recurse(stmt, &mut ctx, &mut renames);
+    }
+
+    ctx.scopes.pop();
+}
+
+/// Scope-tracking context for the deshadow pass.
+struct DeshadowCtx {
+    /// Stack of scopes, each containing the set of names declared in
+    /// that scope.
+    scopes: Vec<HashSet<String>>,
+    /// Monotonic counter for generating unique names.
+    counter: usize,
+}
+
+impl DeshadowCtx {
+    fn new() -> Self {
+        DeshadowCtx {
+            scopes: Vec::new(),
+            counter: 0,
+        }
+    }
+
+    /// Generate a unique name for a shadowed variable. Checks all scopes
+    /// on the stack to avoid collisions with any in-scope name.
+    fn unique_name(&mut self, original: &str) -> String {
+        loop {
+            self.counter += 1;
+            let candidate = format!("{original}_{}", self.counter);
+            if !self.scopes.iter().any(|s| s.contains(&candidate)) {
+                return candidate;
+            }
+        }
+    }
+
+    /// Check if a name is already declared in the current (innermost)
+    /// scope.
+    fn current_scope_contains(&self, name: &str) -> bool {
+        self.scopes.last().is_some_and(|s| s.contains(name))
+    }
+
+    /// Insert a name into the current (innermost) scope.
+    fn insert_into_current_scope(&mut self, name: String) {
+        if let Some(scope) = self.scopes.last_mut() {
+            scope.insert(name);
+        }
+    }
+}
+
+/// Deshadow a block. Pushes a new scope, processes statements in order,
+/// and applies any pending renames to subsequent statements.
+fn deshadow_block(block: &mut Block, ctx: &mut DeshadowCtx) {
+    ctx.scopes.push(HashSet::new());
+
+    // Renames accumulated as we walk: (original_name, new_name).
+    // Each subsequent statement (and its sub-expressions) must have
+    // these renames applied so references resolve to the new binding.
+    let mut renames: Vec<(String, String)> = Vec::new();
+
+    for stmt in &mut block.stmts {
+        // Apply all pending renames to this statement first, so that
+        // references to previously-shadowed names point to the new
+        // binding.
+        for (from, to) in &renames {
+            rename_in_expr_stmt(stmt, from, to);
+        }
+
+        // Now process the statement for new shadowing declarations.
+        collect_decls_and_recurse(stmt, ctx, &mut renames);
+    }
+
+    ctx.scopes.pop();
+}
+
+/// Process a statement: collect any declarations (checking for
+/// shadowing), and recurse into nested scopes.
+fn collect_decls_and_recurse(
+    stmt: &mut Stmt,
+    ctx: &mut DeshadowCtx,
+    renames: &mut Vec<(String, String)>,
+) {
+    match stmt {
+        Stmt::Local(l) => {
+            if ctx.current_scope_contains(&l.name) {
+                // Shadowed! Generate a unique name.
+                let new_name = ctx.unique_name(&l.name);
+                let old_name = std::mem::replace(&mut l.name, new_name.clone());
+                // Do NOT rename l.init — in Rust, the initializer of a
+                // shadowing binding refers to the *outer* variable (which
+                // keeps its original name).
+                ctx.insert_into_current_scope(new_name.clone());
+                renames.push((old_name, new_name));
+            } else {
+                ctx.insert_into_current_scope(l.name.clone());
+            }
+        }
+        Stmt::Const(c) => {
+            if ctx.current_scope_contains(&c.name) {
+                let new_name = ctx.unique_name(&c.name);
+                let old_name = std::mem::replace(&mut c.name, new_name.clone());
+                // const init refers to outer scope, don't rename it.
+                ctx.insert_into_current_scope(new_name.clone());
+                renames.push((old_name, new_name));
+            } else {
+                ctx.insert_into_current_scope(c.name.clone());
+            }
+        }
+        Stmt::Block(b) => {
+            deshadow_block(b, ctx);
+        }
+        Stmt::While { body, .. } => {
+            deshadow_block(body, ctx);
+        }
+        Stmt::Loop { body } => {
+            deshadow_block(body, ctx);
+        }
+        Stmt::For(f) => {
+            deshadow_for(f, ctx);
+        }
+        Stmt::If(i) => {
+            deshadow_if(i, ctx);
+        }
+        Stmt::Switch(s) => {
+            deshadow_switch(s, ctx);
+        }
+        // Other statements don't introduce bindings or nested scopes.
+        _ => {}
+    }
+}
+
+/// Deshadow a for loop. The loop variable is scoped to the loop body.
+fn deshadow_for(f: &mut ForLoop, ctx: &mut DeshadowCtx) {
+    // The for loop introduces its loop variable in a scope that wraps
+    // the body. We push a scope, register the loop var, then deshadow
+    // the body within it.
+    ctx.scopes.push(HashSet::new());
+
+    if ctx.current_scope_contains(&f.var) {
+        let new_name = ctx.unique_name(&f.var);
+        let old_name = std::mem::replace(&mut f.var, new_name.clone());
+        ctx.insert_into_current_scope(new_name.clone());
+        // Rename references in the body (and from/to expressions).
+        rename_in_expr(&mut f.from, &old_name, &new_name);
+        rename_in_expr(&mut f.to, &old_name, &new_name);
+        rename_in_block(&mut f.body, &old_name, &new_name);
+    } else {
+        ctx.insert_into_current_scope(f.var.clone());
+    }
+
+    deshadow_block(&mut f.body, ctx);
+    ctx.scopes.pop();
+}
+
+/// Deshadow an if statement. Each branch (then, else block, else-if)
+/// gets its own nested scope.
+fn deshadow_if(i: &mut StmtIf, ctx: &mut DeshadowCtx) {
+    deshadow_block(&mut i.then_block, ctx);
+    if let Some(else_branch) = &mut i.else_branch {
+        match else_branch {
+            ElseBranch::Block(b) => deshadow_block(b, ctx),
+            ElseBranch::If(nested) => deshadow_if(nested, ctx),
+        }
+    }
+}
+
+/// Deshadow a switch statement. Each arm body gets its own nested scope.
+fn deshadow_switch(s: &mut StmtSwitch, ctx: &mut DeshadowCtx) {
+    for arm in &mut s.arms {
+        deshadow_block(&mut arm.body, ctx);
+    }
+}
+
+// ===== Rename helpers =====
+
+/// Rename all `Expr::Ident(from)` to `to` within a statement, recursing
+/// into all sub-expressions and nested blocks. This is a flat rename —
+/// it does not track scopes, so it should only be used when the caller
+/// has already established that `from` is the shadowed name visible in
+/// all positions being renamed.
+fn rename_in_expr_stmt(stmt: &mut Stmt, from: &str, to: &str) {
+    match stmt {
+        Stmt::Local(l) => {
+            // Rename init (references to the shadowed binding), but NOT
+            // l.name itself (that may have already been renamed).
+            if let Some(init) = &mut l.init {
+                rename_in_expr(init, from, to);
+            }
+        }
+        Stmt::Const(c) => {
+            rename_in_expr(&mut c.expr, from, to);
+        }
+        Stmt::Assignment { lhs, rhs } => {
+            rename_in_expr(lhs, from, to);
+            rename_in_expr(rhs, from, to);
+        }
+        Stmt::CompoundAssignment { lhs, rhs, .. } => {
+            rename_in_expr(lhs, from, to);
+            rename_in_expr(rhs, from, to);
+        }
+        Stmt::While { condition, body } => {
+            rename_in_expr(condition, from, to);
+            rename_in_block(body, from, to);
+        }
+        Stmt::Loop { body } => {
+            rename_in_block(body, from, to);
+        }
+        Stmt::Expr { expr, .. } => {
+            rename_in_expr(expr, from, to);
+        }
+        Stmt::If(i) => {
+            rename_in_if(i, from, to);
+        }
+        Stmt::Return(Some(e)) => {
+            rename_in_expr(e, from, to);
+        }
+        Stmt::For(f) => {
+            rename_in_expr(&mut f.from, from, to);
+            rename_in_expr(&mut f.to, from, to);
+            // Don't rename f.var (it's a declaration name, not a ref)
+            rename_in_block(&mut f.body, from, to);
+        }
+        Stmt::Switch(s) => {
+            rename_in_expr(&mut s.selector, from, to);
+            for arm in &mut s.arms {
+                for sel in &mut arm.selectors {
+                    if let crate::CaseSelector::Expr(e) = sel {
+                        rename_in_expr(e, from, to);
+                    }
+                }
+                rename_in_block(&mut arm.body, from, to);
+            }
+        }
+        Stmt::Block(b) => {
+            rename_in_block(b, from, to);
+        }
+        Stmt::SlabCopy {
+            src,
+            src_offset,
+            dest,
+            dest_offset,
+            size,
+        } => {
+            rename_in_expr(src, from, to);
+            rename_in_expr(src_offset, from, to);
+            rename_in_expr(dest, from, to);
+            rename_in_expr(dest_offset, from, to);
+            rename_in_expr(size, from, to);
+        }
+        // No expressions to rename.
+        Stmt::Return(None) | Stmt::Break | Stmt::Continue | Stmt::Discard | Stmt::Macro { .. } => {}
+    }
+}
+
+/// Rename all `Expr::Ident(from)` to `to` within a block.
+fn rename_in_block(block: &mut Block, from: &str, to: &str) {
+    for stmt in &mut block.stmts {
+        rename_in_expr_stmt(stmt, from, to);
+    }
+}
+
+/// Rename all `Expr::Ident(from)` to `to` within an if statement.
+fn rename_in_if(i: &mut StmtIf, from: &str, to: &str) {
+    rename_in_expr(&mut i.condition, from, to);
+    rename_in_block(&mut i.then_block, from, to);
+    if let Some(else_branch) = &mut i.else_branch {
+        match else_branch {
+            ElseBranch::Block(b) => rename_in_block(b, from, to),
+            ElseBranch::If(nested) => rename_in_if(nested, from, to),
+        }
+    }
+}
+
+/// Rename all `Expr::Ident(from)` to `to` within an expression tree.
+fn rename_in_expr(e: &mut Expr, from: &str, to: &str) {
+    match e {
+        Expr::Ident(name) => {
+            if name == from {
+                *name = to.to_string();
+            }
+        }
+        Expr::Lit(_) | Expr::TypePath { .. } => {}
+        Expr::Array { elems } => {
+            for x in elems {
+                rename_in_expr(x, from, to);
+            }
+        }
+        Expr::Paren(inner) | Expr::Reference(inner) => {
+            rename_in_expr(inner, from, to);
+        }
+        Expr::Binary { lhs, rhs, .. } => {
+            rename_in_expr(lhs, from, to);
+            rename_in_expr(rhs, from, to);
+        }
+        Expr::Unary { expr, .. } => {
+            rename_in_expr(expr, from, to);
+        }
+        Expr::ArrayIndexing { lhs, index } => {
+            rename_in_expr(lhs, from, to);
+            rename_in_expr(index, from, to);
+        }
+        Expr::Swizzle { lhs, params, .. } => {
+            rename_in_expr(lhs, from, to);
+            if let Some(args) = params {
+                for a in args {
+                    rename_in_expr(a, from, to);
+                }
+            }
+        }
+        Expr::Cast { lhs, .. } => {
+            rename_in_expr(lhs, from, to);
+        }
+        Expr::FnCall { params, .. } => {
+            for p in params {
+                rename_in_expr(p, from, to);
+            }
+        }
+        Expr::Struct { fields, .. } => {
+            for f in fields {
+                rename_in_expr(&mut f.expr, from, to);
+            }
+        }
+        Expr::FieldAccess { base, .. } => {
+            rename_in_expr(base, from, to);
+        }
+        Expr::ZeroValueArray { len, .. } => {
+            rename_in_expr(len, from, to);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{FnArg, FnAttrs, ItemFn, Local, ReturnType, render_module};
+    use std::borrow::Cow;
+
+    /// Build a minimal `ItemFn` with the given body statements.
+    fn fn_with_stmts(stmts: Vec<Stmt>) -> ItemFn {
+        ItemFn {
+            type_params: Vec::new(),
+            const_params: Vec::new(),
+            fn_attrs: FnAttrs::None,
+            name: Cow::Borrowed("test_fn"),
+            inputs: Vec::new(),
+            return_type: ReturnType::Default,
+            block: Block { stmts },
+            attrs: Vec::new(),
+        }
+    }
+
+    /// Build a `Module` containing a single function and render it to
+    /// WGSL, after running the deshadow pass.
+    fn render_after_deshadow(f: ItemFn) -> String {
+        let mut module = Module {
+            name: "test",
+            items: vec![Item::Fn(f)],
+            attrs: Vec::new(),
+        };
+        deshadow_module(&mut module);
+        render_module(&module)
+    }
+
+    fn let_stmt(name: &str, init: Expr) -> Stmt {
+        Stmt::Local(Local {
+            mutable: false,
+            name: name.to_string(),
+            ty: None,
+            init: Some(init),
+        })
+    }
+
+    fn ident(name: &str) -> Expr {
+        Expr::Ident(name.to_string())
+    }
+
+    fn lit_f32(val: &str) -> Expr {
+        Expr::Lit(crate::Lit::Float {
+            text: val.to_string(),
+        })
+    }
+
+    #[test]
+    fn basic_shadowing() {
+        let f = fn_with_stmts(vec![
+            let_stmt("x", lit_f32("1.0")),
+            let_stmt("x", lit_f32("2.0")),
+        ]);
+        let wgsl = render_after_deshadow(f);
+        assert!(
+            wgsl.contains("let x = 1.0;"),
+            "first x unchanged, got: {wgsl}"
+        );
+        assert!(
+            wgsl.contains("let x_1 = 2.0;"),
+            "second x renamed to x_1, got: {wgsl}"
+        );
+    }
+
+    #[test]
+    fn shadow_with_reference_in_init() {
+        // let x = 1.0; let x = x + 1.0;
+        // The init of the second x refers to the FIRST x (outer binding).
+        let f = fn_with_stmts(vec![
+            let_stmt("x", lit_f32("1.0")),
+            let_stmt(
+                "x",
+                Expr::Binary {
+                    lhs: Box::new(ident("x")),
+                    op: crate::BinOp::Add,
+                    rhs: Box::new(lit_f32("1.0")),
+                },
+            ),
+        ]);
+        let wgsl = render_after_deshadow(f);
+        assert!(
+            wgsl.contains("let x = 1.0;"),
+            "first x unchanged, got: {wgsl}"
+        );
+        // Second binding renamed, but its init still references the old x.
+        assert!(
+            wgsl.contains("let x_1 = x + 1.0;"),
+            "second x renamed to x_1 with init referencing old x, got: {wgsl}"
+        );
+    }
+
+    #[test]
+    fn shadow_then_use() {
+        // let x = 1.0; let x = 2.0; let y = x;
+        // After deshadow: let x = 1.0; let x_1 = 2.0; let y = x_1;
+        let f = fn_with_stmts(vec![
+            let_stmt("x", lit_f32("1.0")),
+            let_stmt("x", lit_f32("2.0")),
+            let_stmt("y", ident("x")),
+        ]);
+        let wgsl = render_after_deshadow(f);
+        assert!(
+            wgsl.contains("let y = x_1;"),
+            "y should reference x_1 (the shadowed binding), got: {wgsl}"
+        );
+    }
+
+    #[test]
+    fn triple_shadow() {
+        let f = fn_with_stmts(vec![
+            let_stmt("x", lit_f32("1.0")),
+            let_stmt("x", lit_f32("2.0")),
+            let_stmt("x", lit_f32("3.0")),
+        ]);
+        let wgsl = render_after_deshadow(f);
+        assert!(wgsl.contains("let x = 1.0;"), "got: {wgsl}");
+        assert!(wgsl.contains("let x_1 = 2.0;"), "got: {wgsl}");
+        assert!(wgsl.contains("let x_2 = 3.0;"), "got: {wgsl}");
+    }
+
+    #[test]
+    fn nested_block_shadow_is_allowed() {
+        // let x = 1.0; { let x = 2.0; } — valid in WGSL (different
+        // end-of-scope), should NOT be renamed.
+        let f = fn_with_stmts(vec![
+            let_stmt("x", lit_f32("1.0")),
+            Stmt::Block(Block {
+                stmts: vec![let_stmt("x", lit_f32("2.0"))],
+            }),
+        ]);
+        let wgsl = render_after_deshadow(f);
+        assert!(
+            wgsl.contains("let x = 1.0;"),
+            "outer x unchanged, got: {wgsl}"
+        );
+        assert!(
+            wgsl.contains("let x = 2.0;"),
+            "inner block x should NOT be renamed (different end-of-scope), got: {wgsl}"
+        );
+    }
+
+    #[test]
+    fn shadow_in_nested_block_same_scope() {
+        // { let x = 1.0; let x = 2.0; } — same scope within the block,
+        // should be renamed.
+        let f = fn_with_stmts(vec![Stmt::Block(Block {
+            stmts: vec![let_stmt("x", lit_f32("1.0")), let_stmt("x", lit_f32("2.0"))],
+        })]);
+        let wgsl = render_after_deshadow(f);
+        assert!(wgsl.contains("let x = 1.0;"), "got: {wgsl}");
+        assert!(wgsl.contains("let x_1 = 2.0;"), "got: {wgsl}");
+    }
+
+    #[test]
+    fn fn_param_shadowed_by_local() {
+        let mut f = fn_with_stmts(vec![let_stmt("x", lit_f32("1.0"))]);
+        f.inputs = vec![FnArg {
+            inter_stage_io: Vec::new(),
+            name: "x".to_string(),
+            ty: crate::Type::Scalar(crate::ScalarType::F32),
+            attrs: Vec::new(),
+        }];
+        let wgsl = render_after_deshadow(f);
+        // The local `x` shadows the param `x` in the same scope, so it
+        // should be renamed.
+        assert!(
+            wgsl.contains("let x_1 = 1.0;"),
+            "local x should be renamed to avoid shadowing param, got: {wgsl}"
+        );
+    }
+
+    #[test]
+    fn no_shadowing_no_rename() {
+        let f = fn_with_stmts(vec![
+            let_stmt("x", lit_f32("1.0")),
+            let_stmt("y", lit_f32("2.0")),
+        ]);
+        let wgsl = render_after_deshadow(f);
+        assert!(wgsl.contains("let x = 1.0;"), "got: {wgsl}");
+        assert!(wgsl.contains("let y = 2.0;"), "got: {wgsl}");
+    }
+
+    #[test]
+    fn shadow_inside_if_body() {
+        // let x = 1.0; if x > 0.0 { let x = 2.0; let x = 3.0; }
+        // The two inner x's are in the same if-body scope, so the second
+        // should be renamed. The outer x and the first inner x have
+        // different end-of-scope, so they're fine.
+        let f = fn_with_stmts(vec![
+            let_stmt("x", lit_f32("1.0")),
+            Stmt::If(StmtIf {
+                condition: Expr::Binary {
+                    lhs: Box::new(ident("x")),
+                    op: crate::BinOp::Gt,
+                    rhs: Box::new(lit_f32("0.0")),
+                },
+                then_block: Block {
+                    stmts: vec![let_stmt("x", lit_f32("2.0")), let_stmt("x", lit_f32("3.0"))],
+                },
+                else_branch: None,
+            }),
+        ]);
+        let wgsl = render_after_deshadow(f);
+        // Outer x unchanged.
+        assert!(wgsl.contains("let x = 1.0;"), "got: {wgsl}");
+        // First inner x is in a nested scope — fine, no rename.
+        assert!(
+            wgsl.contains("let x = 2.0;"),
+            "first inner x unchanged, got: {wgsl}"
+        );
+        // Second inner x shadows the first inner x — rename.
+        assert!(
+            wgsl.contains("let x_1 = 3.0;"),
+            "second inner x renamed, got: {wgsl}"
+        );
+    }
+
+    #[test]
+    fn shadow_then_assign() {
+        // let x = 1.0; let x = 2.0; x = 3.0;
+        // After deshadow: let x = 1.0; let x_1 = 2.0; x_1 = 3.0;
+        let f = fn_with_stmts(vec![
+            let_stmt("x", lit_f32("1.0")),
+            let_stmt("x", lit_f32("2.0")),
+            Stmt::Assignment {
+                lhs: ident("x"),
+                rhs: lit_f32("3.0"),
+            },
+        ]);
+        let wgsl = render_after_deshadow(f);
+        assert!(
+            wgsl.contains("x_1 = 3.0;"),
+            "assignment should target x_1, got: {wgsl}"
+        );
+    }
+
+    #[test]
+    fn shadow_with_existing_suffixed_name() {
+        // If x_1 already exists, the generated name should skip to x_2.
+        let f = fn_with_stmts(vec![
+            let_stmt("x", lit_f32("1.0")),
+            let_stmt("x_1", lit_f32("0.5")),
+            let_stmt("x", lit_f32("2.0")),
+        ]);
+        let wgsl = render_after_deshadow(f);
+        assert!(wgsl.contains("let x = 1.0;"), "got: {wgsl}");
+        assert!(
+            wgsl.contains("let x_1 = 0.5;"),
+            "existing x_1 unchanged, got: {wgsl}"
+        );
+        assert!(
+            wgsl.contains("let x_2 = 2.0;"),
+            "shadowed x should skip to x_2 (x_1 already taken), got: {wgsl}"
+        );
+    }
+}

--- a/crates/wgsl-rs-ir/src/deshadow.rs
+++ b/crates/wgsl-rs-ir/src/deshadow.rs
@@ -13,13 +13,9 @@
 //!
 //! # Rename propagation
 //!
-//! Renames are propagated lazily via [`DeshadowCtx::active_renames`], a
+//! Renames are propagated lazily via [`DeshadowCtx::resolve_rename`], a
 //! map from original name to mangled name. When resolving an expression,
-//! `rename_expr` consults this map. When a fresh binding is declared,
-//! its name is *removed* from `active_renames`, suppressing any
-//! outer-scope rename — this is what prevents renames from leaking past
-//! a nested-scope redeclaration (the bug fixed by this design). The map
-//! is saved and restored across nested scopes.
+//! `rename_expr` consults this map.
 
 use crate::{
     Block, CaseSelector, ElseBranch, Expr, FnArg, ForLoop, ImplItem, Item, ItemFn, Module, Stmt,

--- a/crates/wgsl-rs-ir/src/deshadow.rs
+++ b/crates/wgsl-rs-ir/src/deshadow.rs
@@ -10,12 +10,6 @@
 //! WGSL does allow shadowing in nested blocks (different end-of-scope),
 //! so this pass only renames when a name is redeclared within the same
 //! block scope.
-//!
-//! # Rename propagation
-//!
-//! Renames are propagated lazily via [`DeshadowCtx::resolve_rename`], a
-//! map from original name to mangled name. When resolving an expression,
-//! `rename_expr` consults this map.
 
 use crate::{
     Block, CaseSelector, ElseBranch, Expr, FnArg, ForLoop, ImplItem, Item, ItemFn, Module, Stmt,

--- a/crates/wgsl-rs-ir/src/deshadow.rs
+++ b/crates/wgsl-rs-ir/src/deshadow.rs
@@ -10,375 +10,310 @@
 //! WGSL does allow shadowing in nested blocks (different end-of-scope),
 //! so this pass only renames when a name is redeclared within the same
 //! block scope.
+//!
+//! # Rename propagation
+//!
+//! Renames are propagated lazily via [`DeshadowCtx::active_renames`], a
+//! map from original name to mangled name. When resolving an expression,
+//! `rename_expr` consults this map. When a fresh binding is declared,
+//! its name is *removed* from `active_renames`, suppressing any
+//! outer-scope rename — this is what prevents renames from leaking past
+//! a nested-scope redeclaration (the bug fixed by this design). The map
+//! is saved and restored across nested scopes.
 
-use std::collections::HashSet;
+use crate::{
+    Block, CaseSelector, ElseBranch, Expr, FnArg, ForLoop, ImplItem, Item, ItemFn, Module, Stmt,
+    StmtIf, StmtSwitch, deshadow::ctx::DeshadowCtx,
+};
 
-use crate::{Block, ElseBranch, Expr, ForLoop, Item, ItemFn, Module, Stmt, StmtIf, StmtSwitch};
+mod ctx;
 
-/// Rename same-scope shadowed locals in every function in the module so
-/// the rendered WGSL is valid.
+/// The deshadow pass. Owns the scope-tracking context and walks the IR
+/// tree, renaming same-scope shadowed bindings.
+#[derive(Default)]
+struct DeshadowPass {
+    ctx: DeshadowCtx,
+}
+
+/// Pub wrappers preserving the old free-function API.
 pub fn deshadow_module(module: &mut Module) {
-    for item in &mut module.items {
-        if let Item::Fn(f) = item {
-            deshadow_fn(f);
-        }
-    }
+    DeshadowPass::default().deshadow_module(module);
 }
 
-/// Like [`deshadow_module`] but operates on a bare slice of items.
 pub fn deshadow_items(items: &mut [Item]) {
-    for item in items {
-        if let Item::Fn(f) = item {
-            deshadow_fn(f);
-        }
-    }
+    DeshadowPass::default().deshadow_items(items);
 }
 
-/// Deshadow a single function. Function parameters and the function
-/// body share the same scope (same end-of-scope in WGSL), so locals
-/// in the top-level body that shadow a parameter must be renamed.
-fn deshadow_fn(f: &mut ItemFn) {
-    let mut ctx = DeshadowCtx::new();
-    let mut base = HashSet::new();
-    for arg in &f.inputs {
-        base.insert(arg.name.clone());
-    }
-    ctx.scopes.push(base);
-
-    // Process the function body statements directly in the param scope
-    // (don't push a new scope — params and body share the same
-    // end-of-scope in WGSL).
-    let mut renames: Vec<(String, String)> = Vec::new();
-    for stmt in &mut f.block.stmts {
-        for (from, to) in &renames {
-            rename_in_expr_stmt(stmt, from, to);
-        }
-        collect_decls_and_recurse(stmt, &mut ctx, &mut renames);
-    }
-
-    ctx.scopes.pop();
-}
-
-/// Scope-tracking context for the deshadow pass.
-struct DeshadowCtx {
-    /// Stack of scopes, each containing the set of names declared in
-    /// that scope.
-    scopes: Vec<HashSet<String>>,
-    /// Monotonic counter for generating unique names.
-    counter: usize,
-}
-
-impl DeshadowCtx {
-    fn new() -> Self {
-        DeshadowCtx {
-            scopes: Vec::new(),
-            counter: 0,
+impl DeshadowPass {
+    /// Rename same-scope shadowed locals in every function in the module so
+    /// the rendered WGSL is valid.
+    fn deshadow_module(&mut self, module: &mut Module) {
+        for item in &mut module.items {
+            self.deshadow_item(item);
         }
     }
 
-    /// Generate a unique name for a shadowed variable. Checks all scopes
-    /// on the stack to avoid collisions with any in-scope name.
-    fn unique_name(&mut self, original: &str) -> String {
-        loop {
-            self.counter += 1;
-            let candidate = format!("{original}_{}", self.counter);
-            if !self.scopes.iter().any(|s| s.contains(&candidate)) {
-                return candidate;
+    /// Like [`deshadow_module`](Self::deshadow_module) but operates on a bare
+    /// slice of items.
+    fn deshadow_items(&mut self, items: &mut [Item]) {
+        for item in items {
+            self.deshadow_item(item);
+        }
+    }
+
+    /// Deshadow a single top-level item. Only functions (free or inside
+    /// `impl` blocks) contain bindings that can shadow; other items are
+    /// no-ops.
+    fn deshadow_item(&mut self, item: &mut Item) {
+        match item {
+            Item::Fn(item_fn) => {
+                self.deshadow_item_fn(item_fn);
             }
-        }
-    }
-
-    /// Check if a name is already declared in the current (innermost)
-    /// scope.
-    fn current_scope_contains(&self, name: &str) -> bool {
-        self.scopes.last().is_some_and(|s| s.contains(name))
-    }
-
-    /// Insert a name into the current (innermost) scope.
-    fn insert_into_current_scope(&mut self, name: String) {
-        if let Some(scope) = self.scopes.last_mut() {
-            scope.insert(name);
-        }
-    }
-}
-
-/// Deshadow a block. Pushes a new scope, processes statements in order,
-/// and applies any pending renames to subsequent statements.
-fn deshadow_block(block: &mut Block, ctx: &mut DeshadowCtx) {
-    ctx.scopes.push(HashSet::new());
-
-    // Renames accumulated as we walk: (original_name, new_name).
-    // Each subsequent statement (and its sub-expressions) must have
-    // these renames applied so references resolve to the new binding.
-    let mut renames: Vec<(String, String)> = Vec::new();
-
-    for stmt in &mut block.stmts {
-        // Apply all pending renames to this statement first, so that
-        // references to previously-shadowed names point to the new
-        // binding.
-        for (from, to) in &renames {
-            rename_in_expr_stmt(stmt, from, to);
-        }
-
-        // Now process the statement for new shadowing declarations.
-        collect_decls_and_recurse(stmt, ctx, &mut renames);
-    }
-
-    ctx.scopes.pop();
-}
-
-/// Process a statement: collect any declarations (checking for
-/// shadowing), and recurse into nested scopes.
-fn collect_decls_and_recurse(
-    stmt: &mut Stmt,
-    ctx: &mut DeshadowCtx,
-    renames: &mut Vec<(String, String)>,
-) {
-    match stmt {
-        Stmt::Local(l) => {
-            if ctx.current_scope_contains(&l.name) {
-                // Shadowed! Generate a unique name.
-                let new_name = ctx.unique_name(&l.name);
-                let old_name = std::mem::replace(&mut l.name, new_name.clone());
-                // Do NOT rename l.init — in Rust, the initializer of a
-                // shadowing binding refers to the *outer* variable (which
-                // keeps its original name).
-                ctx.insert_into_current_scope(new_name.clone());
-                renames.push((old_name, new_name));
-            } else {
-                ctx.insert_into_current_scope(l.name.clone());
-            }
-        }
-        Stmt::Const(c) => {
-            if ctx.current_scope_contains(&c.name) {
-                let new_name = ctx.unique_name(&c.name);
-                let old_name = std::mem::replace(&mut c.name, new_name.clone());
-                // const init refers to outer scope, don't rename it.
-                ctx.insert_into_current_scope(new_name.clone());
-                renames.push((old_name, new_name));
-            } else {
-                ctx.insert_into_current_scope(c.name.clone());
-            }
-        }
-        Stmt::Block(b) => {
-            deshadow_block(b, ctx);
-        }
-        Stmt::While { body, .. } => {
-            deshadow_block(body, ctx);
-        }
-        Stmt::Loop { body } => {
-            deshadow_block(body, ctx);
-        }
-        Stmt::For(f) => {
-            deshadow_for(f, ctx);
-        }
-        Stmt::If(i) => {
-            deshadow_if(i, ctx);
-        }
-        Stmt::Switch(s) => {
-            deshadow_switch(s, ctx);
-        }
-        // Other statements don't introduce bindings or nested scopes.
-        _ => {}
-    }
-}
-
-/// Deshadow a for loop. The loop variable is scoped to the loop body.
-fn deshadow_for(f: &mut ForLoop, ctx: &mut DeshadowCtx) {
-    // The for loop introduces its loop variable in a scope that wraps
-    // the body. We push a scope, register the loop var, then deshadow
-    // the body within it.
-    ctx.scopes.push(HashSet::new());
-
-    if ctx.current_scope_contains(&f.var) {
-        let new_name = ctx.unique_name(&f.var);
-        let old_name = std::mem::replace(&mut f.var, new_name.clone());
-        ctx.insert_into_current_scope(new_name.clone());
-        // Rename references in the body (and from/to expressions).
-        rename_in_expr(&mut f.from, &old_name, &new_name);
-        rename_in_expr(&mut f.to, &old_name, &new_name);
-        rename_in_block(&mut f.body, &old_name, &new_name);
-    } else {
-        ctx.insert_into_current_scope(f.var.clone());
-    }
-
-    deshadow_block(&mut f.body, ctx);
-    ctx.scopes.pop();
-}
-
-/// Deshadow an if statement. Each branch (then, else block, else-if)
-/// gets its own nested scope.
-fn deshadow_if(i: &mut StmtIf, ctx: &mut DeshadowCtx) {
-    deshadow_block(&mut i.then_block, ctx);
-    if let Some(else_branch) = &mut i.else_branch {
-        match else_branch {
-            ElseBranch::Block(b) => deshadow_block(b, ctx),
-            ElseBranch::If(nested) => deshadow_if(nested, ctx),
-        }
-    }
-}
-
-/// Deshadow a switch statement. Each arm body gets its own nested scope.
-fn deshadow_switch(s: &mut StmtSwitch, ctx: &mut DeshadowCtx) {
-    for arm in &mut s.arms {
-        deshadow_block(&mut arm.body, ctx);
-    }
-}
-
-// ===== Rename helpers =====
-
-/// Rename all `Expr::Ident(from)` to `to` within a statement, recursing
-/// into all sub-expressions and nested blocks. This is a flat rename —
-/// it does not track scopes, so it should only be used when the caller
-/// has already established that `from` is the shadowed name visible in
-/// all positions being renamed.
-fn rename_in_expr_stmt(stmt: &mut Stmt, from: &str, to: &str) {
-    match stmt {
-        Stmt::Local(l) => {
-            // Rename init (references to the shadowed binding), but NOT
-            // l.name itself (that may have already been renamed).
-            if let Some(init) = &mut l.init {
-                rename_in_expr(init, from, to);
-            }
-        }
-        Stmt::Const(c) => {
-            rename_in_expr(&mut c.expr, from, to);
-        }
-        Stmt::Assignment { lhs, rhs } => {
-            rename_in_expr(lhs, from, to);
-            rename_in_expr(rhs, from, to);
-        }
-        Stmt::CompoundAssignment { lhs, rhs, .. } => {
-            rename_in_expr(lhs, from, to);
-            rename_in_expr(rhs, from, to);
-        }
-        Stmt::While { condition, body } => {
-            rename_in_expr(condition, from, to);
-            rename_in_block(body, from, to);
-        }
-        Stmt::Loop { body } => {
-            rename_in_block(body, from, to);
-        }
-        Stmt::Expr { expr, .. } => {
-            rename_in_expr(expr, from, to);
-        }
-        Stmt::If(i) => {
-            rename_in_if(i, from, to);
-        }
-        Stmt::Return(Some(e)) => {
-            rename_in_expr(e, from, to);
-        }
-        Stmt::For(f) => {
-            rename_in_expr(&mut f.from, from, to);
-            rename_in_expr(&mut f.to, from, to);
-            // Don't rename f.var (it's a declaration name, not a ref)
-            rename_in_block(&mut f.body, from, to);
-        }
-        Stmt::Switch(s) => {
-            rename_in_expr(&mut s.selector, from, to);
-            for arm in &mut s.arms {
-                for sel in &mut arm.selectors {
-                    if let crate::CaseSelector::Expr(e) = sel {
-                        rename_in_expr(e, from, to);
+            Item::Impl(item_impl) => {
+                for impl_item in &mut item_impl.items {
+                    if let ImplItem::Fn(f) = impl_item {
+                        self.deshadow_item_fn(f);
                     }
                 }
-                rename_in_block(&mut arm.body, from, to);
             }
-        }
-        Stmt::Block(b) => {
-            rename_in_block(b, from, to);
-        }
-        Stmt::SlabCopy {
-            src,
-            src_offset,
-            dest,
-            dest_offset,
-            size,
-        } => {
-            rename_in_expr(src, from, to);
-            rename_in_expr(src_offset, from, to);
-            rename_in_expr(dest, from, to);
-            rename_in_expr(dest_offset, from, to);
-            rename_in_expr(size, from, to);
-        }
-        // No expressions to rename.
-        Stmt::Return(None) | Stmt::Break | Stmt::Continue | Stmt::Discard | Stmt::Macro { .. } => {}
-    }
-}
-
-/// Rename all `Expr::Ident(from)` to `to` within a block.
-fn rename_in_block(block: &mut Block, from: &str, to: &str) {
-    for stmt in &mut block.stmts {
-        rename_in_expr_stmt(stmt, from, to);
-    }
-}
-
-/// Rename all `Expr::Ident(from)` to `to` within an if statement.
-fn rename_in_if(i: &mut StmtIf, from: &str, to: &str) {
-    rename_in_expr(&mut i.condition, from, to);
-    rename_in_block(&mut i.then_block, from, to);
-    if let Some(else_branch) = &mut i.else_branch {
-        match else_branch {
-            ElseBranch::Block(b) => rename_in_block(b, from, to),
-            ElseBranch::If(nested) => rename_in_if(nested, from, to),
+            Item::Const(_)
+            | Item::Uniform(_)
+            | Item::Storage(_)
+            | Item::Workgroup(_)
+            | Item::Sampler(_)
+            | Item::Texture(_)
+            | Item::Struct(_)
+            | Item::Enum(_) => {}
         }
     }
-}
 
-/// Rename all `Expr::Ident(from)` to `to` within an expression tree.
-fn rename_in_expr(e: &mut Expr, from: &str, to: &str) {
-    match e {
-        Expr::Ident(name) => {
-            if name == from {
-                *name = to.to_string();
+    /// Deshadow a single function. Function parameters and the function
+    /// body share the same scope (same end-of-scope in WGSL), so locals
+    /// in the top-level body that shadow a parameter must be renamed.
+    fn deshadow_item_fn(&mut self, f: &mut ItemFn) {
+        let ItemFn {
+            type_params: _,
+            const_params: _,
+            fn_attrs: _,
+            name: _,
+            inputs,
+            return_type: _,
+            block,
+            attrs: _,
+        } = f;
+        self.deshadow_block(block, Some(inputs));
+    }
+
+    /// Deshadow a block. Pushes a new scope, optionally seeds it with
+    /// function parameter names (params and body share the same
+    /// end-of-scope in WGSL), processes statements in order, then pops
+    /// the scope. Renames are scoped automatically via the push/pop —
+    /// no manual save/restore needed.
+    fn deshadow_block(&mut self, b: &mut Block, fn_inputs: Option<&[FnArg]>) {
+        self.ctx.push_scope();
+
+        if let Some(fn_args) = fn_inputs {
+            for arg in fn_args {
+                // Params are the first declarations in this scope; they
+                // can't shadow each other (WGSL forbids duplicate
+                // params), but a later local can shadow them.
+                self.ctx.declare_name(&arg.name);
             }
         }
-        Expr::Lit(_) | Expr::TypePath { .. } => {}
-        Expr::Array { elems } => {
-            for x in elems {
-                rename_in_expr(x, from, to);
-            }
+
+        let Block { stmts } = b;
+        for stmt in stmts.iter_mut() {
+            self.deshadow_stmt(stmt);
         }
-        Expr::Paren(inner) | Expr::Reference(inner) => {
-            rename_in_expr(inner, from, to);
-        }
-        Expr::Binary { lhs, rhs, .. } => {
-            rename_in_expr(lhs, from, to);
-            rename_in_expr(rhs, from, to);
-        }
-        Expr::Unary { expr, .. } => {
-            rename_in_expr(expr, from, to);
-        }
-        Expr::ArrayIndexing { lhs, index } => {
-            rename_in_expr(lhs, from, to);
-            rename_in_expr(index, from, to);
-        }
-        Expr::Swizzle { lhs, params, .. } => {
-            rename_in_expr(lhs, from, to);
-            if let Some(args) = params {
-                for a in args {
-                    rename_in_expr(a, from, to);
+
+        self.ctx.pop_scope();
+    }
+
+    /// Deshadow a statement: resolve references via the scope stack,
+    /// then handle any declarations (checking for same-scope shadowing)
+    /// and recurse into nested scopes.
+    fn deshadow_stmt(&mut self, stmt: &mut Stmt) {
+        match stmt {
+            Stmt::Local(l) => {
+                // Resolve the initializer in the *enclosing* scope (Rust
+                // semantics: the init of a shadowing binding refers to
+                // the outer variable).
+                if let Some(init) = &mut l.init {
+                    self.rename_expr(init);
+                }
+                if let Some(new_name) = self.ctx.declare_name(&l.name) {
+                    l.name = new_name;
                 }
             }
+            Stmt::Const(c) => {
+                self.rename_expr(&mut c.expr);
+                if let Some(new_name) = self.ctx.declare_name(&c.name) {
+                    c.name = new_name;
+                }
+            }
+            Stmt::Assignment { lhs, rhs } => {
+                self.rename_expr(lhs);
+                self.rename_expr(rhs);
+            }
+            Stmt::CompoundAssignment { lhs, rhs, .. } => {
+                self.rename_expr(lhs);
+                self.rename_expr(rhs);
+            }
+            Stmt::While { condition, body } => {
+                self.rename_expr(condition);
+                self.deshadow_block(body, None);
+            }
+            Stmt::Loop { body } => {
+                self.deshadow_block(body, None);
+            }
+            Stmt::Expr { expr, .. } => {
+                self.rename_expr(expr);
+            }
+            Stmt::If(i) => {
+                self.deshadow_if(i);
+            }
+            Stmt::Break | Stmt::Continue | Stmt::Discard => {}
+            Stmt::Return(e) => {
+                if let Some(e) = e {
+                    self.rename_expr(e);
+                }
+            }
+            Stmt::For(f) => {
+                self.deshadow_for(f);
+            }
+            Stmt::Switch(s) => {
+                self.deshadow_switch(s);
+            }
+            Stmt::Block(b) => {
+                self.deshadow_block(b, None);
+            }
+            Stmt::SlabCopy {
+                src,
+                src_offset,
+                dest,
+                dest_offset,
+                size,
+            } => {
+                self.rename_expr(src);
+                self.rename_expr(src_offset);
+                self.rename_expr(dest);
+                self.rename_expr(dest_offset);
+                self.rename_expr(size);
+            }
+            Stmt::Macro { .. } => {}
         }
-        Expr::Cast { lhs, .. } => {
-            rename_in_expr(lhs, from, to);
-        }
-        Expr::FnCall { params, .. } => {
-            for p in params {
-                rename_in_expr(p, from, to);
+    }
+
+    /// Deshadow an if statement. The condition is resolved in the
+    /// enclosing scope; each branch (then, else block, else-if) gets its
+    /// own nested scope.
+    fn deshadow_if(&mut self, i: &mut StmtIf) {
+        self.rename_expr(&mut i.condition);
+        self.deshadow_block(&mut i.then_block, None);
+        if let Some(else_branch) = &mut i.else_branch {
+            match else_branch {
+                ElseBranch::Block(b) => self.deshadow_block(b, None),
+                ElseBranch::If(nested) => self.deshadow_if(nested),
             }
         }
-        Expr::Struct { fields, .. } => {
-            for f in fields {
-                rename_in_expr(&mut f.expr, from, to);
+    }
+
+    /// Deshadow a for loop. The `from`/`to` range expressions are
+    /// resolved in the enclosing scope (Rust evaluates the range before
+    /// entering the loop). The loop variable is declared in a scope
+    /// wrapping the body; the body gets its own nested scope. Renames
+    /// are scoped automatically via the push/pop.
+    fn deshadow_for(&mut self, f: &mut ForLoop) {
+        // Resolve range in the enclosing scope.
+        self.rename_expr(&mut f.from);
+        self.rename_expr(&mut f.to);
+
+        // The loop variable lives in a scope wrapping the body. Per the
+        // WGSL spec, `for` desugars to `{ initializer; loop { body } }`,
+        // so the loop var is always in its own scope and can never
+        // same-scope-collide with an enclosing binding.
+        self.ctx.push_scope();
+        if let Some(new_name) = self.ctx.declare_name(&f.var) {
+            f.var = new_name;
+        }
+
+        self.deshadow_block(&mut f.body, None);
+
+        self.ctx.pop_scope();
+    }
+
+    /// Deshadow a switch statement. The selector and any expression
+    /// case selectors are resolved in the enclosing scope; each arm
+    /// body gets its own nested scope.
+    fn deshadow_switch(&mut self, s: &mut StmtSwitch) {
+        self.rename_expr(&mut s.selector);
+        for arm in &mut s.arms {
+            for sel in &mut arm.selectors {
+                if let CaseSelector::Expr(e) = sel {
+                    self.rename_expr(e);
+                }
             }
+            self.deshadow_block(&mut arm.body, None);
         }
-        Expr::FieldAccess { base, .. } => {
-            rename_in_expr(base, from, to);
-        }
-        Expr::ZeroValueArray { len, .. } => {
-            rename_in_expr(len, from, to);
+    }
+
+    /// Rename all `Expr::Ident` nodes within an expression tree by
+    /// consulting the scope stack ([`DeshadowCtx::resolve_rename`]).
+    /// Recurses into all sub-expressions.
+    fn rename_expr(&mut self, e: &mut Expr) {
+        match e {
+            Expr::Ident(name) => {
+                if let Some(to) = self.ctx.resolve_rename(name) {
+                    *name = to.to_string();
+                }
+            }
+            Expr::Lit(_) | Expr::TypePath { .. } => {}
+            Expr::Array { elems } => {
+                for x in elems {
+                    self.rename_expr(x);
+                }
+            }
+            Expr::Paren(inner) | Expr::Reference(inner) => {
+                self.rename_expr(inner);
+            }
+            Expr::Binary { lhs, rhs, .. } => {
+                self.rename_expr(lhs);
+                self.rename_expr(rhs);
+            }
+            Expr::Unary { expr, .. } => {
+                self.rename_expr(expr);
+            }
+            Expr::ArrayIndexing { lhs, index } => {
+                self.rename_expr(lhs);
+                self.rename_expr(index);
+            }
+            Expr::Swizzle { lhs, params, .. } => {
+                self.rename_expr(lhs);
+                if let Some(args) = params {
+                    for a in args {
+                        self.rename_expr(a);
+                    }
+                }
+            }
+            Expr::Cast { lhs, .. } => {
+                self.rename_expr(lhs);
+            }
+            Expr::FnCall { params, .. } => {
+                for p in params {
+                    self.rename_expr(p);
+                }
+            }
+            Expr::Struct { fields, .. } => {
+                for f in fields {
+                    self.rename_expr(&mut f.expr);
+                }
+            }
+            Expr::FieldAccess { base, .. } => {
+                self.rename_expr(base);
+            }
+            Expr::ZeroValueArray { len, .. } => {
+                self.rename_expr(len);
+            }
         }
     }
 }

--- a/crates/wgsl-rs-ir/src/deshadow/ctx.rs
+++ b/crates/wgsl-rs-ir/src/deshadow/ctx.rs
@@ -1,0 +1,113 @@
+//! Deshadowing context.
+//!
+//! Used by the deshadowing pass to produce unique names for shadowed name
+//! bindings.
+
+use std::collections::{HashMap, HashSet};
+
+/// A single scope.
+///
+/// `names` tracks every name declared in this scope. `renames` maps an
+/// original (shadowed) name to its mangled replacement — only populated
+/// for same-scope shadows. A fresh declaration goes into `names` but not
+/// `renames`, which acts as a "stop" signal during resolution: an outer
+/// scope's rename of the same name must not apply past this point.
+#[derive(Default)]
+struct DeshadowScope {
+    names: HashSet<String>,
+    renames: HashMap<String, String>,
+}
+
+/// Scope-tracking context for the deshadow pass.
+///
+/// Resolution of a reference walks the scope stack innermost-first
+/// ([`resolve_rename`]). If a scope has an entry in `renames` for the
+/// name, that rename applies. If a scope has the name in `names` but
+/// not in `renames`, the name was freshly declared here, so any
+/// outer-scope rename is suppressed (this is what prevents renames from
+/// leaking past a nested-scope redeclaration). Otherwise the walk
+/// continues to the next outer scope.
+#[derive(Default)]
+pub struct DeshadowCtx {
+    /// Stack of scopes, innermost last.
+    scopes: Vec<DeshadowScope>,
+    /// Monotonic counter for generating unique names.
+    counter: usize,
+}
+
+impl DeshadowCtx {
+    /// Generate a unique name for a shadowed variable. Checks all scopes
+    /// on the stack to avoid collisions with any in-scope name.
+    fn unique_name(&mut self, original: &str) -> String {
+        loop {
+            self.counter += 1;
+            let candidate = format!("{original}_{}", self.counter);
+            if !self.scopes.iter().any(|s| s.names.contains(&candidate)) {
+                return candidate;
+            }
+        }
+    }
+
+    /// Check if a name is already declared in the current (innermost)
+    /// scope.
+    fn current_scope_contains(&self, name: &str) -> bool {
+        self.scopes.last().is_some_and(|s| s.names.contains(name))
+    }
+
+    /// Push a new scope onto the stack.
+    pub fn push_scope(&mut self) {
+        self.scopes.push(Default::default());
+    }
+
+    /// Pop the deepest scope off the stack.
+    pub fn pop_scope(&mut self) {
+        self.scopes.pop();
+    }
+
+    /// Declare a name in the current scope. If the name shadows an
+    /// existing same-scope binding, generates a unique mangled name,
+    /// inserts *that* into the scope's `names` and records the rename in
+    /// the scope's `renames`, and returns the new name. If the name is
+    /// fresh, inserts it into `names` and returns `None`.
+    pub fn declare_name(&mut self, original: &str) -> Option<String> {
+        if self.scopes.is_empty() {
+            self.push_scope();
+        }
+        let is_shadow = self.current_scope_contains(original);
+        if is_shadow {
+            let new_name = self.unique_name(original);
+            let scope = self
+                .scopes
+                .last_mut()
+                .expect("scope was just ensured non-empty");
+            scope.names.insert(new_name.clone());
+            scope.renames.insert(original.to_string(), new_name.clone());
+            Some(new_name)
+        } else {
+            let scope = self
+                .scopes
+                .last_mut()
+                .expect("scope was just ensured non-empty");
+            scope.names.insert(original.to_string());
+            None
+        }
+    }
+
+    /// Resolve a reference to a name by walking the scope stack
+    /// innermost-first. Returns the mangled name if an enclosing scope
+    /// shadowed this name (and no intervening scope freshly declared
+    /// it), or `None` if the name should be used as-is.
+    pub fn resolve_rename(&self, name: &str) -> Option<&str> {
+        for scope in self.scopes.iter().rev() {
+            if let Some(new_name) = scope.renames.get(name) {
+                return Some(new_name.as_str());
+            }
+            if scope.names.contains(name) {
+                // Fresh declaration in this scope suppresses any
+                // outer-scope rename.
+                return None;
+            }
+        }
+        None
+    }
+}

--- a/crates/wgsl-rs-ir/src/lib.rs
+++ b/crates/wgsl-rs-ir/src/lib.rs
@@ -22,11 +22,13 @@
 //! args, impl method name mangling, builtin name translation, enum
 //! discriminant auto-increment) lives in the [`render`] module.
 
+pub mod deshadow;
 pub mod mangle;
 pub mod render;
 mod substitute;
 mod types;
 
+pub use deshadow::{deshadow_items, deshadow_module};
 pub use mangle::{mangle, unmangle};
 pub use render::{
     items_need_tier1_extension, render_block, render_expr, render_item, render_items,

--- a/crates/wgsl-rs-ir/src/types.rs
+++ b/crates/wgsl-rs-ir/src/types.rs
@@ -662,6 +662,7 @@ pub enum CaseSelector {
 /// A statement.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Stmt {
+    /// A `let` / `var` / `const` initializer.
     Local(Local),
     /// A `const` item declared inside a function body.
     Const(ItemConst),
@@ -669,6 +670,7 @@ pub enum Stmt {
         lhs: Expr,
         rhs: Expr,
     },
+    /// lhs = rhs
     CompoundAssignment {
         lhs: Expr,
         op: CompoundOp,

--- a/crates/wgsl-rs/src/lib.rs
+++ b/crates/wgsl-rs/src/lib.rs
@@ -235,6 +235,7 @@ impl Source {
         if let Some(s) = subst {
             ir::substitute_types(&mut ir_module, s);
         }
+        ir::deshadow_module(&mut ir_module);
         if ir::items_need_tier1_extension(&ir_module.items) {
             *needs_tier1 = true;
         }
@@ -414,6 +415,7 @@ fn instantiate_template_into<'a>(
         ir::rename_items(&mut items, template.name, &instance_name);
     }
 
+    ir::deshadow_items(&mut items);
     if ir::items_need_tier1_extension(&items) {
         *needs_tier1 = true;
     }

--- a/crates/wgsl-rs/src/linkage/wgpu.rs
+++ b/crates/wgsl-rs/src/linkage/wgpu.rs
@@ -726,8 +726,9 @@ pub enum BufferKind {
 /// nodes); the proc-macro's `instantiate` enforces this at the type
 /// level. The infallibility is honest: every failure mode would be a
 /// bug in IR construction, not a user-facing error.
-pub fn analyze_ir_module(ir_module: wgsl_rs_ir::Module) -> WgpuLinkage {
+pub fn analyze_ir_module(mut ir_module: wgsl_rs_ir::Module) -> WgpuLinkage {
     let module_label = ir_module.name;
+    ir::deshadow_module(&mut ir_module);
     let mut linkage = WgpuLinkage {
         module_label,
         ir: ir_module,
@@ -1186,6 +1187,7 @@ pub(crate) fn assemble_ir(wgsl_source: &Source) -> Result<ir::Module, Error> {
         std::collections::HashSet::new();
     let mut items: Vec<ir::Item> = Vec::new();
     collect_items(wgsl_source, &mut visited, &mut seen, &mut items, None)?;
+    ir::deshadow_items(&mut items);
     Ok(ir::Module {
         name: wgsl_source.name,
         items,

--- a/crates/wgsl-rs/src/linkage/wgpu.rs
+++ b/crates/wgsl-rs/src/linkage/wgpu.rs
@@ -1187,7 +1187,9 @@ pub(crate) fn assemble_ir(wgsl_source: &Source) -> Result<ir::Module, Error> {
         std::collections::HashSet::new();
     let mut items: Vec<ir::Item> = Vec::new();
     collect_items(wgsl_source, &mut visited, &mut seen, &mut items, None)?;
-    ir::deshadow_items(&mut items);
+    // Note: deshadowing is deferred to `analyze_ir_module`, which is the
+    // sole consumer of this assembled IR. Deshadowing here too would be
+    // redundant (the pass is idempotent but wastes work).
     Ok(ir::Module {
         name: wgsl_source.name,
         items,

--- a/crates/wgsl-rs/tests/shadowing.rs
+++ b/crates/wgsl-rs/tests/shadowing.rs
@@ -1,0 +1,205 @@
+//! Regression tests for wgsl-rs#149 (same-scope variable shadowing produces
+//! invalid WGSL) and the related findings from the deshadow-pass review.
+//!
+//! These drive the real `#[wgsl]` macro, render to WGSL, and assert on both
+//! specific substrings (to pin the exact rename behavior) and naga validation
+//! (to catch the `redefinition of x` error #149 reported). `validation` is a
+//! default feature, so naga runs in normal `cargo test`.
+//!
+//! Cases covered:
+//! - #1: pending renames leaking into nested scopes that rebind the same name
+//!   (silent miscompilation; naga accepts it, so substring asserts are the
+//!   primary catch).
+//! - #2: shadowing inside `impl` method bodies (the deshadow pass only walks
+//!   `Item::Fn`, skipping `Item::Impl`/`ImplItem::Fn`; naga catches this with a
+//!   `redefinition` error).
+//! - #3 (type-position rename gap) was considered but cannot be triggered
+//!   through valid Rust: two same-scope `const` items with the same name is
+//!   E0428, and array lengths in WGSL require const expressions so `let`
+//!   shadowing of a `const` can't produce a type-position reference to the
+//!   shadowed binding. The gap is real in the IR but unreachable from the macro
+//!   surface.
+
+#![allow(dead_code)]
+#![allow(unused_variables)]
+#![allow(unused_assignments)]
+
+use wgsl_rs::wgsl;
+
+// ===== #1: nested-scope rename leak (for loop) =====
+
+#[wgsl]
+mod shadow_nested_for {
+    /// `i` is shadowed, then a `for` loop rebinds `i` as its loop variable.
+    /// The loop body must reference the loop counter, NOT the outer
+    /// shadowed `i_1`. The trailing expression references the outer `i_1`.
+    pub fn leak() -> u32 {
+        let i = 0u32;
+        let i = i + 1u32;
+        let mut sum: u32 = 0u32;
+        for i in 0u32..10u32 {
+            sum += i;
+        }
+        sum + i
+    }
+}
+
+#[test]
+fn nested_for_loop_body_references_loop_var_not_outer_shadow() {
+    let src = shadow_nested_for::WGSL_SOURCE
+        .wgsl_source()
+        .expect("render should succeed");
+    // Outer shadow renamed.
+    assert!(
+        src.contains("let i_1 = i + 1u;"),
+        "outer shadowed `i` should be renamed to `i_1`, got: {src}"
+    );
+    // Loop variable keeps its name (new binding, no shadowing).
+    assert!(
+        src.contains("for (var i = 0u; i < 10u; i++)"),
+        "loop var should keep name `i`, got: {src}"
+    );
+    // CRITICAL: the loop body must reference `i` (the loop counter), not
+    // `i_1` (the outer shadowed binding). This assertion fails today due
+    // to the flat rename leaking into the nested scope.
+    assert!(
+        src.contains("sum += i;"),
+        "loop body should reference loop var `i`, not `i_1` (rename leak), got: {src}"
+    );
+    assert!(
+        !src.contains("sum += i_1;"),
+        "loop body must NOT contain `sum += i_1;` (rename leak), got: {src}"
+    );
+    // Trailing expression references the outer shadowed binding.
+    assert!(
+        src.contains("return sum + i_1;"),
+        "trailing expr should reference `i_1`, got: {src}"
+    );
+}
+
+// ===== #1: nested-scope rename leak (plain block) =====
+
+#[wgsl]
+mod shadow_nested_block {
+    /// Outer `x` is shadowed, then a nested block rebinds `x`. The
+    /// assignment inside the block must reference the inner `x`, not the
+    /// outer `x_1`.
+    pub fn leak() -> f32 {
+        let x = 1.0;
+        let x = 2.0;
+        let mut y = 0.0;
+        {
+            let x = 3.0;
+            y = x;
+        }
+        y + x
+    }
+}
+
+#[test]
+fn nested_block_body_references_inner_binding_not_outer_shadow() {
+    let src = shadow_nested_block::WGSL_SOURCE
+        .wgsl_source()
+        .expect("render should succeed");
+    // Outer shadow renamed.
+    assert!(
+        src.contains("let x_1 = 2.0;"),
+        "outer shadowed `x` should be renamed to `x_1`, got: {src}"
+    );
+    // Inner block binding keeps its name (new scope).
+    assert!(
+        src.contains("let x = 3.0;"),
+        "inner block `x` should keep its name (new scope), got: {src}"
+    );
+    // CRITICAL: the assignment must reference the inner `x`, not `x_1`.
+    assert!(
+        src.contains("y = x;"),
+        "inner block should reference inner `x`, not `x_1` (rename leak), got: {src}"
+    );
+    assert!(
+        !src.contains("y = x_1;"),
+        "inner block must NOT contain `y = x_1;` (rename leak), got: {src}"
+    );
+    // Trailing expression references the outer shadowed binding.
+    assert!(
+        src.contains("return y + x_1;"),
+        "trailing expr should reference `x_1`, got: {src}"
+    );
+}
+
+// ===== #2: impl method with same-scope shadowing =====
+
+#[wgsl]
+mod shadow_impl_method {
+    pub struct Light {
+        pub intensity: f32,
+    }
+
+    impl Light {
+        /// A method body with same-scope shadowing. The deshadow pass
+        /// currently skips `Item::Impl`/`ImplItem::Fn`, so this emits
+        /// `redefinition of x` (the exact #149 symptom).
+        pub fn attenuate(intensity: f32, distance: f32) -> f32 {
+            let x = 1.0;
+            let x = 2.0;
+            intensity / (distance * distance) * x
+        }
+    }
+
+    pub fn caller(d: f32) -> f32 {
+        Light::attenuate(5.0, d)
+    }
+}
+
+#[test]
+fn impl_method_shadowing_is_deshadowed() {
+    let src = shadow_impl_method::WGSL_SOURCE
+        .wgsl_source()
+        .expect("render should succeed");
+    // The method body's shadow must be renamed. This fails today: impl
+    // methods are skipped by the deshadow pass.
+    assert!(
+        src.contains("let x_1 = 2.0;"),
+        "impl method shadow should be renamed to `x_1`, got: {src}"
+    );
+    assert!(
+        !src.contains("let x = 1.0;\n    let x = 2.0;"),
+        "impl method must not emit two `let x` in the same scope, got: {src}"
+    );
+}
+
+// ===== Naga validation for all modules =====
+//
+// `validation` is a default feature (Cargo.toml default = ["validation", ...]).
+// These run in normal `cargo test`. Each `validate()` call parses the rendered
+// WGSL with naga and runs full semantic validation.
+//
+// - #1 (for / block): naga accepts the miscompiled output, so these would pass
+//   today even with the bug. The substring asserts above are the real catch;
+//   validation here guards against future regressions after the fix.
+// - #2 (impl method): naga rejects with `redefinition of x` today (exact #149
+//   symptom). After the fix, validation passes.
+
+#[cfg(feature = "validation")]
+#[test]
+fn shadow_nested_for_validates() {
+    shadow_nested_for::WGSL_SOURCE
+        .validate()
+        .expect("shadow_nested_for should produce valid WGSL after deshadow");
+}
+
+#[cfg(feature = "validation")]
+#[test]
+fn shadow_nested_block_validates() {
+    shadow_nested_block::WGSL_SOURCE
+        .validate()
+        .expect("shadow_nested_block should produce valid WGSL after deshadow");
+}
+
+#[cfg(feature = "validation")]
+#[test]
+fn shadow_impl_method_validates() {
+    shadow_impl_method::WGSL_SOURCE
+        .validate()
+        .expect("shadow_impl_method should produce valid WGSL after deshadow");
+}


### PR DESCRIPTION
Rust allows shadowing within the same scope (let x = 1.0; let x = 2.0;) but WGSL rejects two declarations with the same name and end-of-scope.

Add a deshadow IR pass that walks each function body with a scope stack and renames shadowed bindings (and all subsequent references) to unique mangled names like x_1. Handles function params, const items, for-loop vars, if/while/loop/switch bodies, and nested blocks. Nested-block shadowing (different end-of-scope) is left alone since WGSL allows it.

Fixes #149 

[Agent session transcript](https://github.com/user-attachments/files/31342051/deshadowing.json)
