### PR TITLE
feat: impl TextureSample for Texture3D, TextureCube, TextureCubeArray, Texture1D

### DIFF
--- a/crates/roundtrip-tests/src/shaders/texture_operations.rs
+++ b/crates/roundtrip-tests/src/shaders/texture_operations.rs
@@ -1,6 +1,7 @@
 //! Roundtrip tests for texture load/sample operations.
 //!
-//! Tests: `texture_load` and `texture_sample` on `Texture2D<f32>`.
+//! Tests: `texture_load` and `texture_sample` on `Texture2D<f32>` and
+//! `texture_sample` on `Texture3D<f32>`.
 
 #![allow(dead_code)]
 
@@ -10,6 +11,7 @@ use crate::harness::{self, ComparisonResult, RoundtripTest};
 
 const WIDTH: u32 = 8;
 const HEIGHT: u32 = 8;
+const DEPTH: u32 = 2;
 
 #[wgsl]
 pub mod texture_load_2d {
@@ -61,6 +63,38 @@ pub mod texture_sample_2d {
         let uv = vec2f(
             input.position.x / dims.x() as f32,
             input.position.y / dims.y() as f32,
+        );
+        texture_sample(TEX, TEX_SAMPLER, uv)
+    }
+}
+
+#[wgsl]
+pub mod texture_sample_3d {
+    use wgsl_rs::std::*;
+
+    texture!(group(0), binding(0), TEX: Texture3D<f32>);
+    sampler!(group(0), binding(1), TEX_SAMPLER: Sampler);
+
+    pub struct FragInput {
+        #[builtin(position)]
+        pub position: Vec4f,
+    }
+
+    #[vertex]
+    pub fn vtx_main(#[builtin(vertex_index)] vertex_index: u32) -> Vec4f {
+        let x = f32((vertex_index & 1u32) * 2u32) * 2.0 - 1.0;
+        let y = f32((vertex_index >> 1u32) * 2u32) * 2.0 - 1.0;
+        vec4f(x, y, 0.0, 1.0)
+    }
+
+    #[fragment]
+    pub fn frag_main(input: FragInput) -> Vec4f {
+        let dims = texture_dimensions(TEX);
+        let uv = vec3f(
+            input.position.x / dims.x() as f32,
+            input.position.y / dims.y() as f32,
+            // Cycle through depth slices based on x position.
+            (input.position.x % 2.0) / dims.z() as f32,
         );
         texture_sample(TEX, TEX_SAMPLER, uv)
     }
@@ -351,6 +385,192 @@ fn render_texture_sample_gpu(
     harness::read_rgba32float_texture(device, queue, &target, WIDTH, HEIGHT)
 }
 
+/// Writes RGBA8 pixels into a CPU `Texture3D<f32>` as normalized channels.
+fn write_cpu_texture_3d(tex: &wgsl_rs::std::Texture3D<f32>, rgba8: &[[u8; 4]]) {
+    tex.init(WIDTH, HEIGHT, DEPTH);
+    for z in 0..DEPTH {
+        for y in 0..HEIGHT {
+            for x in 0..WIDTH {
+                let idx = (z * WIDTH * HEIGHT + y * WIDTH + x) as usize;
+                let px = if idx < rgba8.len() {
+                    rgba8[idx]
+                } else {
+                    [0u8; 4]
+                };
+                tex.set_pixel(
+                    x,
+                    y,
+                    z,
+                    [
+                        px[0] as f32 / 255.0,
+                        px[1] as f32 / 255.0,
+                        px[2] as f32 / 255.0,
+                        px[3] as f32 / 255.0,
+                    ],
+                );
+            }
+        }
+    }
+}
+
+/// Creates a GPU Rgba8Unorm 3D texture and uploads provided pixels.
+fn create_gpu_source_texture_3d(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    rgba8: &[[u8; 4]],
+) -> wgpu::Texture {
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("texture_ops_source_3d"),
+        size: wgpu::Extent3d {
+            width: WIDTH,
+            height: HEIGHT,
+            depth_or_array_layers: DEPTH,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D3,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+
+    queue.write_texture(
+        wgpu::TexelCopyTextureInfo {
+            texture: &texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        bytemuck::cast_slice(rgba8),
+        wgpu::TexelCopyBufferLayout {
+            offset: 0,
+            bytes_per_row: Some(WIDTH * 4),
+            rows_per_image: Some(HEIGHT),
+        },
+        wgpu::Extent3d {
+            width: WIDTH,
+            height: HEIGHT,
+            depth_or_array_layers: DEPTH,
+        },
+    );
+
+    texture
+}
+
+/// Builds deterministic RGBA8 test pixels for a 3D texture (WIDTH * HEIGHT *
+/// DEPTH).
+fn build_rgba8_pixels_3d() -> Vec<[u8; 4]> {
+    let mut pixels = vec![[0u8; 4]; (WIDTH * HEIGHT * DEPTH) as usize];
+    for z in 0..DEPTH {
+        for y in 0..HEIGHT {
+            for x in 0..WIDTH {
+                let idx = (z * WIDTH * HEIGHT + y * WIDTH + x) as usize;
+                pixels[idx] = [
+                    ((x * 19 + y * 7 + z * 31) % 256) as u8,
+                    ((x * 11 + y * 23 + z * 3) % 256) as u8,
+                    ((x * 5 + y * 13 + z * 17) % 256) as u8,
+                    255u8,
+                ];
+            }
+        }
+    }
+    pixels
+}
+
+/// Renders the texture_sample_3d shader and returns RGBA pixels.
+fn render_texture_sample_3d_gpu(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    source_texture: &wgpu::Texture,
+    filter_mode: wgpu::FilterMode,
+) -> Vec<[f32; 4]> {
+    let source_view = source_texture.create_view(&wgpu::TextureViewDescriptor::default());
+    let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        label: Some("texture_sample_3d_sampler"),
+        mag_filter: filter_mode,
+        min_filter: filter_mode,
+        mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+        ..Default::default()
+    });
+    let target = harness::create_rgba32float_render_target(
+        device,
+        WIDTH,
+        HEIGHT,
+        "texture_sample_3d_target",
+    );
+    let target_view = target.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let module = &texture_sample_3d::WGSL_SOURCE;
+    let mut linkage = wgsl_rs::linkage::wgpu::analyze_wgsl_module(module).unwrap();
+    let module = linkage.shader_module(device);
+
+    let pipeline_layout =
+        linkage.pipeline_layout(device, Some("texture_sample_3d_pipeline_layout"));
+
+    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("texture_sample_3d_pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: linkage
+            .vertex_entry("vtx_main")
+            .expect("vtx_main entry present")
+            .vertex_state(&module),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        fragment: Some(
+            linkage
+                .fragment_entry("frag_main")
+                .expect("frag_main entry present")
+                .fragment_state(
+                    &module,
+                    &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::Rgba32Float,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::all(),
+                    })],
+                ),
+        ),
+        multiview_mask: None,
+        cache: None,
+    });
+
+    let bind_group = linkage
+        .create_bind_group_named(
+            0,
+            device,
+            &[
+                ("TEX", wgpu::BindingResource::TextureView(&source_view)),
+                ("TEX_SAMPLER", wgpu::BindingResource::Sampler(&sampler)),
+            ],
+        )
+        .expect("texture_sample_3d bind group");
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("texture_sample_3d_render"),
+    });
+    {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("texture_sample_3d_render"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &target_view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            ..Default::default()
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.draw(0..3, 0..1);
+    }
+    queue.submit(Some(encoder.finish()));
+
+    harness::read_rgba32float_texture(device, queue, &target, WIDTH, HEIGHT)
+}
+
 pub struct TextureOperationsTest;
 
 impl RoundtripTest for TextureOperationsTest {
@@ -359,7 +579,7 @@ impl RoundtripTest for TextureOperationsTest {
     }
 
     fn description(&self) -> &str {
-        "texture_load and texture_sample on texture_2d<f32>"
+        "texture_load and texture_sample on texture_2d<f32> and texture_3d<f32>"
     }
 
     fn run(&self, device: &wgpu::Device, queue: &wgpu::Queue) -> Vec<ComparisonResult> {
@@ -422,6 +642,80 @@ impl RoundtripTest for TextureOperationsTest {
             &cpu_sample,
             &sample_label_refs,
             epsilon,
+        ));
+
+        // texture_sample on Texture3D<f32> (nearest filtering)
+        let pixels_3d = build_rgba8_pixels_3d();
+        let gpu_source_texture_3d = create_gpu_source_texture_3d(device, queue, &pixels_3d);
+
+        write_cpu_texture_3d(texture_sample_3d::TEX, &pixels_3d);
+        texture_sample_3d::TEX_SAMPLER.set(SamplerState::default());
+        let gpu_sample_3d_pixels = render_texture_sample_3d_gpu(
+            device,
+            queue,
+            &gpu_source_texture_3d,
+            wgpu::FilterMode::Nearest,
+        );
+        let cpu_sample_3d_grid = dispatch_fragments(
+            WIDTH,
+            HEIGHT,
+            |_, _| (),
+            |builtins, _| {
+                let result = texture_sample_3d::frag_main(texture_sample_3d::FragInput {
+                    position: builtins.position,
+                });
+                [result.x, result.y, result.z, result.w]
+            },
+        );
+
+        let gpu_sample_3d = flatten_rgba_pixels(&gpu_sample_3d_pixels);
+        let cpu_sample_3d = flatten_fragment_grid(&cpu_sample_3d_grid);
+        let sample_3d_labels = build_labels("texture_sample_3d");
+        let sample_3d_label_refs: Vec<&str> = sample_3d_labels.iter().map(|s| s.as_str()).collect();
+        results.push(harness::compare_f32_results(
+            "texture_sample_3d",
+            &gpu_sample_3d,
+            &cpu_sample_3d,
+            &sample_3d_label_refs,
+            epsilon,
+        ));
+
+        // texture_sample on Texture3D<f32> (linear / trilinear filtering)
+        // This exercises the trilinear interpolation path in the CPU
+        // implementation against the GPU, verifying the 8-texel blend and
+        // half-texel coordinate offset logic.
+        texture_sample_3d::TEX_SAMPLER.set(SamplerState::linear());
+        let gpu_sample_3d_linear_pixels = render_texture_sample_3d_gpu(
+            device,
+            queue,
+            &gpu_source_texture_3d,
+            wgpu::FilterMode::Linear,
+        );
+        let cpu_sample_3d_linear_grid = dispatch_fragments(
+            WIDTH,
+            HEIGHT,
+            |_, _| (),
+            |builtins, _| {
+                let result = texture_sample_3d::frag_main(texture_sample_3d::FragInput {
+                    position: builtins.position,
+                });
+                [result.x, result.y, result.z, result.w]
+            },
+        );
+
+        let gpu_sample_3d_linear = flatten_rgba_pixels(&gpu_sample_3d_linear_pixels);
+        let cpu_sample_3d_linear = flatten_fragment_grid(&cpu_sample_3d_linear_grid);
+        let sample_3d_linear_labels = build_labels("texture_sample_3d_linear");
+        let sample_3d_linear_label_refs: Vec<&str> =
+            sample_3d_linear_labels.iter().map(|s| s.as_str()).collect();
+        results.push(harness::compare_f32_results(
+            "texture_sample_3d_linear",
+            &gpu_sample_3d_linear,
+            &cpu_sample_3d_linear,
+            &sample_3d_linear_label_refs,
+            // Linear filtering can introduce small interpolation differences
+            // between CPU and GPU, so use a slightly larger epsilon.
+            1e-3,
         ));
 
         results

--- a/crates/wgsl-rs/src/std/texture.rs
+++ b/crates/wgsl-rs/src/std/texture.rs
@@ -10,8 +10,8 @@
 //! On the GPU side, these types transpile to their WGSL equivalents.
 
 use crate::std::{
-    ModuleVar, ModuleVarReadGuard, Vec2f, Vec2i, Vec2u, Vec3u, Vec4f, Vec4i, Vec4u, Wgsl,
-    WgslTextureScalar, vec2f, vec2u, vec3u, vec4f, vec4i, vec4u,
+    ModuleVar, ModuleVarReadGuard, Vec2f, Vec2i, Vec2u, Vec3f, Vec3i, Vec3u, Vec4f, Vec4i, Vec4u,
+    Wgsl, WgslTextureScalar, vec2f, vec2u, vec3u, vec4f, vec4i, vec4u,
 };
 
 use std::marker::PhantomData;
@@ -340,6 +340,74 @@ impl<L: IntoLevel> TextureLoad<i32, L> for Texture1D<u32> {
             .get_pixel(x, level)
             .map(|p| vec4u(p[0], p[1], p[2], p[3]))
             .unwrap_or(vec4u(0, 0, 0, 0))
+    }
+}
+
+impl TextureSample<f32> for Texture1D<f32> {
+    type Output = Vec4f;
+
+    fn sample(&self, sampler: &Sampler, coords: f32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result = sample_texture_1d(&data, &sampler_state, coords, 0);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleLevel<f32, f32> for Texture1D<f32> {
+    type Output = Vec4f;
+
+    fn sample_level(&self, sampler: &Sampler, coords: f32, level: f32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let level = level.floor() as u32;
+        let data = self.get();
+        let result = sample_texture_1d(&data, &sampler_state, coords, level);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleLevel<f32, i32> for Texture1D<f32> {
+    type Output = Vec4f;
+
+    fn sample_level(&self, sampler: &Sampler, coords: f32, level: i32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let level = if level < 0 { 0u32 } else { level as u32 };
+        let data = self.get();
+        let result = sample_texture_1d(&data, &sampler_state, coords, level);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleLevel<f32, u32> for Texture1D<f32> {
+    type Output = Vec4f;
+
+    fn sample_level(&self, sampler: &Sampler, coords: f32, level: u32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result = sample_texture_1d(&data, &sampler_state, coords, level);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleBias<f32, f32> for Texture1D<f32> {
+    type Output = Vec4f;
+
+    fn sample_bias(&self, sampler: &Sampler, coords: f32, _bias: f32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result = sample_texture_1d(&data, &sampler_state, coords, 0);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleGrad<f32, f32, f32> for Texture1D<f32> {
+    type Output = Vec4f;
+
+    fn sample_grad(&self, sampler: &Sampler, coords: f32, _ddx: f32, _ddy: f32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result = sample_texture_1d(&data, &sampler_state, coords, 0);
+        vec4f(result[0], result[1], result[2], result[3])
     }
 }
 
@@ -1111,6 +1179,13 @@ impl<T: WgslTextureScalar + Default + Copy> Texture3D<T> {
     pub fn init(&self, width: u32, height: u32, depth: u32) {
         self.set(TextureData3D::new(width, height, depth))
     }
+
+    /// Set a pixel at the given coordinates.
+    ///
+    /// Not available in WGSL.
+    pub fn set_pixel(&self, x: u32, y: u32, z: u32, value: [T; 4]) {
+        self.data.write().set_pixel(x, y, z, 0, value);
+    }
 }
 
 impl<T: WgslTextureScalar> Texture3D<T> {
@@ -1141,6 +1216,256 @@ impl<T: WgslTextureScalar + Default + Clone> TextureDimensionsQuery for Texture3
 impl<T: WgslTextureScalar + Default + Clone> TextureNumLevelsQuery for Texture3D<T> {
     fn query_num_levels(&self) -> u32 {
         self.get().num_levels()
+    }
+}
+
+impl<L: IntoLevel> TextureLoad<Vec3u, L> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn load(&self, coords: Vec3u, level: L) -> Self::Output {
+        let level = level.into_level();
+
+        self.get()
+            .get_pixel(coords.x(), coords.y(), coords.z(), level)
+            .map(|p| vec4f(p[0], p[1], p[2], p[3]))
+            .unwrap_or(vec4f(0.0, 0.0, 0.0, 0.0))
+    }
+}
+
+impl<L: IntoLevel> TextureLoad<Vec3i, L> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn load(&self, coords: Vec3i, level: L) -> Self::Output {
+        let x = coords.x().max(0) as u32;
+        let y = coords.y().max(0) as u32;
+        let z = coords.z().max(0) as u32;
+        self.load(vec3u(x, y, z), level)
+    }
+}
+
+impl<L: IntoLevel> TextureLoad<Vec3u, L> for Texture3D<i32> {
+    type Output = Vec4i;
+
+    fn load(&self, coords: Vec3u, level: L) -> Self::Output {
+        let level = level.into_level();
+
+        self.get()
+            .get_pixel(coords.x(), coords.y(), coords.z(), level)
+            .map(|p| vec4i(p[0], p[1], p[2], p[3]))
+            .unwrap_or(vec4i(0, 0, 0, 0))
+    }
+}
+
+impl<L: IntoLevel> TextureLoad<Vec3i, L> for Texture3D<i32> {
+    type Output = Vec4i;
+
+    fn load(&self, coords: Vec3i, level: L) -> Self::Output {
+        let x = coords.x().max(0) as u32;
+        let y = coords.y().max(0) as u32;
+        let z = coords.z().max(0) as u32;
+        self.load(vec3u(x, y, z), level)
+    }
+}
+
+impl<L: IntoLevel> TextureLoad<Vec3u, L> for Texture3D<u32> {
+    type Output = Vec4u;
+
+    fn load(&self, coords: Vec3u, level: L) -> Self::Output {
+        let level = level.into_level();
+
+        self.get()
+            .get_pixel(coords.x(), coords.y(), coords.z(), level)
+            .map(|p| vec4u(p[0], p[1], p[2], p[3]))
+            .unwrap_or(vec4u(0, 0, 0, 0))
+    }
+}
+
+impl<L: IntoLevel> TextureLoad<Vec3i, L> for Texture3D<u32> {
+    type Output = Vec4u;
+
+    fn load(&self, coords: Vec3i, level: L) -> Self::Output {
+        let x = coords.x().max(0) as u32;
+        let y = coords.y().max(0) as u32;
+        let z = coords.z().max(0) as u32;
+        self.load(vec3u(x, y, z), level)
+    }
+}
+
+impl TextureSample<Vec3f> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn sample(&self, sampler: &Sampler, coords: Vec3f) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result =
+            sample_texture_3d(&data, &sampler_state, coords.x(), coords.y(), coords.z(), 0);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleOffset<Vec3f, Vec3i> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn sample_offset(&self, sampler: &Sampler, coords: Vec3f, offset: Vec3i) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let (w, h, d) = data.dimensions(0);
+        let u = coords.x() + offset.x() as f32 / w.max(1) as f32;
+        let v = coords.y() + offset.y() as f32 / h.max(1) as f32;
+        let w_coord = coords.z() + offset.z() as f32 / d.max(1) as f32;
+        let result = sample_texture_3d(&data, &sampler_state, u, v, w_coord, 0);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleLevel<Vec3f, f32> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn sample_level(&self, sampler: &Sampler, coords: Vec3f, level: f32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let level = level.floor() as u32;
+        let data = self.get();
+        let result = sample_texture_3d(
+            &data,
+            &sampler_state,
+            coords.x(),
+            coords.y(),
+            coords.z(),
+            level,
+        );
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleLevel<Vec3f, i32> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn sample_level(&self, sampler: &Sampler, coords: Vec3f, level: i32) -> Self::Output {
+        let level = if level < 0 { 0u32 } else { level as u32 };
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result = sample_texture_3d(
+            &data,
+            &sampler_state,
+            coords.x(),
+            coords.y(),
+            coords.z(),
+            level,
+        );
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleLevel<Vec3f, u32> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn sample_level(&self, sampler: &Sampler, coords: Vec3f, level: u32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result = sample_texture_3d(
+            &data,
+            &sampler_state,
+            coords.x(),
+            coords.y(),
+            coords.z(),
+            level,
+        );
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleLevelOffset<Vec3f, f32, Vec3i> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn sample_level_offset(
+        &self,
+        sampler: &Sampler,
+        coords: Vec3f,
+        level: f32,
+        offset: Vec3i,
+    ) -> Self::Output {
+        let sampler_state = sampler.get();
+        let level = level.floor() as u32;
+        let data = self.get();
+        let (w, h, d) = data.dimensions(level);
+        let u = coords.x() + offset.x() as f32 / w.max(1) as f32;
+        let v = coords.y() + offset.y() as f32 / h.max(1) as f32;
+        let w_coord = coords.z() + offset.z() as f32 / d.max(1) as f32;
+        let result = sample_texture_3d(&data, &sampler_state, u, v, w_coord, level);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleBias<Vec3f, f32> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn sample_bias(&self, sampler: &Sampler, coords: Vec3f, _bias: f32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result =
+            sample_texture_3d(&data, &sampler_state, coords.x(), coords.y(), coords.z(), 0);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleBiasOffset<Vec3f, f32, Vec3i> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn sample_bias_offset(
+        &self,
+        sampler: &Sampler,
+        coords: Vec3f,
+        _bias: f32,
+        offset: Vec3i,
+    ) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let (w, h, d) = data.dimensions(0);
+        let u = coords.x() + offset.x() as f32 / w.max(1) as f32;
+        let v = coords.y() + offset.y() as f32 / h.max(1) as f32;
+        let w_coord = coords.z() + offset.z() as f32 / d.max(1) as f32;
+        let result = sample_texture_3d(&data, &sampler_state, u, v, w_coord, 0);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleGrad<Vec3f, Vec3f, Vec3f> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn sample_grad(
+        &self,
+        sampler: &Sampler,
+        coords: Vec3f,
+        _ddx: Vec3f,
+        _ddy: Vec3f,
+    ) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result =
+            sample_texture_3d(&data, &sampler_state, coords.x(), coords.y(), coords.z(), 0);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleGradOffset<Vec3f, Vec3f, Vec3f, Vec3i> for Texture3D<f32> {
+    type Output = Vec4f;
+
+    fn sample_grad_offset(
+        &self,
+        sampler: &Sampler,
+        coords: Vec3f,
+        _ddx: Vec3f,
+        _ddy: Vec3f,
+        offset: Vec3i,
+    ) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let (w, h, d) = data.dimensions(0);
+        let u = coords.x() + offset.x() as f32 / w.max(1) as f32;
+        let v = coords.y() + offset.y() as f32 / h.max(1) as f32;
+        let w_coord = coords.z() + offset.z() as f32 / d.max(1) as f32;
+        let result = sample_texture_3d(&data, &sampler_state, u, v, w_coord, 0);
+        vec4f(result[0], result[1], result[2], result[3])
     }
 }
 
@@ -1222,6 +1547,104 @@ impl<T: WgslTextureScalar + Default + Copy> TextureDimensionsQuery for TextureCu
 impl<T: WgslTextureScalar + Default + Clone> TextureNumLevelsQuery for TextureCube<T> {
     fn query_num_levels(&self) -> u32 {
         self.get().num_levels()
+    }
+}
+
+impl TextureSample<Vec3f> for TextureCube<f32> {
+    type Output = Vec4f;
+
+    fn sample(&self, sampler: &Sampler, coords: Vec3f) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result =
+            sample_texture_cube(&data, &sampler_state, coords.x(), coords.y(), coords.z(), 0);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleLevel<Vec3f, f32> for TextureCube<f32> {
+    type Output = Vec4f;
+
+    fn sample_level(&self, sampler: &Sampler, coords: Vec3f, level: f32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let level = level.floor() as u32;
+        let data = self.get();
+        let result = sample_texture_cube(
+            &data,
+            &sampler_state,
+            coords.x(),
+            coords.y(),
+            coords.z(),
+            level,
+        );
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleLevel<Vec3f, i32> for TextureCube<f32> {
+    type Output = Vec4f;
+
+    fn sample_level(&self, sampler: &Sampler, coords: Vec3f, level: i32) -> Self::Output {
+        let level = if level < 0 { 0u32 } else { level as u32 };
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result = sample_texture_cube(
+            &data,
+            &sampler_state,
+            coords.x(),
+            coords.y(),
+            coords.z(),
+            level,
+        );
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleLevel<Vec3f, u32> for TextureCube<f32> {
+    type Output = Vec4f;
+
+    fn sample_level(&self, sampler: &Sampler, coords: Vec3f, level: u32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result = sample_texture_cube(
+            &data,
+            &sampler_state,
+            coords.x(),
+            coords.y(),
+            coords.z(),
+            level,
+        );
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleBias<Vec3f, f32> for TextureCube<f32> {
+    type Output = Vec4f;
+
+    fn sample_bias(&self, sampler: &Sampler, coords: Vec3f, _bias: f32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result =
+            sample_texture_cube(&data, &sampler_state, coords.x(), coords.y(), coords.z(), 0);
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleGrad<Vec3f, Vec3f, Vec3f> for TextureCube<f32> {
+    type Output = Vec4f;
+
+    fn sample_grad(
+        &self,
+        sampler: &Sampler,
+        coords: Vec3f,
+        _ddx: Vec3f,
+        _ddy: Vec3f,
+    ) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result =
+            sample_texture_cube(&data, &sampler_state, coords.x(), coords.y(), coords.z(), 0);
+        vec4f(result[0], result[1], result[2], result[3])
     }
 }
 
@@ -1309,6 +1732,153 @@ impl<T: WgslTextureScalar> TextureNumLayersQuery for TextureCubeArray<T> {
 impl<T: WgslTextureScalar> TextureNumLevelsQuery for TextureCubeArray<T> {
     fn query_num_levels(&self) -> u32 {
         self.get().num_levels()
+    }
+}
+
+impl TextureSampleArray<Vec3f, u32> for TextureCubeArray<f32> {
+    type Output = Vec4f;
+
+    fn sample_array(&self, sampler: &Sampler, coords: Vec3f, array_index: u32) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result = sample_texture_cube_array(
+            &data,
+            &sampler_state,
+            coords.x(),
+            coords.y(),
+            coords.z(),
+            array_index,
+            0,
+        );
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleArray<Vec3f, i32> for TextureCubeArray<f32> {
+    type Output = Vec4f;
+
+    fn sample_array(&self, sampler: &Sampler, coords: Vec3f, array_index: i32) -> Self::Output {
+        self.sample_array(sampler, coords, array_index.max(0) as u32)
+    }
+}
+
+impl TextureSampleLevelArray<Vec3f, u32, f32> for TextureCubeArray<f32> {
+    type Output = Vec4f;
+
+    fn sample_level_array(
+        &self,
+        sampler: &Sampler,
+        coords: Vec3f,
+        array_index: u32,
+        level: f32,
+    ) -> Self::Output {
+        let sampler_state = sampler.get();
+        let level = level.floor() as u32;
+        let data = self.get();
+        let result = sample_texture_cube_array(
+            &data,
+            &sampler_state,
+            coords.x(),
+            coords.y(),
+            coords.z(),
+            array_index,
+            level,
+        );
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleLevelArray<Vec3f, i32, f32> for TextureCubeArray<f32> {
+    type Output = Vec4f;
+
+    fn sample_level_array(
+        &self,
+        sampler: &Sampler,
+        coords: Vec3f,
+        array_index: i32,
+        level: f32,
+    ) -> Self::Output {
+        self.sample_level_array(sampler, coords, array_index.max(0) as u32, level)
+    }
+}
+
+impl TextureSampleBiasArray<Vec3f, u32, f32> for TextureCubeArray<f32> {
+    type Output = Vec4f;
+
+    fn sample_bias_array(
+        &self,
+        sampler: &Sampler,
+        coords: Vec3f,
+        array_index: u32,
+        _bias: f32,
+    ) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result = sample_texture_cube_array(
+            &data,
+            &sampler_state,
+            coords.x(),
+            coords.y(),
+            coords.z(),
+            array_index,
+            0,
+        );
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleBiasArray<Vec3f, i32, f32> for TextureCubeArray<f32> {
+    type Output = Vec4f;
+
+    fn sample_bias_array(
+        &self,
+        sampler: &Sampler,
+        coords: Vec3f,
+        array_index: i32,
+        bias: f32,
+    ) -> Self::Output {
+        self.sample_bias_array(sampler, coords, array_index.max(0) as u32, bias)
+    }
+}
+
+impl TextureSampleGradArray<Vec3f, u32, Vec3f, Vec3f> for TextureCubeArray<f32> {
+    type Output = Vec4f;
+
+    fn sample_grad_array(
+        &self,
+        sampler: &Sampler,
+        coords: Vec3f,
+        array_index: u32,
+        _ddx: Vec3f,
+        _ddy: Vec3f,
+    ) -> Self::Output {
+        let sampler_state = sampler.get();
+        let data = self.get();
+        let result = sample_texture_cube_array(
+            &data,
+            &sampler_state,
+            coords.x(),
+            coords.y(),
+            coords.z(),
+            array_index,
+            0,
+        );
+        vec4f(result[0], result[1], result[2], result[3])
+    }
+}
+
+impl TextureSampleGradArray<Vec3f, i32, Vec3f, Vec3f> for TextureCubeArray<f32> {
+    type Output = Vec4f;
+
+    fn sample_grad_array(
+        &self,
+        sampler: &Sampler,
+        coords: Vec3f,
+        array_index: i32,
+        ddx: Vec3f,
+        ddy: Vec3f,
+    ) -> Self::Output {
+        self.sample_grad_array(sampler, coords, array_index.max(0) as u32, ddx, ddy)
     }
 }
 
@@ -2925,7 +3495,7 @@ impl<F: WgslTexelFormat, A: WgslStorageAccess> TextureDimensionsQuery for Textur
 
 #[cfg(test)]
 mod tests {
-    use crate::std::{ReadWrite, Write, vec2f, vec2i};
+    use crate::std::{ReadWrite, Write, vec2f, vec2i, vec3f, vec3i};
 
     use super::*;
 
@@ -3704,5 +4274,284 @@ mod tests {
         assert_eq!(pixel.y(), 20);
         assert_eq!(pixel.z(), 30);
         assert_eq!(pixel.w(), 40);
+    }
+
+    #[test]
+    fn test_texture_1d_sample() {
+        let tex: Texture1D<f32> = Texture1D::new(0, 0);
+        tex.init(4);
+        tex.data.write().set_pixel(0, 0, [1.0, 0.0, 0.0, 1.0]);
+        tex.data.write().set_pixel(1, 0, [0.0, 1.0, 0.0, 1.0]);
+        tex.data.write().set_pixel(2, 0, [0.0, 0.0, 1.0, 1.0]);
+        tex.data.write().set_pixel(3, 0, [1.0, 1.0, 0.0, 1.0]);
+
+        let sampler = Sampler::new(0, 0);
+        sampler.init();
+
+        // Nearest filtering: 0.125 maps to texel 0 (red)
+        let color = texture_sample(&tex, &sampler, 0.125f32);
+        assert!((color.x() - 1.0).abs() < 0.001);
+        assert!((color.y() - 0.0).abs() < 0.001);
+
+        // 0.625 maps to texel 2 (blue)
+        let color = texture_sample(&tex, &sampler, 0.625f32);
+        assert!((color.z() - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_texture_1d_sample_level() {
+        let tex: Texture1D<f32> = Texture1D::new(0, 0);
+        tex.init(4);
+        tex.data.write().set_pixel(1, 0, [0.5, 0.25, 0.125, 1.0]);
+
+        let sampler = Sampler::new(0, 0);
+        sampler.init();
+
+        let color = texture_sample_level(&tex, &sampler, 0.375f32, 0.0f32);
+        assert!((color.x() - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_texture_3d_load() {
+        let tex: Texture3D<f32> = Texture3D::new(0, 0);
+        tex.init(4, 4, 2);
+        tex.set_pixel(1, 2, 0, [0.5, 0.25, 0.125, 1.0]);
+        tex.set_pixel(1, 2, 1, [0.9, 0.8, 0.7, 0.6]);
+
+        // Load from z=0
+        let pixel = texture_load(&tex, vec3u(1, 2, 0), 0u32);
+        assert!((pixel.x() - 0.5).abs() < 0.001);
+        assert!((pixel.y() - 0.25).abs() < 0.001);
+
+        // Load from z=1
+        let pixel = texture_load(&tex, vec3u(1, 2, 1), 0u32);
+        assert!((pixel.x() - 0.9).abs() < 0.001);
+
+        // Load with i32 coords
+        let pixel = texture_load(&tex, vec3i(1, 2, 1), 0i32);
+        assert!((pixel.x() - 0.9).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_texture_3d_sample_nearest() {
+        let tex: Texture3D<f32> = Texture3D::new(0, 0);
+        tex.init(2, 2, 2);
+        // Set distinct colors at each corner of the 2x2x2 volume
+        tex.set_pixel(0, 0, 0, [1.0, 0.0, 0.0, 1.0]); // red
+        tex.set_pixel(1, 0, 0, [0.0, 1.0, 0.0, 1.0]); // green
+        tex.set_pixel(0, 1, 0, [0.0, 0.0, 1.0, 1.0]); // blue
+        tex.set_pixel(1, 1, 0, [1.0, 1.0, 0.0, 1.0]); // yellow
+        tex.set_pixel(0, 0, 1, [1.0, 0.0, 1.0, 1.0]); // magenta
+        tex.set_pixel(1, 0, 1, [0.0, 1.0, 1.0, 1.0]); // cyan
+        tex.set_pixel(0, 1, 1, [0.5, 0.5, 0.5, 1.0]); // gray
+        tex.set_pixel(1, 1, 1, [1.0, 1.0, 1.0, 1.0]); // white
+
+        let sampler = Sampler::new(0, 0);
+        sampler.init(); // Nearest filtering
+
+        // 0.25 maps to texel 0, 0.75 maps to texel 1
+        let color = texture_sample(&tex, &sampler, vec3f(0.25, 0.25, 0.25));
+        assert!((color.x() - 1.0).abs() < 0.001); // red
+        assert!((color.y() - 0.0).abs() < 0.001);
+
+        let color = texture_sample(&tex, &sampler, vec3f(0.75, 0.75, 0.75));
+        assert!((color.x() - 1.0).abs() < 0.001); // white
+        assert!((color.y() - 1.0).abs() < 0.001);
+        assert!((color.z() - 1.0).abs() < 0.001);
+
+        // z=1, x=0, y=1 -> gray
+        let color = texture_sample(&tex, &sampler, vec3f(0.25, 0.75, 0.75));
+        assert!((color.x() - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_texture_3d_sample_level() {
+        let tex: Texture3D<f32> = Texture3D::new(0, 0);
+        tex.init(2, 2, 2);
+        tex.set_pixel(0, 0, 0, [0.5, 0.5, 0.5, 1.0]);
+
+        let sampler = Sampler::new(0, 0);
+        sampler.init();
+
+        let color = texture_sample_level(&tex, &sampler, vec3f(0.25, 0.25, 0.25), 0.0f32);
+        assert!((color.x() - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_texture_3d_sample_linear() {
+        // 2x2x2 texture: only texel (0,0,0) is non-zero.
+        // Under linear filtering at coords (0,0,0):
+        //   half_texel = 0.5/2 = 0.25
+        //   u - 0.25 = -0.25, scaled by 2 -> -0.5, floor.clamp -> texel 0, frac 0.5
+        //   So x0=0, x1=1, fx=0.5 (similarly y, z)
+        //   Only c000 = [1,0,0,1]; all other 7 corners are [0,0,0,0].
+        //   Trilinear: 0.5^3 weight on c000 -> r = 0.125, w = 0.125.
+        let tex: Texture3D<f32> = Texture3D::new(0, 0);
+        tex.init(2, 2, 2);
+        tex.set_pixel(0, 0, 0, [1.0, 0.0, 0.0, 1.0]);
+
+        let sampler = Sampler::new(0, 0);
+        sampler.set(SamplerState::linear());
+
+        let color = texture_sample(&tex, &sampler, vec3f(0.0, 0.0, 0.0));
+        assert!(
+            (color.x() - 0.125).abs() < 0.001,
+            "expected r=0.125 from trilinear, got {}",
+            color.x()
+        );
+        assert!((color.y() - 0.0).abs() < 0.001);
+        assert!((color.z() - 0.0).abs() < 0.001);
+        assert!(
+            (color.w() - 0.125).abs() < 0.001,
+            "expected w=0.125 from trilinear, got {}",
+            color.w()
+        );
+
+        // At coords (1,1,1) with linear filtering:
+        //   u=1, u-0.25=0.75, *2=1.5, floor=1, frac=0.5 -> x0=1, x1=1, fx=0.5
+        // So c000 is not reached (x0=1, not 0). All 8 corners are 0. Result = 0.
+        let color = texture_sample(&tex, &sampler, vec3f(1.0, 1.0, 1.0));
+        assert!((color.x() - 0.0).abs() < 0.001);
+
+        // At coords (0.25, 0.25, 0.25): the (0,0,0) corner gets full weight.
+        //   u=0.25, u-0.25=0, *2=0, floor=0, frac=0 -> x0=0, x1=1, fx=0
+        //   fx=fy=fz=0 -> weight on c000 = 1.0 -> r = 1.0
+        let color = texture_sample(&tex, &sampler, vec3f(0.25, 0.25, 0.25));
+        assert!(
+            (color.x() - 1.0).abs() < 0.001,
+            "expected r=1.0 at (0.25,0.25,0.25), got {}",
+            color.x()
+        );
+    }
+
+    #[test]
+    fn test_texture_cube_sample() {
+        // Verify all 6 cube faces are selected correctly. Each face gets a
+        // distinct color at texel (0, 0). The sampling direction is chosen so
+        // that the major axis selects the target face and the projection maps
+        // to near (0, 0) within that face, hitting texel (0, 0) under nearest
+        // filtering on a 4x4 face.
+        //
+        // Face order: 0=+X, 1=-X, 2=+Y, 3=-Y, 4=+Z, 5=-Z.
+        let face_colors: [[f32; 4]; 6] = [
+            [1.0, 0.0, 0.0, 1.0], // +X: red
+            [0.0, 1.0, 0.0, 1.0], // -X: green
+            [0.0, 0.0, 1.0, 1.0], // +Y: blue
+            [1.0, 1.0, 0.0, 1.0], // -Y: yellow
+            [1.0, 0.0, 1.0, 1.0], // +Z: magenta
+            [0.0, 1.0, 1.0, 1.0], // -Z: cyan
+        ];
+
+        // (direction, expected_face_index)
+        // Each direction makes the target axis the strict major axis, so face
+        // selection is unambiguous. The non-major components are ±0.9 so the
+        // projection lands near u=v=0.05 (texel 0 on a 4-wide face).
+        let cases: [([f32; 3], usize); 6] = [
+            ([1.0, 0.9, 0.9], 0),   // +X: u=0.5-0.9/2=0.05, v=0.05
+            ([-1.0, 0.9, -0.9], 1), // -X: u=0.5+(-0.9)/2=0.05, v=0.05
+            ([-0.9, 1.0, -0.9], 2), // +Y: u=0.5+(-0.9)/2=0.05, v=0.05
+            ([-0.9, -1.0, 0.9], 3), // -Y: u=0.05, v=0.05
+            ([-0.9, 0.9, 1.0], 4),  // +Z: u=0.05, v=0.05
+            ([0.9, 0.9, -1.0], 5),  // -Z: u=0.05, v=0.05
+        ];
+
+        let tex: TextureCube<f32> = TextureCube::new(0, 0);
+        tex.init(4);
+        for (face, &color) in face_colors.iter().enumerate() {
+            tex.data.write().faces[face].set_pixel(0, 0, 0, color);
+        }
+
+        let sampler = Sampler::new(0, 0);
+        sampler.init(); // Nearest
+
+        for (dir, face) in cases {
+            let color = texture_sample(&tex, &sampler, vec3f(dir[0], dir[1], dir[2]));
+            let expected = face_colors[face];
+            assert!(
+                (color.x() - expected[0]).abs() < 0.001,
+                "face {face} (+{}/{}) expected r={:.3}, got {color:?} for dir {dir:?}",
+                if face % 2 == 0 { '+' } else { '-' },
+                ['X', 'X', 'Y', 'Y', 'Z', 'Z'][face],
+                expected[0]
+            );
+            assert!(
+                (color.y() - expected[1]).abs() < 0.001,
+                "face {face} y mismatch"
+            );
+            assert!(
+                (color.z() - expected[2]).abs() < 0.001,
+                "face {face} z mismatch"
+            );
+        }
+    }
+
+    #[test]
+    fn test_texture_cube_sample_zero_direction() {
+        // A zero-length direction is degenerate. The CPU implementation
+        // returns a deterministic fallback (face 0, center) rather than NaN.
+        let tex: TextureCube<f32> = TextureCube::new(0, 0);
+        tex.init(4);
+        tex.data.write().faces[0].set_pixel(2, 2, 0, [0.5, 0.5, 0.5, 1.0]);
+
+        let sampler = Sampler::new(0, 0);
+        sampler.init();
+
+        let color = texture_sample(&tex, &sampler, vec3f(0.0, 0.0, 0.0));
+        // Should not be NaN; should return the center texel of face 0.
+        assert!(
+            color.x().is_finite(),
+            "zero direction should not produce NaN"
+        );
+        assert!((color.x() - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_texture_cube_sample_level() {
+        let tex: TextureCube<f32> = TextureCube::new(0, 0);
+        tex.init(2);
+        // Direction (1, 1, 1) selects +X face, u=0, v=0 -> texel (0, 0)
+        tex.data.write().faces[0].set_pixel(0, 0, 0, [0.5, 0.5, 0.5, 1.0]);
+
+        let sampler = Sampler::new(0, 0);
+        sampler.init();
+
+        let color = texture_sample_level(&tex, &sampler, vec3f(1.0, 1.0, 1.0), 0.0f32);
+        assert!((color.x() - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_texture_cube_array_sample() {
+        let tex: TextureCubeArray<f32> = TextureCubeArray::new(0, 0);
+        tex.init(2, 2);
+
+        // Layer 0, +X face, texel (0, 0) = red
+        tex.data.write().cubes[0].faces[0].set_pixel(0, 0, 0, [1.0, 0.0, 0.0, 1.0]);
+        // Layer 1, +X face, texel (0, 0) = green
+        tex.data.write().cubes[1].faces[0].set_pixel(0, 0, 0, [0.0, 1.0, 0.0, 1.0]);
+
+        let sampler = Sampler::new(0, 0);
+        sampler.init();
+
+        // Direction (1, 1, 1) selects +X face at (0, 0)
+        let color = texture_sample_array(&tex, &sampler, vec3f(1.0, 1.0, 1.0), 0u32);
+        assert!((color.x() - 1.0).abs() < 0.001, "expected red on layer 0");
+
+        let color = texture_sample_array(&tex, &sampler, vec3f(1.0, 1.0, 1.0), 1u32);
+        assert!((color.y() - 1.0).abs() < 0.001, "expected green on layer 1");
+    }
+
+    #[test]
+    fn test_texture_cube_array_sample_level() {
+        let tex: TextureCubeArray<f32> = TextureCubeArray::new(0, 0);
+        tex.init(2, 2);
+        tex.data.write().cubes[0].faces[0].set_pixel(0, 0, 0, [0.3, 0.6, 0.9, 1.0]);
+
+        let sampler = Sampler::new(0, 0);
+        sampler.init();
+
+        let color = texture_sample_level_array(&tex, &sampler, vec3f(1.0, 1.0, 1.0), 0u32, 0.0f32);
+        assert!((color.x() - 0.3).abs() < 0.001);
+        assert!((color.y() - 0.6).abs() < 0.001);
+        assert!((color.z() - 0.9).abs() < 0.001);
     }
 }

--- a/crates/wgsl-rs/src/std/texture/builtins.rs
+++ b/crates/wgsl-rs/src/std/texture/builtins.rs
@@ -278,6 +278,17 @@ impl<T> TextureData3D<T> {
             .get(y as usize)?
             .get(x as usize)
     }
+
+    /// Set a pixel at the given coordinate and mip level.
+    pub fn set_pixel(&mut self, x: u32, y: u32, z: u32, level: u32, value: [T; 4]) {
+        if let Some(mip) = self.mips.get_mut(level as usize)
+            && let Some(slice) = mip.get_mut(z as usize)
+            && let Some(row) = slice.get_mut(y as usize)
+            && let Some(pixel) = row.get_mut(x as usize)
+        {
+            *pixel = value;
+        }
+    }
 }
 
 /// CPU-side texture data for cube textures.
@@ -2226,7 +2237,11 @@ fn bilinear_interpolate<T: Copy + Default + Into<f32> + From<f32>>(
 fn normalized_to_texel(coord: f32, size: u32) -> (u32, f32) {
     let scaled = coord * size as f32;
     let texel = (scaled.floor() as i32).clamp(0, (size as i32) - 1) as u32;
-    let frac = scaled.fract();
+    // Use `scaled.fract().abs()` instead of `scaled.fract()` because
+    // `f32::fract` returns a negative value for negative inputs (e.g.
+    // `(-0.5).fract() == -0.5`), which would produce negative interpolation
+    // weights and nonsensical results when sampling below texel 0.
+    let frac = scaled.fract().abs();
     (texel, frac)
 }
 
@@ -2357,4 +2372,256 @@ pub(crate) fn gather_4_depth_texels(
     // WGSL gather order: x=(u_min,v_max), y=(u_max,v_max), z=(u_max,v_min),
     // w=(u_min,v_min)
     [bl, br, tr, tl]
+}
+
+/// Helper for trilinear interpolation across the 8 corners of a 3D cell.
+///
+/// `fx`, `fy`, `fz` are the fractional weights in `[0, 1)` for the +1
+/// direction along each axis. The 8 corners are named `(x0|y0|z0)` style:
+/// `c000`, `c100`, `c010`, `c110`, `c001`, `c101`, `c011`, `c111`, where
+/// a `1` in position `x/y/z` means the +1 texel along that axis.
+#[allow(clippy::too_many_arguments)]
+fn trilinear_interpolate<T: Copy + Default + Into<f32> + From<f32>>(
+    c000: [T; 4],
+    c100: [T; 4],
+    c010: [T; 4],
+    c110: [T; 4],
+    c001: [T; 4],
+    c101: [T; 4],
+    c011: [T; 4],
+    c111: [T; 4],
+    fx: f32,
+    fy: f32,
+    fz: f32,
+) -> [T; 4] {
+    let lerp = |a: f32, b: f32, t: f32| a * (1.0 - t) + b * t;
+    std::array::from_fn(|i| {
+        let top = lerp(
+            lerp(c000[i].into(), c100[i].into(), fx),
+            lerp(c010[i].into(), c110[i].into(), fx),
+            fy,
+        );
+        let bottom = lerp(
+            lerp(c001[i].into(), c101[i].into(), fx),
+            lerp(c011[i].into(), c111[i].into(), fx),
+            fy,
+        );
+        T::from(lerp(top, bottom, fz))
+    })
+}
+
+/// Sample a 1D texture at the given normalized coordinate.
+pub(crate) fn sample_texture_1d<T: Copy + Default + Into<f32> + From<f32>>(
+    data: &TextureData1D<T>,
+    sampler_state: &SamplerState,
+    u: f32,
+    level: u32,
+) -> [T; 4] {
+    let u = SamplerState::apply_address_mode(sampler_state.address_mode_u, u);
+
+    let width = data.width(level);
+    if width == 0 {
+        return std::array::from_fn(|_| T::default());
+    }
+
+    match sampler_state.min_filter {
+        FilterMode::Nearest => {
+            let x = Ord::min((u * width as f32).floor() as u32, width - 1);
+            data.get_pixel(x, level)
+                .copied()
+                .unwrap_or_else(|| std::array::from_fn(|_| T::default()))
+        }
+        FilterMode::Linear => {
+            let (x0, fx) = normalized_to_texel(u - 0.5 / width as f32, width);
+            let x1 = Ord::min(x0 + 1, width - 1);
+            let left = data
+                .get_pixel(x0, level)
+                .copied()
+                .unwrap_or_else(|| std::array::from_fn(|_| T::default()));
+            let right = data
+                .get_pixel(x1, level)
+                .copied()
+                .unwrap_or_else(|| std::array::from_fn(|_| T::default()));
+            std::array::from_fn(|i| T::from(left[i].into() * (1.0 - fx) + right[i].into() * fx))
+        }
+    }
+}
+
+/// Sample a 3D texture at the given normalized coordinates.
+///
+/// `u`, `v`, `w` are normalized coordinates in `[0, 1]`. The W coordinate
+/// uses `address_mode_w` for wrapping. Nearest filtering picks the nearest
+/// texel in 3D; linear filtering does trilinear interpolation across the 8
+/// surrounding texels.
+pub(crate) fn sample_texture_3d<T: Copy + Default + Into<f32> + From<f32>>(
+    data: &TextureData3D<T>,
+    sampler_state: &SamplerState,
+    u: f32,
+    v: f32,
+    w: f32,
+    level: u32,
+) -> [T; 4] {
+    let u = SamplerState::apply_address_mode(sampler_state.address_mode_u, u);
+    let v = SamplerState::apply_address_mode(sampler_state.address_mode_v, v);
+    let w = SamplerState::apply_address_mode(sampler_state.address_mode_w, w);
+
+    let (width, height, depth) = data.dimensions(level);
+    if width == 0 || height == 0 || depth == 0 {
+        return std::array::from_fn(|_| T::default());
+    }
+
+    match sampler_state.min_filter {
+        FilterMode::Nearest => {
+            let x = Ord::min((u * width as f32).floor() as u32, width - 1);
+            let y = Ord::min((v * height as f32).floor() as u32, height - 1);
+            let z = Ord::min((w * depth as f32).floor() as u32, depth - 1);
+            data.get_pixel(x, y, z, level)
+                .copied()
+                .unwrap_or_else(|| std::array::from_fn(|_| T::default()))
+        }
+        FilterMode::Linear => {
+            let (x0, fx) = normalized_to_texel(u - 0.5 / width as f32, width);
+            let (y0, fy) = normalized_to_texel(v - 0.5 / height as f32, height);
+            let (z0, fz) = normalized_to_texel(w - 0.5 / depth as f32, depth);
+            let x1 = Ord::min(x0 + 1, width - 1);
+            let y1 = Ord::min(y0 + 1, height - 1);
+            let z1 = Ord::min(z0 + 1, depth - 1);
+
+            let default_pixel = || std::array::from_fn(|_| T::default());
+            let c000 = data
+                .get_pixel(x0, y0, z0, level)
+                .copied()
+                .unwrap_or_else(default_pixel);
+            let c100 = data
+                .get_pixel(x1, y0, z0, level)
+                .copied()
+                .unwrap_or_else(default_pixel);
+            let c010 = data
+                .get_pixel(x0, y1, z0, level)
+                .copied()
+                .unwrap_or_else(default_pixel);
+            let c110 = data
+                .get_pixel(x1, y1, z0, level)
+                .copied()
+                .unwrap_or_else(default_pixel);
+            let c001 = data
+                .get_pixel(x0, y0, z1, level)
+                .copied()
+                .unwrap_or_else(default_pixel);
+            let c101 = data
+                .get_pixel(x1, y0, z1, level)
+                .copied()
+                .unwrap_or_else(default_pixel);
+            let c011 = data
+                .get_pixel(x0, y1, z1, level)
+                .copied()
+                .unwrap_or_else(default_pixel);
+            let c111 = data
+                .get_pixel(x1, y1, z1, level)
+                .copied()
+                .unwrap_or_else(default_pixel);
+
+            trilinear_interpolate(c000, c100, c010, c110, c001, c101, c011, c111, fx, fy, fz)
+        }
+    }
+}
+
+/// Selects the cube face and projected `(u, v)` coordinates for a given
+/// direction vector, using the standard WebGPU cube-map major-axis
+/// selection convention.
+///
+/// Returns `(face_index, u, v)` where `face_index` is in `0..6` following
+/// the WebGPU face order: 0=+X, 1=-X, 2=+Y, 3=-Y, 4=+Z, 5=-Z. The returned
+/// `u`, `v` are in `[0, 1]` within the selected face, suitable for passing
+/// to [`sample_texture_2d`].
+///
+/// A zero-length direction is degenerate (GPU behavior is undefined);
+/// this function returns face 0 at its center as a deterministic
+/// fallback rather than producing NaN from division by zero.
+///
+/// See <https://www.w3.org/TR/webgpu/#texture-view-format-cube>.
+fn select_cube_face(dx: f32, dy: f32, dz: f32) -> (usize, f32, f32) {
+    let ax = dx.abs();
+    let ay = dy.abs();
+    let az = dz.abs();
+    let ma = ax.max(ay).max(az);
+
+    // A zero-length direction is degenerate. Return a deterministic
+    // fallback to avoid division by zero.
+    if ma == 0.0 {
+        return (0, 0.5, 0.5);
+    }
+
+    // Major-axis selection. For each face the projection follows the
+    // standard cube-map convention: the two non-major axes are mapped to
+    // face (u, v), with sign flips depending on face orientation so that
+    // the texture is oriented correctly when viewed from outside the cube.
+    // The major axis is `ma`, so we divide by `2.0 * ma` to map the
+    // non-major components into [-0.5, 0.5] before centering at 0.5.
+    if ax == ma {
+        // X major
+        if dx >= 0.0 {
+            // +X face: u = -dz, v = -dy
+            (0, 0.5 - dz / (2.0 * ma), 0.5 - dy / (2.0 * ma))
+        } else {
+            // -X face: u = +dz, v = -dy
+            (1, 0.5 + dz / (2.0 * ma), 0.5 - dy / (2.0 * ma))
+        }
+    } else if ay == ma {
+        // Y major
+        if dy >= 0.0 {
+            // +Y face: u = +dx, v = +dz
+            (2, 0.5 + dx / (2.0 * ma), 0.5 + dz / (2.0 * ma))
+        } else {
+            // -Y face: u = +dx, v = -dz
+            (3, 0.5 + dx / (2.0 * ma), 0.5 - dz / (2.0 * ma))
+        }
+    } else {
+        // Z major
+        if dz >= 0.0 {
+            // +Z face: u = +dx, v = -dy
+            (4, 0.5 + dx / (2.0 * ma), 0.5 - dy / (2.0 * ma))
+        } else {
+            // -Z face: u = -dx, v = -dy
+            (5, 0.5 - dx / (2.0 * ma), 0.5 - dy / (2.0 * ma))
+        }
+    }
+}
+
+/// Sample a cube texture at the given direction.
+///
+/// The direction `(dx, dy, dz)` is first mapped to a face via
+/// [`select_cube_face`], then the face's 2D texture is sampled using
+/// [`sample_texture_2d`]. The W component of the sampler's address modes
+/// is not applied (cube textures have no W coordinate).
+pub(crate) fn sample_texture_cube<T: Copy + Default + Into<f32> + From<f32>>(
+    data: &TextureDataCube<T>,
+    sampler_state: &SamplerState,
+    dx: f32,
+    dy: f32,
+    dz: f32,
+    level: u32,
+) -> [T; 4] {
+    let (face, u, v) = select_cube_face(dx, dy, dz);
+    sample_texture_2d(&data.faces[face], sampler_state, u, v, level)
+}
+
+/// Sample a cube array texture at the given direction and array layer.
+///
+/// The `array_index` is clamped to `[0, num_layers - 1]` before sampling
+/// the selected cube via [`sample_texture_cube`].
+pub(crate) fn sample_texture_cube_array<T: Copy + Default + Into<f32> + From<f32>>(
+    data: &TextureDataCubeArray<T>,
+    sampler_state: &SamplerState,
+    dx: f32,
+    dy: f32,
+    dz: f32,
+    array_index: u32,
+    level: u32,
+) -> [T; 4] {
+    let layer = (array_index as usize).min(data.cubes.len().saturating_sub(1));
+    data.cubes
+        .get(layer)
+        .map(|cube| sample_texture_cube(cube, sampler_state, dx, dy, dz, level))
+        .unwrap_or_else(|| std::array::from_fn(|_| T::default()))
 }


### PR DESCRIPTION
Adds CPU-side sampling trait impls for the remaining sampled texture types from the WGSL spec.

- **Texture1D**: TextureSample, TextureSampleLevel, TextureSampleBias, TextureSampleGrad
- **Texture3D**: TextureSample (+ offset), TextureSampleLevel (+ offset), TextureSampleBias (+ offset), TextureSampleGrad (+ offset), plus TextureLoad for f32/i32/u32
- **TextureCube**: TextureSample, TextureSampleLevel, TextureSampleBias, TextureSampleGrad (major-axis face selection per WebGPU spec)
- **TextureCubeArray**: TextureSampleArray, TextureSampleLevelArray, TextureSampleBiasArray, TextureSampleGradArray (u32 and i32 array indices)

New helpers: `sample_texture_1d`, `sample_texture_3d` (trilinear), `sample_texture_cube`, `select_cube_face`, `trilinear_interpolate`. Also adds the missing `TextureData3D::set_pixel` and a `texture_sample_3d` roundtrip test (CPU vs GPU, max error 0.00e0).

Closes #151

Follow up: 
* #157 
* 
[Agent session transcript](https://github.com/user-attachments/files/31344167/151_156.json)

