### PR TITLE
feat: implement all WGSL matrix multiplication combinations

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -671,3 +671,62 @@ don't need return types, so they can be passed through as `Stmt::Macro`.
 This is why crabslab's `slab_read!`/`slab_write!` are statement macros
 (4 args including a dest name) rather than expressions.
 
+
+### 2026-08-23: Implement all WGSL matrix * vector, vector * matrix, and matrix * matrix combinations
+
+**Problem:**
+wgsl-rs only implemented `Mat * Vec` for the three square matrix types
+(`Mat2x2f`, `Mat3x3f`, `Mat4x4f`), delegating to glam. The row-vector * matrix
+product (`v * m`) was not implemented at all (GitHub issue #152), and neither
+were any non-square `Mat * Vec` or any non-square `Mat * Mat` combinations.
+glam has no non-square matrix types, so those cases had no glam fallback.
+
+**Decision:**
+Implement every WGSL-spec-valid multiplication combination in
+`crates/wgsl-rs/src/std/matrix.rs` via three macros:
+
+- `impl_mat_vec_mul!`: all 9 `matCxR * vecC -> vecR` cases. Row i of the
+  output is the dot product of row i of the matrix with the input vector.
+- `impl_vec_mat_mul!`: all 9 `vecR * matCxR -> vecC` cases. Component i of
+  the output is `dot(v, m.columns[i])` (the spec's
+  `transpose(transpose(m) * transpose(v))` lowered to column dots).
+- `impl_mat_mat_mul!`: all 27 `matKxR * matCxK -> matCxR` cases. Column j
+  of the output is `a * b.columns[j]`, reusing the `Mat * Vec` impl.
+
+Square `Mat * Mat` and `Mat * Vec` cases were previously delegated to glam;
+they now go through the same macro path as non-square cases for uniformity
+and so that all the linear-algebra semantics live in one auditable place.
+Scalar * matrix (and matrix * scalar) for the square types still delegate
+to glam; non-square scalar multiplication is implemented with a small
+`impl_mat_scalar_mul!` macro that multiplies each column vector.
+
+**Justification:**
+- Spec-compliant: the WGSL spec (`arithmetic-expr` section) defines all
+  three product kinds for every compatible shape combination; wgsl-rs
+  should mirror that on the CPU side so the "two worlds" agree.
+- GPU-side is trivial: the `#[wgsl]` macro lowers `*` to the WGSL `*`
+  operator regardless of operand shapes, so the GPU already handled every
+  case correctly. The fix is purely CPU-side trait impls so Rust type
+  inference resolves and the CPU `dispatch_workgroups` path matches.
+- Macro-based: the three macros keep the 45 total impls compact and ensure
+  every combination uses the same computation shape, making it easy to
+  audit against the spec. The `:tt` fragment specifier is used for the
+  dimension arguments so they can be matched against literal `2`/`3`/`4`
+  in the internal helper arms.
+- Verified by roundtrip tests: six new `#[wgsl]` compute shader modules
+  in `roundtrip-tests` (vec3*mat2x3, vec2*mat3x2, mat2x3*vec2, mat3x2*vec3,
+  mat2x3*mat3x2, mat3x2*mat2x3) confirm CPU and GPU outputs agree to within
+  ~1e-5 on Apple M4 Max / Metal.
+
+**Why not delegate non-square to glam?** glam 0.30 has no `Mat2x3`/`Mat3x2`/
+etc. types, so there is no glam implementation to delegate to. A manual
+implementation is required for non-square cases, and using the same manual
+path for square cases keeps the code uniform and removes a glam dependency
+from the multiplication hot path.
+
+**Performance tradeoff:** moving square `Mat*Mat` and `Mat*Vec` off glam
+trades glam's SIMD path for scalar component arithmetic on the two most
+common CPU-side matrix ops (`Mat4f * Vec4f`, `Mat4f * Mat4f`). This is
+acceptable because the CPU path in wgsl-rs exists primarily to validate
+the GPU path in roundtrip tests, not as a hot execution path. Revisit if
+CPU matrix math shows up in a profile for a downstream crate.

--- a/crates/example/src/examples.rs
+++ b/crates/example/src/examples.rs
@@ -27,6 +27,7 @@ pub const EXAMPLE_MODULES: &[&wgsl_rs::Source] = &[
     &packing_example::WGSL_SOURCE,
     &advanced_numeric_example::WGSL_SOURCE,
     &matrix_builtin_example::WGSL_SOURCE,
+    &vec_mat_mul_example::WGSL_SOURCE,
     &synchronization_example::WGSL_SOURCE,
     &macro_rules_definitions::WGSL_SOURCE,
     &slab_read_write::WGSL_SOURCE,
@@ -1266,6 +1267,33 @@ pub mod matrix_builtin_example {
 
     pub fn demo_transpose_4x4(m: Mat4f) -> Mat4f {
         transpose(m)
+    }
+}
+
+#[wgsl]
+pub mod vec_mat_mul_example {
+    //! Demonstrates row-vector * matrix, non-square matrix * vector, and
+    //! non-square matrix * matrix multiplication.
+    //!
+    //! WGSL allows `v * m` (row-vector-matrix product), `m * v` (column-
+    //! vector-matrix product), and `a * b` for any compatible matrix shapes,
+    //! not just square matrices. These operations all lower to the WGSL `*`
+    //! operator.
+    use wgsl_rs::std::*;
+
+    /// Row-vector * matrix: `Vec3f * Mat2x3f -> Vec2f`.
+    pub fn row_vec_times_mat(v: Vec3f, m: Mat2x3f) -> Vec2f {
+        v * m
+    }
+
+    /// Non-square matrix * vector: `Mat2x3f * Vec2f -> Vec3f`.
+    pub fn mat_times_vec_nonsquare(m: Mat2x3f, v: Vec2f) -> Vec3f {
+        m * v
+    }
+
+    /// Non-square matrix * matrix: `Mat2x3f * Mat3x2f -> Mat3x3f`.
+    pub fn mat_times_mat_nonsquare(a: Mat2x3f, b: Mat3x2f) -> Mat3x3f {
+        a * b
     }
 }
 

--- a/crates/roundtrip-tests/src/shaders/matrix_operations.rs
+++ b/crates/roundtrip-tests/src/shaders/matrix_operations.rs
@@ -590,6 +590,197 @@ pub mod mat4_vec4_mul {
     }
 }
 
+// === Row-vector * matrix (the issue #152 case) ===============================
+
+#[wgsl]
+pub mod vec3_mat2x3_mul {
+    use wgsl_rs::std::*;
+
+    storage!(group(0), binding(0), INPUT: [f32; 576]);
+    storage!(group(0), binding(1), read_write, OUTPUT: [f32; 128]);
+
+    /// Computes Vec3f * Mat2x3f -> Vec2f for 64 inputs.
+    #[compute]
+    #[workgroup_size(64)]
+    pub fn main(#[builtin(global_invocation_id)] global_id: Vec3u) {
+        let idx = global_id.x as usize;
+        let base = idx * 9;
+        let input = get!(INPUT);
+
+        let m = mat2x3f(
+            vec3f(input[base], input[base + 1], input[base + 2]),
+            vec3f(input[base + 3], input[base + 4], input[base + 5]),
+        );
+        let v = vec3f(input[base + 6], input[base + 7], input[base + 8]);
+        let out: Vec2f = v * m;
+
+        get_mut!(OUTPUT)[idx * 2] = out.x;
+        get_mut!(OUTPUT)[idx * 2 + 1] = out.y;
+    }
+}
+
+#[wgsl]
+pub mod vec2_mat3x2_mul {
+    use wgsl_rs::std::*;
+
+    storage!(group(0), binding(0), INPUT: [f32; 512]);
+    storage!(group(0), binding(1), read_write, OUTPUT: [f32; 192]);
+
+    /// Computes Vec2f * Mat3x2f -> Vec3f for 64 inputs.
+    #[compute]
+    #[workgroup_size(64)]
+    pub fn main(#[builtin(global_invocation_id)] global_id: Vec3u) {
+        let idx = global_id.x as usize;
+        let base = idx * 8;
+        let input = get!(INPUT);
+
+        let m = mat3x2f(
+            vec2f(input[base], input[base + 1]),
+            vec2f(input[base + 2], input[base + 3]),
+            vec2f(input[base + 4], input[base + 5]),
+        );
+        let v = vec2f(input[base + 6], input[base + 7]);
+        let out: Vec3f = v * m;
+
+        get_mut!(OUTPUT)[idx * 3] = out.x;
+        get_mut!(OUTPUT)[idx * 3 + 1] = out.y;
+        get_mut!(OUTPUT)[idx * 3 + 2] = out.z;
+    }
+}
+
+// === Non-square matrix * vector ==============================================
+
+#[wgsl]
+pub mod mat2x3_vec2_mul {
+    use wgsl_rs::std::*;
+
+    storage!(group(0), binding(0), INPUT: [f32; 512]);
+    storage!(group(0), binding(1), read_write, OUTPUT: [f32; 192]);
+
+    /// Computes Mat2x3f * Vec2f -> Vec3f for 64 inputs.
+    #[compute]
+    #[workgroup_size(64)]
+    pub fn main(#[builtin(global_invocation_id)] global_id: Vec3u) {
+        let idx = global_id.x as usize;
+        let base = idx * 8;
+        let input = get!(INPUT);
+
+        let m = mat2x3f(
+            vec3f(input[base], input[base + 1], input[base + 2]),
+            vec3f(input[base + 3], input[base + 4], input[base + 5]),
+        );
+        let v = vec2f(input[base + 6], input[base + 7]);
+        let out: Vec3f = m * v;
+
+        get_mut!(OUTPUT)[idx * 3] = out.x;
+        get_mut!(OUTPUT)[idx * 3 + 1] = out.y;
+        get_mut!(OUTPUT)[idx * 3 + 2] = out.z;
+    }
+}
+
+#[wgsl]
+pub mod mat3x2_vec3_mul {
+    use wgsl_rs::std::*;
+
+    storage!(group(0), binding(0), INPUT: [f32; 576]);
+    storage!(group(0), binding(1), read_write, OUTPUT: [f32; 128]);
+
+    /// Computes Mat3x2f * Vec3f -> Vec2f for 64 inputs.
+    #[compute]
+    #[workgroup_size(64)]
+    pub fn main(#[builtin(global_invocation_id)] global_id: Vec3u) {
+        let idx = global_id.x as usize;
+        let base = idx * 9;
+        let input = get!(INPUT);
+
+        let m = mat3x2f(
+            vec2f(input[base], input[base + 1]),
+            vec2f(input[base + 2], input[base + 3]),
+            vec2f(input[base + 4], input[base + 5]),
+        );
+        let v = vec3f(input[base + 6], input[base + 7], input[base + 8]);
+        let out: Vec2f = m * v;
+
+        get_mut!(OUTPUT)[idx * 2] = out.x;
+        get_mut!(OUTPUT)[idx * 2 + 1] = out.y;
+    }
+}
+
+// === Non-square matrix * matrix ==============================================
+
+#[wgsl]
+pub mod mat2x3_mat3x2_mul {
+    use wgsl_rs::std::*;
+
+    storage!(group(0), binding(0), INPUT: [f32; 768]);
+    storage!(group(0), binding(1), read_write, OUTPUT: [f32; 576]);
+
+    /// Computes Mat2x3f * Mat3x2f -> Mat3x3f for 64 inputs.
+    #[compute]
+    #[workgroup_size(64)]
+    pub fn main(#[builtin(global_invocation_id)] global_id: Vec3u) {
+        let idx = global_id.x as usize;
+        let base = idx * 12;
+        let input = get!(INPUT);
+
+        let a = mat2x3f(
+            vec3f(input[base], input[base + 1], input[base + 2]),
+            vec3f(input[base + 3], input[base + 4], input[base + 5]),
+        );
+        let b = mat3x2f(
+            vec2f(input[base + 6], input[base + 7]),
+            vec2f(input[base + 8], input[base + 9]),
+            vec2f(input[base + 10], input[base + 11]),
+        );
+        let out: Mat3x3f = a * b;
+
+        let out_base = idx * 9;
+        get_mut!(OUTPUT)[out_base] = out[0usize].x;
+        get_mut!(OUTPUT)[out_base + 1] = out[0usize].y;
+        get_mut!(OUTPUT)[out_base + 2] = out[0usize].z;
+        get_mut!(OUTPUT)[out_base + 3] = out[1usize].x;
+        get_mut!(OUTPUT)[out_base + 4] = out[1usize].y;
+        get_mut!(OUTPUT)[out_base + 5] = out[1usize].z;
+        get_mut!(OUTPUT)[out_base + 6] = out[2usize].x;
+        get_mut!(OUTPUT)[out_base + 7] = out[2usize].y;
+        get_mut!(OUTPUT)[out_base + 8] = out[2usize].z;
+    }
+}
+
+#[wgsl]
+pub mod mat3x2_mat2x3_mul {
+    use wgsl_rs::std::*;
+
+    storage!(group(0), binding(0), INPUT: [f32; 768]);
+    storage!(group(0), binding(1), read_write, OUTPUT: [f32; 256]);
+
+    /// Computes Mat3x2f * Mat2x3f -> Mat2x2f for 64 inputs.
+    #[compute]
+    #[workgroup_size(64)]
+    pub fn main(#[builtin(global_invocation_id)] global_id: Vec3u) {
+        let idx = global_id.x as usize;
+        let base = idx * 12;
+        let input = get!(INPUT);
+
+        let a = mat3x2f(
+            vec2f(input[base], input[base + 1]),
+            vec2f(input[base + 2], input[base + 3]),
+            vec2f(input[base + 4], input[base + 5]),
+        );
+        let b = mat2x3f(
+            vec3f(input[base + 6], input[base + 7], input[base + 8]),
+            vec3f(input[base + 9], input[base + 10], input[base + 11]),
+        );
+        let out: Mat2x2f = a * b;
+
+        let out_base = idx * 4;
+        get_mut!(OUTPUT)[out_base] = out[0usize].x;
+        get_mut!(OUTPUT)[out_base + 1] = out[0usize].y;
+        get_mut!(OUTPUT)[out_base + 2] = out[1usize].x;
+        get_mut!(OUTPUT)[out_base + 3] = out[1usize].y;
+    }
+}
+
 #[wgsl]
 pub mod mat2_mat2_mul {
     use wgsl_rs::std::*;
@@ -1126,6 +1317,104 @@ fn mat4_mat4_inputs() -> [f32; 2048] {
     out
 }
 
+/// Generates inputs for Vec3f * Mat2x3f: a Mat2x3f (6 values) plus a Vec3f
+/// (3 values) per item.
+fn vec3_mat2x3_inputs() -> [f32; 576] {
+    let mats = mat2x3_inputs();
+    let mut out = [0.0f32; 576];
+    for i in 0..N {
+        let m_base = i * 6;
+        let base = i * 9;
+        out[base..base + 6].copy_from_slice(&mats[m_base..m_base + 6]);
+        let t = i as f32 * 0.13 - 3.0;
+        out[base + 6] = 0.6 + t * 0.04;
+        out[base + 7] = -0.4 + t * 0.03;
+        out[base + 8] = 1.2 - t * 0.02;
+    }
+    out
+}
+
+/// Generates inputs for Vec2f * Mat3x2f: a Mat3x2f (6 values) plus a Vec2f
+/// (2 values) per item.
+fn vec2_mat3x2_inputs() -> [f32; 512] {
+    let mats = mat3x2_inputs();
+    let mut out = [0.0f32; 512];
+    for i in 0..N {
+        let m_base = i * 6;
+        let base = i * 8;
+        out[base..base + 6].copy_from_slice(&mats[m_base..m_base + 6]);
+        let t = i as f32 * 0.17 - 2.5;
+        out[base + 6] = 0.7 + t * 0.05;
+        out[base + 7] = -0.3 + t * 0.04;
+    }
+    out
+}
+
+/// Generates inputs for Mat2x3f * Vec2f: a Mat2x3f (6 values) plus a Vec2f
+/// (2 values) per item.
+fn mat2x3_vec2_inputs() -> [f32; 512] {
+    let mats = mat2x3_inputs();
+    let mut out = [0.0f32; 512];
+    for i in 0..N {
+        let m_base = i * 6;
+        let base = i * 8;
+        out[base..base + 6].copy_from_slice(&mats[m_base..m_base + 6]);
+        let t = i as f32 * 0.19 - 3.5;
+        out[base + 6] = 0.5 + t * 0.06;
+        out[base + 7] = -0.2 + t * 0.03;
+    }
+    out
+}
+
+/// Generates inputs for Mat3x2f * Vec3f: a Mat3x2f (6 values) plus a Vec3f
+/// (3 values) per item.
+fn mat3x2_vec3_inputs() -> [f32; 576] {
+    let mats = mat3x2_inputs();
+    let mut out = [0.0f32; 576];
+    for i in 0..N {
+        let m_base = i * 6;
+        let base = i * 9;
+        out[base..base + 6].copy_from_slice(&mats[m_base..m_base + 6]);
+        let t = i as f32 * 0.15 - 2.2;
+        out[base + 6] = 0.4 + t * 0.03;
+        out[base + 7] = 0.9 - t * 0.02;
+        out[base + 8] = -0.5 + t * 0.04;
+    }
+    out
+}
+
+/// Generates inputs for Mat2x3f * Mat3x2f: a Mat2x3f (6 values) plus a
+/// Mat3x2f (6 values) per item.
+fn mat2x3_mat3x2_inputs() -> [f32; 768] {
+    let a = mat2x3_inputs();
+    let b = mat3x2_inputs();
+    let mut out = [0.0f32; 768];
+    for i in 0..N {
+        let a_base = i * 6;
+        let b_base = i * 6;
+        let base = i * 12;
+        out[base..base + 6].copy_from_slice(&a[a_base..a_base + 6]);
+        out[base + 6..base + 12].copy_from_slice(&b[b_base..b_base + 6]);
+    }
+    out
+}
+
+/// Generates inputs for Mat3x2f * Mat2x3f: a Mat3x2f (6 values) plus a
+/// Mat2x3f (6 values) per item.
+fn mat3x2_mat2x3_inputs() -> [f32; 768] {
+    let a = mat3x2_inputs();
+    let b = mat2x3_inputs();
+    let mut out = [0.0f32; 768];
+    for i in 0..N {
+        let a_base = i * 6;
+        let b_base = i * 6;
+        let base = i * 12;
+        out[base..base + 6].copy_from_slice(&a[a_base..a_base + 6]);
+        out[base + 6..base + 12].copy_from_slice(&b[b_base..b_base + 6]);
+    }
+    out
+}
+
 /// Runs one f32-based compute shader on the GPU and returns unpacked f32
 /// output.
 fn run_gpu_f32_shader(
@@ -1446,6 +1735,98 @@ impl RoundtripTest for MatrixOperationsTest {
             });
             let cpu = mat4_mat4_mul::OUTPUT.get().to_vec();
             push_f32_result(&mut results, "mat4_mat4_mul", &gpu, &cpu, 1e-4);
+        }
+
+        // === Row-vector * matrix (issue #152) ===================================
+
+        {
+            let input = vec3_mat2x3_inputs();
+            let mut linkage =
+                wgsl_rs::linkage::wgpu::analyze_wgsl_module(&vec3_mat2x3_mul::WGSL_SOURCE).unwrap();
+            let gpu = run_gpu_f32_shader(device, queue, &mut linkage, &input, 128);
+            vec3_mat2x3_mul::INPUT.set(input);
+            vec3_mat2x3_mul::OUTPUT.set([0.0f32; 128]);
+            dispatch_workgroups((1, 1, 1), (N as u32, 1, 1), |b| {
+                vec3_mat2x3_mul::main(b.global_invocation_id)
+            });
+            let cpu = vec3_mat2x3_mul::OUTPUT.get().to_vec();
+            push_f32_result(&mut results, "vec3_mat2x3_mul", &gpu, &cpu, 1e-5);
+        }
+
+        {
+            let input = vec2_mat3x2_inputs();
+            let mut linkage =
+                wgsl_rs::linkage::wgpu::analyze_wgsl_module(&vec2_mat3x2_mul::WGSL_SOURCE).unwrap();
+            let gpu = run_gpu_f32_shader(device, queue, &mut linkage, &input, 192);
+            vec2_mat3x2_mul::INPUT.set(input);
+            vec2_mat3x2_mul::OUTPUT.set([0.0f32; 192]);
+            dispatch_workgroups((1, 1, 1), (N as u32, 1, 1), |b| {
+                vec2_mat3x2_mul::main(b.global_invocation_id)
+            });
+            let cpu = vec2_mat3x2_mul::OUTPUT.get().to_vec();
+            push_f32_result(&mut results, "vec2_mat3x2_mul", &gpu, &cpu, 1e-5);
+        }
+
+        // === Non-square matrix * vector ========================================
+
+        {
+            let input = mat2x3_vec2_inputs();
+            let mut linkage =
+                wgsl_rs::linkage::wgpu::analyze_wgsl_module(&mat2x3_vec2_mul::WGSL_SOURCE).unwrap();
+            let gpu = run_gpu_f32_shader(device, queue, &mut linkage, &input, 192);
+            mat2x3_vec2_mul::INPUT.set(input);
+            mat2x3_vec2_mul::OUTPUT.set([0.0f32; 192]);
+            dispatch_workgroups((1, 1, 1), (N as u32, 1, 1), |b| {
+                mat2x3_vec2_mul::main(b.global_invocation_id)
+            });
+            let cpu = mat2x3_vec2_mul::OUTPUT.get().to_vec();
+            push_f32_result(&mut results, "mat2x3_vec2_mul", &gpu, &cpu, 1e-5);
+        }
+
+        {
+            let input = mat3x2_vec3_inputs();
+            let mut linkage =
+                wgsl_rs::linkage::wgpu::analyze_wgsl_module(&mat3x2_vec3_mul::WGSL_SOURCE).unwrap();
+            let gpu = run_gpu_f32_shader(device, queue, &mut linkage, &input, 128);
+            mat3x2_vec3_mul::INPUT.set(input);
+            mat3x2_vec3_mul::OUTPUT.set([0.0f32; 128]);
+            dispatch_workgroups((1, 1, 1), (N as u32, 1, 1), |b| {
+                mat3x2_vec3_mul::main(b.global_invocation_id)
+            });
+            let cpu = mat3x2_vec3_mul::OUTPUT.get().to_vec();
+            push_f32_result(&mut results, "mat3x2_vec3_mul", &gpu, &cpu, 1e-5);
+        }
+
+        // === Non-square matrix * matrix ========================================
+
+        {
+            let input = mat2x3_mat3x2_inputs();
+            let mut linkage =
+                wgsl_rs::linkage::wgpu::analyze_wgsl_module(&mat2x3_mat3x2_mul::WGSL_SOURCE)
+                    .unwrap();
+            let gpu = run_gpu_f32_shader(device, queue, &mut linkage, &input, 576);
+            mat2x3_mat3x2_mul::INPUT.set(input);
+            mat2x3_mat3x2_mul::OUTPUT.set([0.0f32; 576]);
+            dispatch_workgroups((1, 1, 1), (N as u32, 1, 1), |b| {
+                mat2x3_mat3x2_mul::main(b.global_invocation_id)
+            });
+            let cpu = mat2x3_mat3x2_mul::OUTPUT.get().to_vec();
+            push_f32_result(&mut results, "mat2x3_mat3x2_mul", &gpu, &cpu, 1e-4);
+        }
+
+        {
+            let input = mat3x2_mat2x3_inputs();
+            let mut linkage =
+                wgsl_rs::linkage::wgpu::analyze_wgsl_module(&mat3x2_mat2x3_mul::WGSL_SOURCE)
+                    .unwrap();
+            let gpu = run_gpu_f32_shader(device, queue, &mut linkage, &input, 256);
+            mat3x2_mat2x3_mul::INPUT.set(input);
+            mat3x2_mat2x3_mul::OUTPUT.set([0.0f32; 256]);
+            dispatch_workgroups((1, 1, 1), (N as u32, 1, 1), |b| {
+                mat3x2_mat2x3_mul::main(b.global_invocation_id)
+            });
+            let cpu = mat3x2_mat2x3_mul::OUTPUT.get().to_vec();
+            push_f32_result(&mut results, "mat3x2_mat2x3_mul", &gpu, &cpu, 1e-4);
         }
 
         results

--- a/crates/wgsl-rs/src/std/matrix.rs
+++ b/crates/wgsl-rs/src/std/matrix.rs
@@ -2,6 +2,33 @@
 //!
 //! Column-major matrices with public `columns` arrays, matching WGSL's
 //! matrix types. Columns are accessed by index: `m[0]`, `m[1]`, etc.
+//!
+//! # Naming convention
+//!
+//! `MatCxRf` has **C columns and R rows**; each column is a `VecRf`. So
+//! `Mat2x3f` holds 2 columns of `Vec3f` (6 total components). This mirrors
+//! WGSL's `matCxR<T>` spelling.
+//!
+//! # Multiplication
+//!
+//! All WGSL-spec-valid `*` combinations are implemented. The operand order
+//! determines the result shape, and the two orders are **not interchangeable**
+//! for non-square matrices:
+//!
+//! | expression | input shapes | output |
+//! | --- | --- | --- |
+//! | `m * v` | `MatCxRf` * `VecCf` | `VecRf` |
+//! | `v * m` | `VecRf` * `MatCxRf` | `VecCf` |
+//! | `a * b` | `MatKxRf` * `MatCxKf` | `MatCxRf` |
+//! | `s * m`, `m * s` | `f32` * `MatCxRf` | `MatCxRf` |
+//!
+//! For example, `Mat2x3f * Vec2f` produces a `Vec3f`, while `Vec3f *
+//! Mat2x3f` produces a `Vec2f`. Scalar scaling is commutative and works on
+//! either side for every matrix shape.
+//!
+//! See the WGSL spec's `arithmetic-expr` section for the linear-algebra
+//! definitions. On the GPU these all lower to the WGSL `*` operator; the
+//! impls here exist so the CPU ("two worlds") path agrees.
 
 use super::*;
 
@@ -264,26 +291,193 @@ impl From<Mat4x4f> for glam::Mat4 {
     }
 }
 
-// Arithmetic: matrix * matrix, matrix * vector, matrix * scalar, scalar *
-// matrix. Delegated to glam for the square matrix types.
+// === Multiplication =========================================================
+//
+// Scalar multiplications for the square matrix types delegate to glam; all
+// matrix * vector, vector * matrix, and matrix * matrix impls use direct
+// component arithmetic. glam has no non-square matrix types, so non-square
+// cases must be implemented manually; the square cases share the same code
+// path for uniformity and to keep the linear-algebra semantics in one place.
+//
+// WGSL spec semantics (see `arithmetic-expr`):
+//   - `m: matCxR<T>` * `v: vecC<T>`     -> `vecR<T>`  (column-vector product)
+//   - `v: vecR<T>` * `m: matCxR<T>`     -> `vecC<T>`  (row-vector product)
+//   - `e1: matKxR<T>` * `e2: matCxK<T>` -> `matCxR<T>` (matrix product)
+//
+// The result of `v * m` is `transpose(transpose(m) * transpose(v))`, which
+// expands to component `i` of the output being `dot(v, m.columns[i])`.
 
-impl std::ops::Mul<Mat2x2f> for Mat2x2f {
-    type Output = Mat2x2f;
-    fn mul(self, rhs: Mat2x2f) -> Mat2x2f {
-        let g: glam::Mat2 = self.into();
-        let rg: glam::Mat2 = rhs.into();
-        (g * rg).into()
-    }
+// === Matrix * vector ========================================================
+//
+// `m * v` is the linear combination `sum_j v[j] * m.columns[j]`. Since each
+// column is a `VecRf` with `Add` and `Mul<f32>`, the sum yields a `VecRf`
+// directly. Dispatch is on C (the number of columns / the input vector's
+// length).
+
+macro_rules! impl_mat_vec_mul {
+    ($mat:ty, $vec_in:ty, $vec_out:ty, $c:tt) => {
+        impl std::ops::Mul<$vec_in> for $mat {
+            type Output = $vec_out;
+            fn mul(self, rhs: $vec_in) -> $vec_out {
+                let cols = self.columns;
+                impl_mat_vec_mul!(@combine $c, cols, rhs)
+            }
+        }
+    };
+    (@combine 2, $cols:ident, $v:ident) => {
+        $cols[0] * $v.x + $cols[1] * $v.y
+    };
+    (@combine 3, $cols:ident, $v:ident) => {
+        $cols[0] * $v.x + $cols[1] * $v.y + $cols[2] * $v.z
+    };
+    (@combine 4, $cols:ident, $v:ident) => {
+        $cols[0] * $v.x + $cols[1] * $v.y + $cols[2] * $v.z + $cols[3] * $v.w
+    };
 }
 
-impl std::ops::Mul<Vec2f> for Mat2x2f {
-    type Output = Vec2f;
-    fn mul(self, rhs: Vec2f) -> Vec2f {
-        let g: glam::Mat2 = self.into();
-        let gv: glam::Vec2 = rhs.into();
-        (g * gv).into()
-    }
+impl_mat_vec_mul!(Mat2x2f, Vec2f, Vec2f, 2);
+impl_mat_vec_mul!(Mat2x3f, Vec2f, Vec3f, 2);
+impl_mat_vec_mul!(Mat2x4f, Vec2f, Vec4f, 2);
+impl_mat_vec_mul!(Mat3x2f, Vec3f, Vec2f, 3);
+impl_mat_vec_mul!(Mat3x3f, Vec3f, Vec3f, 3);
+impl_mat_vec_mul!(Mat3x4f, Vec3f, Vec4f, 3);
+impl_mat_vec_mul!(Mat4x2f, Vec4f, Vec2f, 4);
+impl_mat_vec_mul!(Mat4x3f, Vec4f, Vec3f, 4);
+impl_mat_vec_mul!(Mat4x4f, Vec4f, Vec4f, 4);
+
+// === Vector * matrix ========================================================
+//
+// `v * m` is per-component dots against the columns: output component `i` is
+// `dot(v, m.columns[i])`. Dispatch is on C (the number of output components,
+// i.e. the number of columns) and R (the input vector's length / each
+// column's length).
+
+macro_rules! impl_vec_mat_mul {
+    ($vec:ty, $mat:ty, $vec_out:ty, $c:tt, $r:tt) => {
+        impl std::ops::Mul<$mat> for $vec {
+            type Output = $vec_out;
+            fn mul(self, rhs: $mat) -> $vec_out {
+                let cols = rhs.columns;
+                let s = self;
+                impl_vec_mat_mul!(@col $c, $r, cols, s)
+            }
+        }
+    };
+    // Output has 2 components (C=2).
+    (@col 2, $r:tt, $cols:ident, $s:ident) => {
+        Vec2 {
+            x: impl_vec_mat_mul!(@dot $r, $s, $cols[0]),
+            y: impl_vec_mat_mul!(@dot $r, $s, $cols[1]),
+        }
+    };
+    // Output has 3 components (C=3).
+    (@col 3, $r:tt, $cols:ident, $s:ident) => {
+        Vec3 {
+            x: impl_vec_mat_mul!(@dot $r, $s, $cols[0]),
+            y: impl_vec_mat_mul!(@dot $r, $s, $cols[1]),
+            z: impl_vec_mat_mul!(@dot $r, $s, $cols[2]),
+        }
+    };
+    // Output has 4 components (C=4).
+    (@col 4, $r:tt, $cols:ident, $s:ident) => {
+        Vec4 {
+            x: impl_vec_mat_mul!(@dot $r, $s, $cols[0]),
+            y: impl_vec_mat_mul!(@dot $r, $s, $cols[1]),
+            z: impl_vec_mat_mul!(@dot $r, $s, $cols[2]),
+            w: impl_vec_mat_mul!(@dot $r, $s, $cols[3]),
+        }
+    };
+    (@dot 2, $s:ident, $col:expr) => {
+        $s.x * $col.x + $s.y * $col.y
+    };
+    (@dot 3, $s:ident, $col:expr) => {
+        $s.x * $col.x + $s.y * $col.y + $s.z * $col.z
+    };
+    (@dot 4, $s:ident, $col:expr) => {
+        $s.x * $col.x + $s.y * $col.y + $s.z * $col.z + $s.w * $col.w
+    };
 }
+
+impl_vec_mat_mul!(Vec2f, Mat2x2f, Vec2f, 2, 2);
+impl_vec_mat_mul!(Vec2f, Mat3x2f, Vec3f, 3, 2);
+impl_vec_mat_mul!(Vec2f, Mat4x2f, Vec4f, 4, 2);
+impl_vec_mat_mul!(Vec3f, Mat2x3f, Vec2f, 2, 3);
+impl_vec_mat_mul!(Vec3f, Mat3x3f, Vec3f, 3, 3);
+impl_vec_mat_mul!(Vec3f, Mat4x3f, Vec4f, 4, 3);
+impl_vec_mat_mul!(Vec4f, Mat2x4f, Vec2f, 2, 4);
+impl_vec_mat_mul!(Vec4f, Mat3x4f, Vec3f, 3, 4);
+impl_vec_mat_mul!(Vec4f, Mat4x4f, Vec4f, 4, 4);
+
+// === Matrix * matrix ========================================================
+//
+// `a * b` is column-wise: column `j` of the result is `a * b.columns[j]`,
+// dispatched to the `Mat * Vec` impl above. This covers all 27 valid WGSL
+// combinations (K, C, R each in {2, 3, 4}); square cases use the same code
+// path for uniformity and to keep the implementation self-contained.
+
+macro_rules! impl_mat_mat_mul {
+    ($a:ty, $b:ty, $out:ty, $c:tt) => {
+        impl std::ops::Mul<$b> for $a {
+            type Output = $out;
+            fn mul(self, rhs: $b) -> $out {
+                type Out = $out;
+                let cols = rhs.columns;
+                Out {
+                    columns: impl_mat_mat_mul!(@cols $c, self, cols),
+                }
+            }
+        }
+    };
+    (@cols 2, $self:ident, $cols:ident) => {
+        [$self * $cols[0], $self * $cols[1]]
+    };
+    (@cols 3, $self:ident, $cols:ident) => {
+        [$self * $cols[0], $self * $cols[1], $self * $cols[2]]
+    };
+    (@cols 4, $self:ident, $cols:ident) => {
+        [
+            $self * $cols[0],
+            $self * $cols[1],
+            $self * $cols[2],
+            $self * $cols[3],
+        ]
+    };
+}
+
+// K=2: a is Mat2xR, b is MatCx2, out is MatCxR.
+impl_mat_mat_mul!(Mat2x2f, Mat2x2f, Mat2x2f, 2);
+impl_mat_mat_mul!(Mat2x2f, Mat3x2f, Mat3x2f, 3);
+impl_mat_mat_mul!(Mat2x2f, Mat4x2f, Mat4x2f, 4);
+impl_mat_mat_mul!(Mat2x3f, Mat2x2f, Mat2x3f, 2);
+impl_mat_mat_mul!(Mat2x3f, Mat3x2f, Mat3x3f, 3);
+impl_mat_mat_mul!(Mat2x3f, Mat4x2f, Mat4x3f, 4);
+impl_mat_mat_mul!(Mat2x4f, Mat2x2f, Mat2x4f, 2);
+impl_mat_mat_mul!(Mat2x4f, Mat3x2f, Mat3x4f, 3);
+impl_mat_mat_mul!(Mat2x4f, Mat4x2f, Mat4x4f, 4);
+
+// K=3: a is Mat3xR, b is MatCx3, out is MatCxR.
+impl_mat_mat_mul!(Mat3x2f, Mat2x3f, Mat2x2f, 2);
+impl_mat_mat_mul!(Mat3x2f, Mat3x3f, Mat3x2f, 3);
+impl_mat_mat_mul!(Mat3x2f, Mat4x3f, Mat4x2f, 4);
+impl_mat_mat_mul!(Mat3x3f, Mat2x3f, Mat2x3f, 2);
+impl_mat_mat_mul!(Mat3x3f, Mat3x3f, Mat3x3f, 3);
+impl_mat_mat_mul!(Mat3x3f, Mat4x3f, Mat4x3f, 4);
+impl_mat_mat_mul!(Mat3x4f, Mat2x3f, Mat2x4f, 2);
+impl_mat_mat_mul!(Mat3x4f, Mat3x3f, Mat3x4f, 3);
+impl_mat_mat_mul!(Mat3x4f, Mat4x3f, Mat4x4f, 4);
+
+// K=4: a is Mat4xR, b is MatCx4, out is MatCxR.
+impl_mat_mat_mul!(Mat4x2f, Mat2x4f, Mat2x2f, 2);
+impl_mat_mat_mul!(Mat4x2f, Mat3x4f, Mat3x2f, 3);
+impl_mat_mat_mul!(Mat4x2f, Mat4x4f, Mat4x2f, 4);
+impl_mat_mat_mul!(Mat4x3f, Mat2x4f, Mat2x3f, 2);
+impl_mat_mat_mul!(Mat4x3f, Mat3x4f, Mat3x3f, 3);
+impl_mat_mat_mul!(Mat4x3f, Mat4x4f, Mat4x3f, 4);
+impl_mat_mat_mul!(Mat4x4f, Mat2x4f, Mat2x4f, 2);
+impl_mat_mat_mul!(Mat4x4f, Mat3x4f, Mat3x4f, 3);
+impl_mat_mat_mul!(Mat4x4f, Mat4x4f, Mat4x4f, 4);
+
+// === Scalar multiplication (delegated to glam for square types) =============
 
 impl std::ops::Mul<f32> for Mat2x2f {
     type Output = Mat2x2f;
@@ -298,24 +492,6 @@ impl std::ops::Mul<Mat2x2f> for f32 {
     fn mul(self, rhs: Mat2x2f) -> Mat2x2f {
         let g: glam::Mat2 = rhs.into();
         (self * g).into()
-    }
-}
-
-impl std::ops::Mul<Mat3x3f> for Mat3x3f {
-    type Output = Mat3x3f;
-    fn mul(self, rhs: Mat3x3f) -> Mat3x3f {
-        let g: glam::Mat3 = self.into();
-        let rg: glam::Mat3 = rhs.into();
-        (g * rg).into()
-    }
-}
-
-impl std::ops::Mul<Vec3f> for Mat3x3f {
-    type Output = Vec3f;
-    fn mul(self, rhs: Vec3f) -> Vec3f {
-        let g: glam::Mat3 = self.into();
-        let gv: glam::Vec3 = rhs.into();
-        (g * gv).into()
     }
 }
 
@@ -335,24 +511,6 @@ impl std::ops::Mul<Mat3x3f> for f32 {
     }
 }
 
-impl std::ops::Mul<Mat4x4f> for Mat4x4f {
-    type Output = Mat4x4f;
-    fn mul(self, rhs: Mat4x4f) -> Mat4x4f {
-        let g: glam::Mat4 = self.into();
-        let rg: glam::Mat4 = rhs.into();
-        (g * rg).into()
-    }
-}
-
-impl std::ops::Mul<Vec4f> for Mat4x4f {
-    type Output = Vec4f;
-    fn mul(self, rhs: Vec4f) -> Vec4f {
-        let g: glam::Mat4 = self.into();
-        let gv: glam::Vec4 = rhs.into();
-        (g * gv).into()
-    }
-}
-
 impl std::ops::Mul<f32> for Mat4x4f {
     type Output = Mat4x4f;
     fn mul(self, rhs: f32) -> Mat4x4f {
@@ -368,6 +526,36 @@ impl std::ops::Mul<Mat4x4f> for f32 {
         (self * g).into()
     }
 }
+
+/// Multiplies each component of a non-square matrix by a scalar.
+macro_rules! impl_mat_scalar_mul {
+    ($mat:ty) => {
+        impl std::ops::Mul<f32> for $mat {
+            type Output = $mat;
+            fn mul(self, rhs: f32) -> $mat {
+                type Out = $mat;
+                let cols = self.columns;
+                Out {
+                    columns: cols.map(|c| c * rhs),
+                }
+            }
+        }
+
+        impl std::ops::Mul<$mat> for f32 {
+            type Output = $mat;
+            fn mul(self, rhs: $mat) -> $mat {
+                rhs * self
+            }
+        }
+    };
+}
+
+impl_mat_scalar_mul!(Mat2x3f);
+impl_mat_scalar_mul!(Mat2x4f);
+impl_mat_scalar_mul!(Mat3x2f);
+impl_mat_scalar_mul!(Mat3x4f);
+impl_mat_scalar_mul!(Mat4x2f);
+impl_mat_scalar_mul!(Mat4x3f);
 
 // Determinant.
 
@@ -748,6 +936,381 @@ mod test {
                         * modelview
                         * vec4f(input.position.x, input.position.y, input.position.z, 1.0),
                 }
+            }
+        }
+    }
+
+    // === Matrix * vector tests ================================================
+
+    #[test]
+    fn mat2x2_mul_vec2() {
+        let m = mat2x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0));
+        let v = vec2f(5.0, 6.0);
+        // [1 3][5] = [1*5 + 3*6, 2*5 + 4*6] = [23, 34]
+        // [2 4][6]
+        let out: Vec2f = m * v;
+        assert_eq!(out.to_array(), [23.0, 34.0]);
+    }
+
+    #[test]
+    fn mat2x3_mul_vec2() {
+        // mat2x3f: 2 columns of vec3f. m * vec2 -> vec3.
+        let m = mat2x3f(vec3f(1.0, 2.0, 3.0), vec3f(4.0, 5.0, 6.0));
+        let v = vec2f(7.0, 8.0);
+        // Row 0: 1*7 + 4*8 = 39
+        // Row 1: 2*7 + 5*8 = 54
+        // Row 2: 3*7 + 6*8 = 69
+        let out: Vec3f = m * v;
+        assert_eq!(out.to_array(), [39.0, 54.0, 69.0]);
+    }
+
+    #[test]
+    fn mat3x2_mul_vec3() {
+        let m = mat3x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0), vec2f(5.0, 6.0));
+        let v = vec3f(7.0, 8.0, 9.0);
+        // Row 0: 1*7 + 3*8 + 5*9 = 7+24+45 = 76
+        // Row 1: 2*7 + 4*8 + 6*9 = 14+32+54 = 100
+        let out: Vec2f = m * v;
+        assert_eq!(out.to_array(), [76.0, 100.0]);
+    }
+
+    #[test]
+    fn mat2x4_mul_vec2() {
+        let m = mat2x4f(vec4f(1.0, 2.0, 3.0, 4.0), vec4f(5.0, 6.0, 7.0, 8.0));
+        let v = vec2f(9.0, 10.0);
+        // Row 0: 1*9 + 5*10 = 59
+        // Row 1: 2*9 + 6*10 = 78
+        // Row 2: 3*9 + 7*10 = 97
+        // Row 3: 4*9 + 8*10 = 116
+        let out: Vec4f = m * v;
+        assert_eq!(out.to_array(), [59.0, 78.0, 97.0, 116.0]);
+    }
+
+    #[test]
+    fn mat4x2_mul_vec4() {
+        let m = mat4x2f(
+            vec2f(1.0, 2.0),
+            vec2f(3.0, 4.0),
+            vec2f(5.0, 6.0),
+            vec2f(7.0, 8.0),
+        );
+        let v = vec4f(9.0, 10.0, 11.0, 12.0);
+        // Row 0: 1*9 + 3*10 + 5*11 + 7*12 = 9+30+55+84 = 178
+        // Row 1: 2*9 + 4*10 + 6*11 + 8*12 = 18+40+66+96 = 220
+        let out: Vec2f = m * v;
+        assert_eq!(out.to_array(), [178.0, 220.0]);
+    }
+
+    #[test]
+    fn mat3x4_mul_vec3() {
+        let m = mat3x4f(
+            vec4f(1.0, 2.0, 3.0, 4.0),
+            vec4f(5.0, 6.0, 7.0, 8.0),
+            vec4f(9.0, 10.0, 11.0, 12.0),
+        );
+        let v = vec3f(13.0, 14.0, 15.0);
+        // Row 0: 1*13 + 5*14 + 9*15 = 13+70+135 = 218
+        // Row 1: 2*13 + 6*14 + 10*15 = 26+84+150 = 260
+        // Row 2: 3*13 + 7*14 + 11*15 = 39+98+165 = 302
+        // Row 3: 4*13 + 8*14 + 12*15 = 52+112+180 = 344
+        let out: Vec4f = m * v;
+        assert_eq!(out.to_array(), [218.0, 260.0, 302.0, 344.0]);
+    }
+
+    #[test]
+    fn mat4x3_mul_vec4() {
+        let m = mat4x3f(
+            vec3f(1.0, 2.0, 3.0),
+            vec3f(4.0, 5.0, 6.0),
+            vec3f(7.0, 8.0, 9.0),
+            vec3f(10.0, 11.0, 12.0),
+        );
+        let v = vec4f(13.0, 14.0, 15.0, 16.0);
+        // Row 0: 1*13 + 4*14 + 7*15 + 10*16 = 13+56+105+160 = 334
+        // Row 1: 2*13 + 5*14 + 8*15 + 11*16 = 26+70+120+176 = 392
+        // Row 2: 3*13 + 6*14 + 9*15 + 12*16 = 39+84+135+192 = 450
+        let out: Vec3f = m * v;
+        assert_eq!(out.to_array(), [334.0, 392.0, 450.0]);
+    }
+
+    // === Vector * matrix tests =================================================
+    //
+    // For `v * m`, output component i = dot(v, m.columns[i]).
+    // Per the WGSL spec this is `transpose(transpose(m) * transpose(v))`.
+
+    #[test]
+    fn vec2_mul_mat2x2() {
+        let v = vec2f(5.0, 6.0);
+        let m = mat2x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0));
+        // Out[0] = dot(v, m[0]) = 5*1 + 6*2 = 17
+        // Out[1] = dot(v, m[1]) = 5*3 + 6*4 = 39
+        let out: Vec2f = v * m;
+        assert_eq!(out.to_array(), [17.0, 39.0]);
+    }
+
+    #[test]
+    fn vec3_mul_mat2x3() {
+        // The example from issue #152.
+        let v = vec3f(9.0, 8.0, 7.0);
+        let m = mat2x3f(vec3f(1.0, 2.0, 3.0), vec3f(4.0, 5.0, 6.0));
+        // Out[0] = 9*1 + 8*2 + 7*3 = 9+16+21 = 46
+        // Out[1] = 9*4 + 8*5 + 7*6 = 36+40+42 = 118
+        let out: Vec2f = v * m;
+        assert_eq!(out.to_array(), [46.0, 118.0]);
+    }
+
+    #[test]
+    fn vec2_mul_mat3x2() {
+        let v = vec2f(7.0, 8.0);
+        let m = mat3x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0), vec2f(5.0, 6.0));
+        // Out[0] = 7*1 + 8*2 = 23
+        // Out[1] = 7*3 + 8*4 = 53
+        // Out[2] = 7*5 + 8*6 = 83
+        let out: Vec3f = v * m;
+        assert_eq!(out.to_array(), [23.0, 53.0, 83.0]);
+    }
+
+    #[test]
+    fn vec4_mul_mat2x4() {
+        let v = vec4f(9.0, 10.0, 11.0, 12.0);
+        let m = mat2x4f(vec4f(1.0, 2.0, 3.0, 4.0), vec4f(5.0, 6.0, 7.0, 8.0));
+        // Out[0] = 9*1 + 10*2 + 11*3 + 12*4 = 9+20+33+48 = 110
+        // Out[1] = 9*5 + 10*6 + 11*7 + 12*8 = 45+60+77+96 = 278
+        let out: Vec2f = v * m;
+        assert_eq!(out.to_array(), [110.0, 278.0]);
+    }
+
+    #[test]
+    fn vec3_mul_mat4x3() {
+        let v = vec3f(13.0, 14.0, 15.0);
+        let m = mat4x3f(
+            vec3f(1.0, 2.0, 3.0),
+            vec3f(4.0, 5.0, 6.0),
+            vec3f(7.0, 8.0, 9.0),
+            vec3f(10.0, 11.0, 12.0),
+        );
+        // Out[0] = 13*1 + 14*2 + 15*3 = 13+28+45 = 86
+        // Out[1] = 13*4 + 14*5 + 15*6 = 52+70+90 = 212
+        // Out[2] = 13*7 + 14*8 + 15*9 = 91+112+135 = 338
+        // Out[3] = 13*10 + 14*11 + 15*12 = 130+154+180 = 464
+        let out: Vec4f = v * m;
+        assert_eq!(out.to_array(), [86.0, 212.0, 338.0, 464.0]);
+    }
+
+    /// Sanity check: `v * m` equals `transpose(m) * v` when interpreted as the
+    /// column-vector-matrix product of the transpose. This verifies the two
+    /// implementations agree with each other across all R sizes.
+    #[test]
+    fn vec_mul_mat_matches_transpose_mat_mul_vec() {
+        // R=2
+        {
+            let v = vec2f(1.5, -2.5);
+            let m = mat3x2f(vec2f(0.5, 1.0), vec2f(-1.5, 2.5), vec2f(3.0, -0.5));
+            let lhs: Vec3f = v * m;
+            let mt: Mat2x3f = transpose(m);
+            let rhs: Vec3f = mt * v;
+            assert_eq!(lhs.to_array(), rhs.to_array());
+        }
+        // R=3
+        {
+            let v = vec3f(1.0, 2.0, 3.0);
+            let m = mat2x3f(vec3f(4.0, 5.0, 6.0), vec3f(7.0, 8.0, 9.0));
+            let lhs: Vec2f = v * m;
+            let mt: Mat3x2f = transpose(m);
+            let rhs: Vec2f = mt * v;
+            assert_eq!(lhs.to_array(), rhs.to_array());
+        }
+        // R=4
+        {
+            let v = vec4f(1.0, 2.0, 3.0, 4.0);
+            let m = mat2x4f(vec4f(5.0, 6.0, 7.0, 8.0), vec4f(9.0, 10.0, 11.0, 12.0));
+            let lhs: Vec2f = v * m;
+            let mt: Mat4x2f = transpose(m);
+            let rhs: Vec2f = mt * v;
+            assert_eq!(lhs.to_array(), rhs.to_array());
+        }
+    }
+
+    // === Matrix * matrix tests =================================================
+
+    #[test]
+    fn mat2x2_mul_mat2x2() {
+        let a = mat2x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0));
+        let b = mat2x2f(vec2f(5.0, 6.0), vec2f(7.0, 8.0));
+        // Column 0 of out = a * b[0] = a * vec2f(5,6) = (1*5+3*6, 2*5+4*6) = (23,34)
+        // Column 1 of out = a * b[1] = a * vec2f(7,8) = (1*7+3*8, 2*7+4*8) = (31,46)
+        let out: Mat2x2f = a * b;
+        assert_eq!(out.columns[0].to_array(), [23.0, 34.0]);
+        assert_eq!(out.columns[1].to_array(), [31.0, 46.0]);
+    }
+
+    #[test]
+    fn mat2x3_mul_mat3x2() {
+        // a is mat2x3 (K=2 cols, R=3 rows), b is mat3x2 (C=3 cols, K=2 rows),
+        // out is mat3x3 (3 cols, 3 rows).
+        let a = mat2x3f(vec3f(1.0, 2.0, 3.0), vec3f(4.0, 5.0, 6.0));
+        let b = mat3x2f(vec2f(7.0, 8.0), vec2f(9.0, 10.0), vec2f(11.0, 12.0));
+        // Column j of out = a * b[j].
+        // out[0] = a * vec2f(7,8)  = (1*7+4*8, 2*7+5*8, 3*7+6*8)   = (39, 54, 69)
+        // out[1] = a * vec2f(9,10) = (1*9+4*10, 2*9+5*10, 3*9+6*10) = (49, 68, 87)
+        // out[2] = a * vec2f(11,12)= (1*11+4*12, 2*11+5*12, 3*11+6*12)=(59,82,105)
+        let out: Mat3x3f = a * b;
+        assert_eq!(out.columns[0].to_array(), [39.0, 54.0, 69.0]);
+        assert_eq!(out.columns[1].to_array(), [49.0, 68.0, 87.0]);
+        assert_eq!(out.columns[2].to_array(), [59.0, 82.0, 105.0]);
+    }
+
+    #[test]
+    fn mat3x2_mul_mat2x3() {
+        // a is mat3x2 (K=3 cols, R=2 rows), b is mat2x3 (C=2 cols, K=3 rows),
+        // out is mat2x2 (2 cols, 2 rows).
+        let a = mat3x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0), vec2f(5.0, 6.0));
+        let b = mat2x3f(vec3f(7.0, 8.0, 9.0), vec3f(10.0, 11.0, 12.0));
+        // out[0] = a * b[0] = a * vec3f(7,8,9) = (1*7+3*8+5*9, 2*7+4*8+6*9) = (76, 100)
+        // out[1] = a * b[1] = a * vec3f(10,11,12) = (1*10+3*11+5*12, 2*10+4*11+6*12) =
+        // (103, 136)
+        let out: Mat2x2f = a * b;
+        assert_eq!(out.columns[0].to_array(), [76.0, 100.0]);
+        assert_eq!(out.columns[1].to_array(), [103.0, 136.0]);
+    }
+
+    #[test]
+    fn mat2x3_mul_mat4x2() {
+        // a is mat2x3 (K=2, R=3), b is mat4x2 (C=4, K=2), out is mat4x3.
+        let a = mat2x3f(vec3f(1.0, 2.0, 3.0), vec3f(4.0, 5.0, 6.0));
+        let b = mat4x2f(
+            vec2f(7.0, 8.0),
+            vec2f(9.0, 10.0),
+            vec2f(11.0, 12.0),
+            vec2f(13.0, 14.0),
+        );
+        // out[j] = a * b[j]:
+        // [0] = a * (7,8)   = (39, 54, 69)
+        // [1] = a * (9,10)  = (49, 68, 87)
+        // [2] = a * (11,12) = (59, 82, 105)
+        // [3] = a * (13,14) = (69, 96, 123)
+        let out: Mat4x3f = a * b;
+        assert_eq!(out.columns[0].to_array(), [39.0, 54.0, 69.0]);
+        assert_eq!(out.columns[1].to_array(), [49.0, 68.0, 87.0]);
+        assert_eq!(out.columns[2].to_array(), [59.0, 82.0, 105.0]);
+        assert_eq!(out.columns[3].to_array(), [69.0, 96.0, 123.0]);
+    }
+
+    #[test]
+    fn mat3x4_mul_mat2x3() {
+        // a is mat3x4 (K=3, R=4), b is mat2x3 (C=2, K=3), out is mat2x4.
+        let a = mat3x4f(
+            vec4f(1.0, 2.0, 3.0, 4.0),
+            vec4f(5.0, 6.0, 7.0, 8.0),
+            vec4f(9.0, 10.0, 11.0, 12.0),
+        );
+        let b = mat2x3f(vec3f(13.0, 14.0, 15.0), vec3f(16.0, 17.0, 18.0));
+        // out[0] = a * (13,14,15) =
+        //   (1*13+5*14+9*15, 2*13+6*14+10*15, 3*13+7*14+11*15, 4*13+8*14+12*15)
+        //  = (218, 260, 302, 344)
+        // out[1] = a * (16,17,18) =
+        //   (1*16+5*17+9*18, 2*16+6*17+10*18, 3*16+7*17+11*18, 4*16+8*17+12*18)
+        //  = (263, 314, 365, 416)
+        let out: Mat2x4f = a * b;
+        assert_eq!(out.columns[0].to_array(), [218.0, 260.0, 302.0, 344.0]);
+        assert_eq!(out.columns[1].to_array(), [263.0, 314.0, 365.0, 416.0]);
+    }
+
+    #[test]
+    fn mat4x4_mul_mat4x4() {
+        let a = mat4x4f(
+            vec4f(1.0, 0.0, 0.0, 0.0),
+            vec4f(0.0, 1.0, 0.0, 0.0),
+            vec4f(0.0, 0.0, 1.0, 0.0),
+            vec4f(0.0, 0.0, 0.0, 1.0),
+        );
+        let b = mat4x4f(
+            vec4f(2.0, 3.0, 4.0, 5.0),
+            vec4f(6.0, 7.0, 8.0, 9.0),
+            vec4f(10.0, 11.0, 12.0, 13.0),
+            vec4f(14.0, 15.0, 16.0, 17.0),
+        );
+        // Identity * b = b.
+        let out: Mat4x4f = a * b;
+        assert_eq!(out.columns[0].to_array(), [2.0, 3.0, 4.0, 5.0]);
+        assert_eq!(out.columns[1].to_array(), [6.0, 7.0, 8.0, 9.0]);
+        assert_eq!(out.columns[2].to_array(), [10.0, 11.0, 12.0, 13.0]);
+        assert_eq!(out.columns[3].to_array(), [14.0, 15.0, 16.0, 17.0]);
+    }
+
+    #[test]
+    fn mat2x4_mul_mat4x2() {
+        // a is mat2x4 (K=2, R=4), b is mat4x2 (C=4, K=2), out is mat4x4.
+        let a = mat2x4f(vec4f(1.0, 2.0, 3.0, 4.0), vec4f(5.0, 6.0, 7.0, 8.0));
+        let b = mat4x2f(
+            vec2f(9.0, 10.0),
+            vec2f(11.0, 12.0),
+            vec2f(13.0, 14.0),
+            vec2f(15.0, 16.0),
+        );
+        // out[j] = a * b[j]:
+        // [0] = a * (9,10)  = (1*9+5*10, 2*9+6*10, 3*9+7*10, 4*9+8*10) = (59,78,97,116)
+        // [1] = a * (11,12) = (1*11+5*12, 2*11+6*12, 3*11+7*12, 4*11+8*12) =
+        // (71,94,117,140) [2] = a * (13,14) = (83,110,137,164)
+        // [3] = a * (15,16) = (95,126,157,188)
+        let out: Mat4x4f = a * b;
+        assert_eq!(out.columns[0].to_array(), [59.0, 78.0, 97.0, 116.0]);
+        assert_eq!(out.columns[1].to_array(), [71.0, 94.0, 117.0, 140.0]);
+        assert_eq!(out.columns[2].to_array(), [83.0, 110.0, 137.0, 164.0]);
+        assert_eq!(out.columns[3].to_array(), [95.0, 126.0, 157.0, 188.0]);
+    }
+
+    // === Scalar * matrix tests =================================================
+
+    #[test]
+    fn mat2x3_scalar_mul() {
+        let m = mat2x3f(vec3f(1.0, 2.0, 3.0), vec3f(4.0, 5.0, 6.0));
+        let out: Mat2x3f = m * 2.0;
+        assert_eq!(out.columns[0].to_array(), [2.0, 4.0, 6.0]);
+        assert_eq!(out.columns[1].to_array(), [8.0, 10.0, 12.0]);
+        // Commutative.
+        let out2: Mat2x3f = 2.0 * m;
+        assert_eq!(out2.columns[0].to_array(), [2.0, 4.0, 6.0]);
+        assert_eq!(out2.columns[1].to_array(), [8.0, 10.0, 12.0]);
+    }
+
+    #[test]
+    fn mat4x2_scalar_mul() {
+        let m = mat4x2f(
+            vec2f(1.0, 2.0),
+            vec2f(3.0, 4.0),
+            vec2f(5.0, 6.0),
+            vec2f(7.0, 8.0),
+        );
+        let out: Mat4x2f = m * 3.0;
+        assert_eq!(out.columns[0].to_array(), [3.0, 6.0]);
+        assert_eq!(out.columns[3].to_array(), [21.0, 24.0]);
+    }
+
+    // === GPU-side `#[wgsl]` compile check ======================================
+    //
+    // Ensures the proc-macro accepts `vec * mat` and `mat * vec` expressions
+    // and renders them to WGSL using the `*` operator (the GPU side handles
+    // the linear algebra natively).
+
+    #[test]
+    fn module_vec_mat_mul_compiles() {
+        #[crate::wgsl(crate_path = crate)]
+        pub mod vec_mat {
+            #![allow(dead_code)]
+
+            use crate::std::*;
+
+            pub fn vec_times_mat(v: Vec3f, m: Mat2x3f) -> Vec2f {
+                v * m
+            }
+
+            pub fn mat_times_vec(m: Mat2x3f, v: Vec2f) -> Vec3f {
+                m * v
+            }
+
+            pub fn mat_times_mat(a: Mat2x3f, b: Mat3x2f) -> Mat3x3f {
+                a * b
             }
         }
     }


### PR DESCRIPTION
Adds the missing `Vec * Mat` (row-vector product), non-square `Mat * Vec`, and non-square `Mat * Mat` `Mul` impls so wgsl-rs covers every WGSL-spec-valid multiplication combination (K, C, R each in {2,3,4}): 9 mat`*`vec, 9 vec`*`mat, 27 mat`*`mat.

Previously only the 3 square `Mat*Mat` and 3 square `Mat*Vec` cases existed (delegated to glam); the row-vector product and all non-square products were missing.

Square cases now share the same macro path as non-square cases for uniformity (glam has no non-square matrix types, so non-square cases require direct component arithmetic regardless). Scalar `*` for square matrices still delegates to glam.

- Documents the `MatCxRf` naming convention and the three product rules in the `matrix.rs` module doc.
- Adds a `vec_mat_mul_example` module to the example crate.
- Adds 6 new GPU/CPU roundtrip tests (vec`*`mat, mat`*`vec, mat`*`mat in non-square form) confirming CPU and GPU agree on Apple M4 Max / Metal.
- Adds a DEVLOG entry recording the design decision and the perf tradeoff of moving square mat`*`mat/mat`*`vec off glam.

Closes #152