### PR TITLE
impl builtin constants for Vec and Mat types

### DIFF
--- a/crates/example/src/examples.rs
+++ b/crates/example/src/examples.rs
@@ -41,6 +41,7 @@ pub const EXAMPLE_MODULES: &[&wgsl_rs::Source] = &[
     &shared_inter_stage::WGSL_SOURCE,
     &hello_triangle_generic::WGSL_SOURCE,
     &phantom_data::WGSL_SOURCE,
+    &builtin_constants::WGSL_SOURCE,
 ];
 
 pub fn get_module_by_name(name: &str) -> Option<&'static wgsl_rs::Source> {
@@ -1926,5 +1927,22 @@ pub mod phantom_data {
 
     pub fn read_tagged(t: Tagged<f32, u32>) -> f32 {
         t.x
+    }
+}
+
+#[wgsl]
+pub mod builtin_constants {
+    use wgsl_rs::std::*;
+
+    pub fn demo_constants() {
+        // square matrices have `IDENTITY` and `ZERO`
+        let _m0 = Mat4x4f::IDENTITY * Mat4x4f::ZERO;
+        // non-square only have `ZERO`
+        let _m1 = Mat4x3f::ZERO;
+
+        // vectors have `ONE`, `ZERO`, and `X`, `Y`, `Z`, `W` (where appropriate)
+        let _v0 = Vec4f::X + Vec4f::ONE;
+        let _v1 = Vec3u::ZERO;
+        let _v2 = Vec2i::Y - Vec2i::X;
     }
 }

--- a/crates/wgsl-rs-macros/src/ir_convert.rs
+++ b/crates/wgsl-rs-macros/src/ir_convert.rs
@@ -658,7 +658,12 @@ pub fn expr_from_parse(e: &parse::Expr) -> Result<ir::Expr> {
             field: field.to_string(),
         },
         parse::Expr::TypePath { ty, member, .. } => ir::Expr::TypePath {
-            ty: ty.to_string(),
+            ty: {
+                let t = ty.to_string();
+                // for builtin WGSL types, we need to convert the type name, e.g. Vec3f -> vec3f
+                // this is needed so that associated constants are mapped correctly
+                parse::builtin_wgsl_type_name(&t).unwrap_or(t)
+            },
             member: member.to_string(),
         },
         parse::Expr::Reference { expr, .. } => {

--- a/crates/wgsl-rs-macros/src/parse.rs
+++ b/crates/wgsl-rs-macros/src/parse.rs
@@ -1211,6 +1211,30 @@ fn split_as_mat(s: &str) -> Option<MatAlias<'_>> {
     None
 }
 
+/// Converts the Rust type name to the WGSL type name for WGSL builtin types
+/// e.g. `Vec3f` -> `vec3f`, `Mat2x3f` -> `mat2x3f`
+pub(crate) fn builtin_wgsl_type_name(name: &str) -> Option<String> {
+    if let Some((elements, suffix)) = split_as_vec(name)
+        && matches!(elements, "2" | "3" | "4")
+        && matches!(suffix, "f" | "i" | "u" | "b")
+    {
+        return Some(format!("vec{elements}{suffix}"));
+    }
+
+    if let Some(MatAlias {
+        columns,
+        rows,
+        suffix: "f",
+    }) = split_as_mat(name)
+        && matches!(columns, "2" | "3" | "4")
+        && matches!(rows, "2" | "3" | "4")
+    {
+        return Some(format!("mat{columns}x{rows}f"));
+    }
+
+    None
+}
+
 impl Type {
     /// Parse a `syn::Type` into a WGSL `Type`, using the given context to
     /// resolve type parameter names.
@@ -3709,10 +3733,15 @@ fn parse_wgsl_allow(attrs: &[syn::Attribute]) -> Result<Vec<WarningName>, Error>
 
 /// Parse `#[wgsl_ignore]` attribute.
 ///
-/// Returns `true` if `wgsl_ignore` was recognized.
+/// Returns `true` if an attribute ending in `wgsl_ignore` was recognized.
 fn attrs_contain_wgsl_ignore(attrs: &[syn::Attribute]) -> bool {
     for attr in attrs {
-        if attr.path().is_ident("wgsl_ignore") {
+        if attr
+            .path()
+            .segments
+            .last()
+            .is_some_and(|segment| segment.ident == "wgsl_ignore")
+        {
             return true;
         }
     }
@@ -5353,9 +5382,12 @@ impl ItemMod {
         for item in self.content.iter() {
             if let Item::Use(use_item) = item {
                 for path in use_item.modules.iter() {
-                    // If this import is `use wgsl_rs::std::*;`, skip any importing
-                    // on the WGSL side.
+                    // If this import is `use wgsl_rs::std::*;`, only import built-in constants,
+                    // e.g. Vec3f::ZERO
                     if is_wgsl_std(wgsl_rs_crate_path, path) {
+                        imports.push(quote! {
+                            #wgsl_rs_crate_path::std::builtin_constants::WGSL_SOURCE
+                        });
                         continue;
                     }
 

--- a/crates/wgsl-rs/src/std.rs
+++ b/crates/wgsl-rs/src/std.rs
@@ -56,6 +56,14 @@ pub use synchronization::*;
 pub use texture::*;
 pub use vector::*;
 
+#[rustfmt::skip] // needed so that rustfmt doesn't merge imports
+#[allow(unused_imports)]
+#[crate::wgsl(crate_path = crate)]
+pub mod builtin_constants {
+    use crate::std::builtin_matrix_constants::*;
+    use crate::std::builtin_vector_constants::*;
+}
+
 pub enum Error {}
 
 /// Marker trait for an owned type that is Send + Sync.

--- a/crates/wgsl-rs/src/std/matrix.rs
+++ b/crates/wgsl-rs/src/std/matrix.rs
@@ -729,6 +729,84 @@ impl NumericBuiltinTranspose for Mat2x4f {
     }
 }
 
+
+#[crate::wgsl(crate_path = crate)]
+pub mod builtin_matrix_constants {
+    #[crate::wgsl_ignore]
+    use crate::std::*;
+
+    impl Mat2x2f {
+        pub const ZERO: Mat2x2f = mat2x2f(vec2f(0.0, 0.0), vec2f(0.0, 0.0));
+        pub const IDENTITY: Mat2x2f = mat2x2f(vec2f(1.0, 0.0), vec2f(0.0, 1.0));
+    }
+
+    impl Mat2x3f {
+        pub const ZERO: Mat2x3f = mat2x3f(vec3f(0.0, 0.0, 0.0), vec3f(0.0, 0.0, 0.0));
+    }
+
+    impl Mat2x4f {
+        pub const ZERO: Mat2x4f = mat2x4f(vec4f(0.0, 0.0, 0.0, 0.0), vec4f(0.0, 0.0, 0.0, 0.0));
+    }
+
+    impl Mat3x2f {
+        pub const ZERO: Mat3x2f = mat3x2f(vec2f(0.0, 0.0), vec2f(0.0, 0.0), vec2f(0.0, 0.0));
+    }
+
+    impl Mat3x3f {
+        pub const ZERO: Mat3x3f = mat3x3f(
+            vec3f(0.0, 0.0, 0.0),
+            vec3f(0.0, 0.0, 0.0),
+            vec3f(0.0, 0.0, 0.0),
+        );
+        pub const IDENTITY: Mat3x3f = mat3x3f(
+            vec3f(1.0, 0.0, 0.0),
+            vec3f(0.0, 1.0, 0.0),
+            vec3f(0.0, 0.0, 1.0),
+        );
+    }
+
+    impl Mat3x4f {
+        pub const ZERO: Mat3x4f = mat3x4f(
+            vec4f(0.0, 0.0, 0.0, 0.0),
+            vec4f(0.0, 0.0, 0.0, 0.0),
+            vec4f(0.0, 0.0, 0.0, 0.0),
+        );
+    }
+
+    impl Mat4x2f {
+        pub const ZERO: Mat4x2f = mat4x2f(
+            vec2f(0.0, 0.0),
+            vec2f(0.0, 0.0),
+            vec2f(0.0, 0.0),
+            vec2f(0.0, 0.0),
+        );
+    }
+
+    impl Mat4x3f {
+        pub const ZERO: Mat4x3f = mat4x3f(
+            vec3f(0.0, 0.0, 0.0),
+            vec3f(0.0, 0.0, 0.0),
+            vec3f(0.0, 0.0, 0.0),
+            vec3f(0.0, 0.0, 0.0),
+        );
+    }
+
+    impl Mat4x4f {
+        pub const ZERO: Mat4x4f = mat4x4f(
+            vec4f(0.0, 0.0, 0.0, 0.0),
+            vec4f(0.0, 0.0, 0.0, 0.0),
+            vec4f(0.0, 0.0, 0.0, 0.0),
+            vec4f(0.0, 0.0, 0.0, 0.0),
+        );
+        pub const IDENTITY: Mat4x4f = mat4x4f(
+            vec4f(1.0, 0.0, 0.0, 0.0),
+            vec4f(0.0, 1.0, 0.0, 0.0),
+            vec4f(0.0, 0.0, 1.0, 0.0),
+            vec4f(0.0, 0.0, 0.0, 1.0),
+        );
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -1311,6 +1389,29 @@ mod test {
 
             pub fn mat_times_mat(a: Mat2x3f, b: Mat3x2f) -> Mat3x3f {
                 a * b
+            }
+        }
+    }
+
+    #[test]
+    fn can_compile_module_with_all_matrix_consts() {
+        #[crate::wgsl(crate_path = crate)]
+        mod matrices {
+            use crate::std::*;
+
+            pub fn _main() {
+                let _mat2x2f_zero = Mat2x2f::ZERO;
+                let _mat2x2f_identity = Mat2x2f::IDENTITY;
+                let _mat2x3f_zero = Mat2x3f::ZERO;
+                let _mat2x4f_zero = Mat2x4f::ZERO;
+                let _mat3x2f_zero = Mat3x2f::ZERO;
+                let _mat3x3f_zero = Mat3x3f::ZERO;
+                let _mat3x3f_identity = Mat3x3f::IDENTITY;
+                let _mat3x4f_zero = Mat3x4f::ZERO;
+                let _mat4x2f_zero = Mat4x2f::ZERO;
+                let _mat4x3f_zero = Mat4x3f::ZERO;
+                let _mat4x4f_zero = Mat4x4f::ZERO;
+                let _mat4x4f_identity = Mat4x4f::IDENTITY;
             }
         }
     }

--- a/crates/wgsl-rs/src/std/vector.rs
+++ b/crates/wgsl-rs/src/std/vector.rs
@@ -1624,6 +1624,84 @@ impl std::ops::Neg for Vec4<i32> {
     }
 }
 
+#[crate::wgsl(crate_path = crate)]
+pub mod builtin_vector_constants {
+    #[crate::wgsl_ignore]
+    use crate::std::*;
+
+    impl Vec2f {
+        pub const ZERO: Vec2f = vec2f(0.0, 0.0);
+        pub const ONE: Vec2f = vec2f(1.0, 1.0);
+        pub const X: Vec2f = vec2f(1.0, 0.0);
+        pub const Y: Vec2f = vec2f(0.0, 1.0);
+    }
+
+    impl Vec3f {
+        pub const ZERO: Vec3f = vec3f(0.0, 0.0, 0.0);
+        pub const ONE: Vec3f = vec3f(1.0, 1.0, 1.0);
+        pub const X: Vec3f = vec3f(1.0, 0.0, 0.0);
+        pub const Y: Vec3f = vec3f(0.0, 1.0, 0.0);
+        pub const Z: Vec3f = vec3f(0.0, 0.0, 1.0);
+    }
+
+    impl Vec4f {
+        pub const ZERO: Vec4f = vec4f(0.0, 0.0, 0.0, 0.0);
+        pub const ONE: Vec4f = vec4f(1.0, 1.0, 1.0, 1.0);
+        pub const X: Vec4f = vec4f(1.0, 0.0, 0.0, 0.0);
+        pub const Y: Vec4f = vec4f(0.0, 1.0, 0.0, 0.0);
+        pub const Z: Vec4f = vec4f(0.0, 0.0, 1.0, 0.0);
+        pub const W: Vec4f = vec4f(0.0, 0.0, 0.0, 1.0);
+    }
+
+    impl Vec2u {
+        pub const ZERO: Vec2u = vec2u(0, 0);
+        pub const ONE: Vec2u = vec2u(1, 1);
+        pub const X: Vec2u = vec2u(1, 0);
+        pub const Y: Vec2u = vec2u(0, 1);
+    }
+
+    impl Vec3u {
+        pub const ZERO: Vec3u = vec3u(0, 0, 0);
+        pub const ONE: Vec3u = vec3u(1, 1, 1);
+        pub const X: Vec3u = vec3u(1, 0, 0);
+        pub const Y: Vec3u = vec3u(0, 1, 0);
+        pub const Z: Vec3u = vec3u(0, 0, 1);
+    }
+
+    impl Vec4u {
+        pub const ZERO: Vec4u = vec4u(0, 0, 0, 0);
+        pub const ONE: Vec4u = vec4u(1, 1, 1, 1);
+        pub const X: Vec4u = vec4u(1, 0, 0, 0);
+        pub const Y: Vec4u = vec4u(0, 1, 0, 0);
+        pub const Z: Vec4u = vec4u(0, 0, 1, 0);
+        pub const W: Vec4u = vec4u(0, 0, 0, 1);
+    }
+
+    impl Vec2i {
+        pub const ZERO: Vec2i = vec2i(0, 0);
+        pub const ONE: Vec2i = vec2i(1, 1);
+        pub const X: Vec2i = vec2i(1, 0);
+        pub const Y: Vec2i = vec2i(0, 1);
+    }
+
+    impl Vec3i {
+        pub const ZERO: Vec3i = vec3i(0, 0, 0);
+        pub const ONE: Vec3i = vec3i(1, 1, 1);
+        pub const X: Vec3i = vec3i(1, 0, 0);
+        pub const Y: Vec3i = vec3i(0, 1, 0);
+        pub const Z: Vec3i = vec3i(0, 0, 1);
+    }
+
+    impl Vec4i {
+        pub const ZERO: Vec4i = vec4i(0, 0, 0, 0);
+        pub const ONE: Vec4i = vec4i(1, 1, 1, 1);
+        pub const X: Vec4i = vec4i(1, 0, 0, 0);
+        pub const Y: Vec4i = vec4i(0, 1, 0, 0);
+        pub const Z: Vec4i = vec4i(0, 0, 1, 0);
+        pub const W: Vec4i = vec4i(0, 0, 0, 1);
+    }
+}
+
 #[cfg(test)]
 mod test {
 
@@ -1671,6 +1749,70 @@ mod test {
 
                 // 4D vectors - boolean
                 let _v4b = vec4b(true, false, true, false);
+            }
+        }
+    }
+
+    #[test]
+    fn can_compile_module_with_all_vector_consts() {
+        #[crate::wgsl(crate_path = crate)]
+        mod vectors {
+            use crate::std::*;
+
+            pub fn _main() {
+                let _v2f_zero = Vec2f::ZERO;
+                let _v2f_one = Vec2f::ONE;
+                let _v2f_x = Vec2f::X;
+                let _v2f_y = Vec2f::Y;
+
+                let _v3f_zero = Vec3f::ZERO;
+                let _v3f_one = Vec3f::ONE;
+                let _v3f_x = Vec3f::X;
+                let _v3f_y = Vec3f::Y;
+                let _v3f_z = Vec3f::Z;
+
+                let _v4f_zero = Vec4f::ZERO;
+                let _v4f_one = Vec4f::ONE;
+                let _v4f_x = Vec4f::X;
+                let _v4f_y = Vec4f::Y;
+                let _v4f_z = Vec4f::Z;
+                let _v4f_w = Vec4f::W;
+
+                let _v2u_zero = Vec2u::ZERO;
+                let _v2u_one = Vec2u::ONE;
+                let _v2u_x = Vec2u::X;
+                let _v2u_y = Vec2u::Y;
+
+                let _v3u_zero = Vec3u::ZERO;
+                let _v3u_one = Vec3u::ONE;
+                let _v3u_x = Vec3u::X;
+                let _v3u_y = Vec3u::Y;
+                let _v3u_z = Vec3u::Z;
+
+                let _v4u_zero = Vec4u::ZERO;
+                let _v4u_one = Vec4u::ONE;
+                let _v4u_x = Vec4u::X;
+                let _v4u_y = Vec4u::Y;
+                let _v4u_z = Vec4u::Z;
+                let _v4u_w = Vec4u::W;
+
+                let _v2i_zero = Vec2i::ZERO;
+                let _v2i_one = Vec2i::ONE;
+                let _v2i_x = Vec2i::X;
+                let _v2i_y = Vec2i::Y;
+
+                let _v3i_zero = Vec3i::ZERO;
+                let _v3i_one = Vec3i::ONE;
+                let _v3i_x = Vec3i::X;
+                let _v3i_y = Vec3i::Y;
+                let _v3i_z = Vec3i::Z;
+
+                let _v4i_zero = Vec4i::ZERO;
+                let _v4i_one = Vec4i::ONE;
+                let _v4i_x = Vec4i::X;
+                let _v4i_y = Vec4i::Y;
+                let _v4i_z = Vec4i::Z;
+                let _v4i_w = Vec4i::W;
             }
         }
     }


### PR DESCRIPTION
Adds `Vec3f::X`, `Mat3x4f::ZERO`, etc. style constants to `wgsl-rs::std`, closes #166

This was a little trickier than I had imagined as I ran into two issues:

The builtin types get mapped to lowercase names (e.g. Vec3f -> vec3f), and the associated constants get given names built from those lowercase names (e.g. vec3_X). However, when using constants wgls-rs currently just uses the raw type name (e.g. Vec3_X). I couldn't find a nicer way to deal with this without making larger changes, so I created `builtin_wgsl_type_name` to do the conversion and used it where `Expr::TypePath`s get constructed in ir_convert.rs.

I needed to `use crate::std::*;` in the modules containing the constants so that the Rust side knows that they exist, but this causes a recursive import, so I had to tag it with `#[crate::wgsl_ignore]`. However, the existing code for dealing with `wgsl_ignore` only works for attributes that are literally `wgsl_ignore` without a preceding path, so I changed `attrs_contain_wgsl_ignore` to match any attribute where the final path segment is `wgsl_ignore`.

Lmk if you have "nicer" solutions to either of these or want anything else changed :)

 
